### PR TITLE
Add /changelog to public routes

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -12,7 +12,7 @@ export function middleware(request: NextRequest) {
     const { pathname } = request.nextUrl;
 
     // Public routes that don't require authentication
-    const publicRoutes = ['/login', '/register', '/forgot-password', '/reset-password', '/password-reset-confirm', '/test-images', '/pricing', '/terms-of-service', '/privacy-policy'];
+    const publicRoutes = ['/login', '/register', '/forgot-password', '/reset-password', '/password-reset-confirm', '/test-images', '/pricing', '/terms-of-service', '/privacy-policy', '/changelog'];
 
     // Auth-specific routes that authenticated users should be redirected away from
     const authOnlyRoutes = ['/login', '/register', '/forgot-password', '/reset-password', '/password-reset-confirm'];


### PR DESCRIPTION
## Summary
Added the `/changelog` route to the list of public routes that don't require authentication.

## Changes
- Added `/changelog` to the `publicRoutes` array in the authentication middleware, allowing unauthenticated users to access the changelog page

## Details
This change enables public access to the changelog page without requiring users to be logged in, consistent with other informational pages like pricing, terms of service, and privacy policy.

https://claude.ai/code/session_0116ovrmVhYc682Vv38QLcKZ