### PR TITLE
Remove duplicate Tarot card display

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,7 +1,7 @@
 # Frontend Environment Variables
 
 # Backend API URL (required)
-NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_API_URL=https://backend-arcanaai.nguyenvanloc.com
 
 # Environment (optional)
 NODE_ENV=development

--- a/frontend/src/app/api/changelog/latest/route.ts
+++ b/frontend/src/app/api/changelog/latest/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 
-const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || 'https://backend-arcanaai.nguyenvanloc.com';
 
 export async function GET() {
     try {

--- a/frontend/src/app/api/changelog/route.ts
+++ b/frontend/src/app/api/changelog/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 
-const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || 'https://backend-arcanaai.nguyenvanloc.com';
 
 export async function GET() {
     try {

--- a/frontend/src/app/api/changelog/version/[version]/route.ts
+++ b/frontend/src/app/api/changelog/version/[version]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || 'https://backend-arcanaai.nguyenvanloc.com';
 
 export async function GET(
     request: NextRequest,

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -423,7 +423,6 @@ function HomeContent() {
     messages,
     loading,
     error,
-    currentCards,
     streamingContent,
     setCurrentSession,
     createSession,
@@ -431,7 +430,6 @@ function HomeContent() {
     fetchMessages,
     sendMessage,
     renameSession,
-    clearCurrentCards,
   } = useChatSessions();
 
   const [input, setInput] = useState('');
@@ -490,13 +488,12 @@ function HomeContent() {
     if (session) {
       setCurrentSession(session);
       await fetchMessages(sessionId);
-      clearCurrentCards();
       // Auto-collapse sidebar on mobile after selection
       if (window.innerWidth < 768) {
         setSidebarCollapsed(true);
       }
     }
-  }, [sessions, setCurrentSession, fetchMessages, clearCurrentCards]);
+  }, [sessions, setCurrentSession, fetchMessages]);
 
   // Handle reading history URL parameter
   useEffect(() => {
@@ -773,21 +770,7 @@ function HomeContent() {
                     </div>
                   ))}
 
-                  {/* Display current cards - Mobile-first grid */}
-                  {currentCards.length > 0 && (
-                    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 md:gap-6 my-6 md:my-8">
-                      {currentCards.map((card, index) => (
-                        <div key={index} className="card-mystical tarot-card perspective-1000 mx-auto">
-                          <TarotCard
-                            card={card}
-                            size="large"
-                            showDetails={true}
-                            className="max-w-[240px] md:max-w-[280px] w-full"
-                          />
-                        </div>
-                      ))}
-                    </div>
-                  )}
+
 
                   {/* Display streaming content */}
                   {streamingContent && (


### PR DESCRIPTION
This pull request updates the frontend to use a new backend API URL and removes the display and management of `currentCards` in the main page component. The environment variable and all relevant API route files are updated to point to the new backend, and related frontend logic for handling `currentCards` is cleaned up.

**Backend URL update:**

* Changed the default and example backend API URL from `http://localhost:8000` to `https://backend-arcanaai.nguyenvanloc.com` in environment variables and all API route files (`.env.example`, `src/app/api/changelog/latest/route.ts`, `src/app/api/changelog/route.ts`, `src/app/api/changelog/version/[version]/route.ts`). [[1]](diffhunk://#diff-7b3b2052ac3e484bcffbb75d7ee140a9ebe7677fd7ea34ac17ca193dd3c0ecfcL4-R4) [[2]](diffhunk://#diff-632ca5d8790fd7d727c61fe479fc571af8127d0f6a3904fd5e2de34d683df7f7L3-R3) [[3]](diffhunk://#diff-1ccc5217fd528f1ecf2cc04a7c01294c39d3672c668dd08eabb5e9eb2cf48a7cL3-R3) [frontend/src/app/api/changelog/version/[version]/route.tsL3-R3](diffhunk://#diff-52bdfbb536649337271649bce4a34dec59dafd835577eea639dc214d83e845f5L3-R3))

**Frontend logic cleanup:**

* Removed `currentCards` state and its related UI rendering from the `HomeContent` component in `page.tsx`. [[1]](diffhunk://#diff-bc32312b6e0185cbc840269d0632c2a90ed907d36aa7bd3f8baeb68b9ff9449fL426-L434) [[2]](diffhunk://#diff-bc32312b6e0185cbc840269d0632c2a90ed907d36aa7bd3f8baeb68b9ff9449fL776-R773)
* Removed the call to `clearCurrentCards` and its dependency from the session selection logic in `HomeContent`.