### PR TITLE
Replace credit card payment with Adsterra ad-watching turn system

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -39,7 +39,7 @@ from sqlalchemy.exc import IntegrityError, OperationalError, SQLAlchemyError
 
 from config import settings
 from database import Base, engine
-from routers import admin, auth, changelog, chat, health, journal, sharing, subscription, support, tarot, tasks
+from routers import ads, admin, auth, changelog, chat, health, journal, sharing, subscription, support, tarot, tasks
 from utils.error_handlers import (
     TarotAPIException,
     general_exception_handler,
@@ -137,6 +137,7 @@ app.include_router(health.router)  # Health checks and system status
 app.include_router(admin.router)  # Administrative functions
 app.include_router(sharing.router)  # Reading sharing functionality
 app.include_router(subscription.router)  # Subscription and payment management
+app.include_router(ads.router)  # Ad-watching turn rewards
 app.include_router(journal.router)  # Advanced tarot journal and personal growth
 app.include_router(support.router)  # Support ticket system with file uploads
 app.include_router(changelog.router)  # Changelog and version information

--- a/backend/migrations/versions/20260423_000000_add_ad_views_table.py
+++ b/backend/migrations/versions/20260423_000000_add_ad_views_table.py
@@ -1,0 +1,38 @@
+"""add ad_views table and ad turn fields to users
+
+Revision ID: add_ad_views_table
+Revises: 58b706ad7d4e
+Create Date: 2026-04-23 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "add_ad_views_table"
+down_revision: Union[str, None] = "58b706ad7d4e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add ad-watching fields to users table
+    op.add_column("users", sa.Column("ad_turns_earned_today", sa.Integer(), nullable=True, server_default="0"))
+    op.add_column("users", sa.Column("ad_turns_reset_date", sa.Date(), nullable=True))
+
+    # Create ad_views table
+    op.create_table(
+        "ad_views",
+        sa.Column("id", sa.Integer(), primary_key=True, index=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False, index=True),
+        sa.Column("ad_provider", sa.String(), nullable=False, server_default="adsterra"),
+        sa.Column("turns_awarded", sa.Integer(), server_default="1"),
+        sa.Column("viewed_at", sa.DateTime(timezone=True), server_default=sa.func.now(), index=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("ad_views")
+    op.drop_column("users", "ad_turns_reset_date")
+    op.drop_column("users", "ad_turns_earned_today")

--- a/backend/models.py
+++ b/backend/models.py
@@ -58,6 +58,10 @@ class User(Base):
     # Specialized premium access (for acquaintances/VIP users)
     is_specialized_premium = Column(Boolean, default=False)
 
+    # Ad-watching turn system
+    ad_turns_earned_today = Column(Integer, default=0)
+    ad_turns_reset_date = Column(Date, nullable=True)  # Date when daily ad counter was last reset
+
     # Avatar storage
     avatar_filename = Column(String, nullable=True)  # Stores the filename of the avatar
 
@@ -74,6 +78,7 @@ class User(Base):
     subscription_events = relationship("SubscriptionEvent", back_populates="user", cascade="all, delete-orphan")
     payment_transactions = relationship("PaymentTransaction", back_populates="user", cascade="all, delete-orphan")
     turn_usage_history = relationship("TurnUsageHistory", back_populates="user", cascade="all, delete-orphan")
+    ad_views = relationship("AdView", back_populates="user", cascade="all, delete-orphan")
 
     @property
     def password(self):
@@ -169,6 +174,24 @@ class User(Base):
         if self.number_of_paid_turns is None:
             self.number_of_paid_turns = 0
         self.number_of_paid_turns += turns
+
+    AD_TURNS_DAILY_LIMIT = 5
+
+    def reset_ad_turns_if_needed(self):
+        """Reset the daily ad turn counter if the date has changed."""
+        from datetime import date
+        today = date.today()
+        if self.ad_turns_reset_date != today:
+            self.ad_turns_earned_today = 0
+            self.ad_turns_reset_date = today
+
+    def can_earn_ad_turn(self) -> bool:
+        self.reset_ad_turns_if_needed()
+        return (self.ad_turns_earned_today or 0) < self.AD_TURNS_DAILY_LIMIT
+
+    def remaining_ad_turns_today(self) -> int:
+        self.reset_ad_turns_if_needed()
+        return self.AD_TURNS_DAILY_LIMIT - (self.ad_turns_earned_today or 0)
 
 
 class ChatSession(Base):
@@ -964,3 +987,20 @@ class ReadingReminder(Base):
     __table_args__ = (
         CheckConstraint("reminder_type IN ('anniversary', 'follow_up', 'milestone')", name="valid_reminder_type"),
     )
+
+
+class AdView(Base):
+    """Records a completed ad view that awarded the user one turn.
+
+    Used to track daily ad view counts (capped at 5/day) and prevent abuse.
+    """
+
+    __tablename__ = "ad_views"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    ad_provider = Column(String, nullable=False, default="adsterra")
+    turns_awarded = Column(Integer, default=1)
+    viewed_at = Column(DateTime(timezone=True), server_default=func.now(), index=True)
+
+    user = relationship("User", back_populates="ad_views")

--- a/backend/models.py
+++ b/backend/models.py
@@ -175,7 +175,7 @@ class User(Base):
             self.number_of_paid_turns = 0
         self.number_of_paid_turns += turns
 
-    AD_TURNS_DAILY_LIMIT = 5
+    AD_TURNS_DAILY_LIMIT = 20
 
     def reset_ad_turns_if_needed(self):
         """Reset the daily ad turn counter if the date has changed."""

--- a/backend/routers/ads.py
+++ b/backend/routers/ads.py
@@ -1,0 +1,108 @@
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models import User, AdView
+from routers.auth import get_current_user
+from schemas import AdCompleteRequest, AdCompleteResponse
+from services.subscription_service import SubscriptionService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api", tags=["ads"])
+subscription_service = SubscriptionService()
+
+
+@router.post("/ads/complete", response_model=AdCompleteResponse)
+async def complete_ad_view(
+    request: AdCompleteRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Award one turn after the user completes watching an ad.
+
+    Rate-limited to 5 ad views per day per user.
+    """
+    # Refresh user from DB to get latest ad counters
+    db.refresh(current_user)
+
+    # Reset daily counter if the date has rolled over
+    current_user.reset_ad_turns_if_needed()
+
+    if not current_user.can_earn_ad_turn():
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={
+                "message": "Daily ad limit reached. Come back tomorrow for more turns.",
+                "ad_turns_earned_today": current_user.ad_turns_earned_today,
+                "ad_turns_remaining_today": 0,
+            },
+        )
+
+    try:
+        # Award one turn (reuse existing paid-turn mechanism — ad turns never expire)
+        current_user.add_paid_turns(1)
+        current_user.ad_turns_earned_today = (current_user.ad_turns_earned_today or 0) + 1
+
+        # Record the ad view
+        ad_view = AdView(
+            user_id=current_user.id,
+            ad_provider=request.ad_provider,
+            turns_awarded=1,
+        )
+        db.add(ad_view)
+
+        # Log it as a subscription event so history stays consistent
+        subscription_service.log_subscription_event(
+            db=db,
+            user=current_user,
+            event_type="ad_view_completed",
+            event_source="adsterra",
+            subscription_status=current_user.subscription_status or "none",
+            turns_affected=1,
+            event_data={"ad_provider": request.ad_provider},
+        )
+
+        db.commit()
+        db.refresh(current_user)
+
+        logger.info(
+            f"User {current_user.id} earned 1 turn from ad. "
+            f"Daily total: {current_user.ad_turns_earned_today}"
+        )
+
+        return AdCompleteResponse(
+            success=True,
+            turns_awarded=1,
+            total_turns=current_user.get_total_turns(),
+            ad_turns_earned_today=current_user.ad_turns_earned_today,
+            ad_turns_remaining_today=current_user.remaining_ad_turns_today(),
+            message="Turn awarded! Enjoy your reading.",
+        )
+
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Failed to award ad turn for user {current_user.id}: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to award turn. Please try again.",
+        )
+
+
+@router.get("/ads/status")
+async def get_ad_status(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return how many ad-earned turns the user has left today."""
+    db.refresh(current_user)
+    current_user.reset_ad_turns_if_needed()
+    db.commit()
+
+    return {
+        "ad_turns_earned_today": current_user.ad_turns_earned_today or 0,
+        "ad_turns_remaining_today": current_user.remaining_ad_turns_today(),
+        "daily_limit": User.AD_TURNS_DAILY_LIMIT,
+    }

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1717,3 +1717,19 @@ class SupportTicketResponse(BaseModel):
     message: str
     ticket_id: str
     slack_message_id: Optional[str] = None
+
+
+# Ad-watching schemas
+class AdCompleteRequest(BaseModel):
+    """Request schema for completing an ad view to earn a turn."""
+    ad_provider: str = "adsterra"
+
+
+class AdCompleteResponse(BaseModel):
+    """Response schema after a successful ad view."""
+    success: bool
+    turns_awarded: int
+    total_turns: int
+    ad_turns_earned_today: int
+    ad_turns_remaining_today: int
+    message: str

--- a/docs/ad-watching-setup.md
+++ b/docs/ad-watching-setup.md
@@ -1,0 +1,85 @@
+# Ad-Watching Turn System — Setup Guide
+
+## 1. Sign Up for Adsterra
+
+1. Go to **adsterra.com** and create a **Publisher** account
+2. Add your website (`arcanaai.nguyenvanloc.com`) as a new site
+3. Wait for site approval (usually within 24 hours)
+4. Once approved, create a new ad zone:
+   - **Format**: Direct Link or Interstitial (both work for web)
+   - **Category**: Entertainment / Lifestyle
+   - Copy the **Zone ID** — you will need it in step 2
+
+---
+
+## 2. Configure Environment Variables
+
+Add this to your frontend `.env` (or `.env.production`):
+
+```env
+NEXT_PUBLIC_ADSTERRA_ZONE_ID=your_zone_id_here
+```
+
+> Without this, the 15-second countdown still works but no real ad is shown. That is useful for local testing.
+
+---
+
+## 3. Run the Database Migration
+
+SSH into your server and run:
+
+```bash
+cd /path/to/arcana-ai/backend
+alembic upgrade head
+```
+
+This creates the `ad_views` table and adds `ad_turns_earned_today` / `ad_turns_reset_date` columns to the `users` table.
+
+---
+
+## 4. Deploy the Updated Code
+
+```bash
+# Pull the latest branch
+git pull origin claude/research-ad-plans-VNlrM
+
+# Rebuild and restart containers
+docker compose down
+docker compose up -d --build
+```
+
+---
+
+## 5. Test the Full Flow
+
+1. Log in to your app
+2. Click **Get Turns** in the turn counter (or open the modal)
+3. Click **Watch Ad (+1 turn)**
+4. The ad modal opens — wait 15 seconds
+5. Click **Claim Turn**
+6. Your turn count should increase by 1
+7. Repeat up to 20 times — on the 21st attempt the button should be disabled with "Ad limit reached today"
+
+---
+
+## 6. Verify in the Database (Optional)
+
+```sql
+-- Check a user's ad turns today
+SELECT id, username, ad_turns_earned_today, ad_turns_reset_date
+FROM users WHERE username = 'your_test_user';
+
+-- Check ad view history
+SELECT * FROM ad_views ORDER BY viewed_at DESC LIMIT 10;
+```
+
+---
+
+## Summary of Limits
+
+| Rule | Value |
+|---|---|
+| Max ad turns per day | 20 |
+| Turns per ad watched | 1 |
+| Do ad-earned turns expire? | No |
+| Daily counter resets | Midnight (server date) |

--- a/docs/ad-watching-setup.md
+++ b/docs/ad-watching-setup.md
@@ -17,8 +17,13 @@
 Add this to your frontend `.env` (or `.env.production`):
 
 ```env
-NEXT_PUBLIC_ADSTERRA_ZONE_ID=your_zone_id_here
+NEXT_PUBLIC_ADSTERRA_SCRIPT_URL=
 ```
+
+To find your script URL:
+1. Open your Adsterra dashboard
+2. Expand your site → click **Get Code** next to the Popunder zone
+3. Copy the `src="..."` value from the `<script>` tag — that is your full script URL
 
 > Without this, the 15-second countdown still works but no real ad is shown. That is useful for local testing.
 

--- a/frontend/src/components/SubscriptionModal.tsx
+++ b/frontend/src/components/SubscriptionModal.tsx
@@ -1,9 +1,7 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useSubscription } from '@/hooks/useSubscription';
-import { useMetaMask } from '@/hooks/useMetaMask';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
 import {
     Dialog,
     DialogContent,
@@ -11,15 +9,9 @@ import {
     DialogHeader,
     DialogTitle
 } from '@/components/ui/dialog';
-import {
-    Zap,
-    Crown,
-    Star,
-    Gift,
-    Wallet
-} from 'lucide-react';
-import { subscription } from '@/lib/api';
-import { toast } from 'react-hot-toast';
+import { Zap, Crown, Star, Tv2 } from 'lucide-react';
+import { ads } from '@/lib/api';
+import { WatchAdButton } from '@/components/WatchAdButton';
 
 interface SubscriptionModalProps {
     isOpen: boolean;
@@ -29,273 +21,149 @@ interface SubscriptionModalProps {
 export function SubscriptionModal({ isOpen, onClose }: SubscriptionModalProps) {
     const {
         turns,
-        products,
         loading,
         getSubscriptionStatusText,
         getDaysUntilReset,
         refreshData,
     } = useSubscription();
 
-    const {
-        isConnected,
-        account,
-        isLoading,
-        connect: connectMetaMask,
-        sendPayment,
-    } = useMetaMask();
+    const [adTurnsEarnedToday, setAdTurnsEarnedToday] = useState(0);
+    const [adStatusLoading, setAdStatusLoading] = useState(false);
 
-    const [paymentLoading, setPaymentLoading] = useState<string | null>(null);
+    // Fetch today's ad usage whenever the modal opens
+    useEffect(() => {
+        if (!isOpen) return;
+        setAdStatusLoading(true);
+        ads.getStatus()
+            .then((status) => setAdTurnsEarnedToday(status.ad_turns_earned_today))
+            .catch(() => {/* non-critical */ })
+            .finally(() => setAdStatusLoading(false));
+    }, [isOpen]);
 
-    const handleUSDTPayment = async (productVariant: string, usdtAmount: string, usdPrice: string) => {
-        setPaymentLoading(productVariant);
-
-        try {
-            // Connect MetaMask if not connected
-            if (!isConnected) {
-                await connectMetaMask();
-                return;
-            }
-
-            // For now, we'll use ETH equivalent for USDT until token support is fully implemented
-            // This is a simplified approach - in production you'd want proper USDT token handling
-            const transactionHash = await sendPayment({
-                productVariant: productVariant,
-                ethAmount: '0.001', // Small ETH amount as placeholder for USDT
-                usdPrice: usdPrice,
-            });
-
-            // Process payment on backend
-            await subscription.processEthereumPayment(
-                transactionHash,
-                productVariant,
-                usdtAmount,
-                account!
-            );
-
-            toast.success('Payment successful! Your turns have been added.');
-            await refreshData();
-            onClose();
-
-        } catch (error) {
-            console.error('Payment failed:', error);
-            // Toast error is already shown by useMetaMask hook
-        } finally {
-            setPaymentLoading(null);
-        }
+    const handleTurnEarned = async () => {
+        setAdTurnsEarnedToday((prev) => prev + 1);
+        await refreshData();
     };
-
-
-
-
 
     return (
         <Dialog open={isOpen} onOpenChange={onClose}>
-            <DialogContent className="max-w-5xl max-h-[95vh] overflow-y-auto bg-gray-900 border-purple-700">
-                <DialogHeader className="space-y-3 md:space-y-4">
-                    <DialogTitle className="text-xl md:text-2xl lg:text-3xl font-bold text-center bg-gradient-to-r from-purple-400 via-purple-600 to-indigo-600 bg-clip-text text-transparent">
-                        <div className="flex items-center justify-center space-x-2 md:space-x-3">
-                            <Crown className="h-6 w-6 md:h-7 md:w-7 lg:h-8 lg:w-8 text-purple-500" />
-                            <span>Choose Your Plan</span>
-                            <Star className="h-6 w-6 md:h-7 md:w-7 lg:h-8 lg:w-8 text-purple-500" />
+            <DialogContent className="max-w-2xl max-h-[95vh] overflow-y-auto bg-gray-900 border-purple-700">
+                <DialogHeader className="space-y-3">
+                    <DialogTitle className="text-xl md:text-2xl font-bold text-center bg-gradient-to-r from-purple-400 via-purple-600 to-indigo-600 bg-clip-text text-transparent">
+                        <div className="flex items-center justify-center space-x-2">
+                            <Crown className="h-6 w-6 text-purple-500" />
+                            <span>Get More Turns</span>
+                            <Star className="h-6 w-6 text-purple-500" />
                         </div>
                     </DialogTitle>
-                    <DialogDescription className="text-base md:text-lg text-purple-300 text-center">
-                        Choose your payment method to add reading turns to your account.
+                    <DialogDescription className="text-base text-purple-300 text-center">
+                        Watch a short ad to earn a free turn — no payment needed.
                     </DialogDescription>
                 </DialogHeader>
 
                 <div className="space-y-4 md:space-y-6">
-                    {/* MetaMask Status */}
-                    <Card className="border-green-500 bg-green-900/20">
-                        <CardContent className="p-4 md:p-6">
-                            <div className="flex items-center justify-between">
-                                <div className="flex items-center space-x-3">
-                                    <Wallet className="h-6 w-6 text-green-400" />
-                                    <div>
-                                        <h3 className="font-medium text-green-400">MetaMask Wallet - USDT Payment</h3>
-                                        <p className="text-sm text-green-300">
-                                            {isConnected
-                                                ? `Connected: ${account?.slice(0, 6)}...${account?.slice(-4)}`
-                                                : 'Pay instantly with USDT stablecoin'
-                                            }
-                                        </p>
-                                    </div>
-                                </div>
-                                {!isConnected && (
-                                    <Button
-                                        onClick={connectMetaMask}
-                                        disabled={isLoading}
-                                        className="bg-green-600 hover:bg-green-700 text-white px-4 py-2"
-                                    >
-                                        {isLoading ? 'Connecting...' : 'Connect'}
-                                    </Button>
-                                )}
-                            </div>
-                        </CardContent>
-                    </Card>
-
-                    {/* Credit Card Coming Soon Notice */}
-                    <Card className="border-yellow-500 bg-yellow-900/20">
-                        <CardContent className="p-4 md:p-6">
-                            <div className="flex items-center justify-center space-x-3 text-center">
-                                <Star className="h-6 w-6 text-yellow-400" />
-                                <div>
-                                    <h3 className="font-medium text-yellow-400 text-lg">Credit Card Payments Coming Soon</h3>
-                                    <p className="text-sm text-yellow-300 mt-1">
-                                        Credit card processing is being implemented. Use MetaMask with USDT for instant payments!
-                                    </p>
-                                </div>
-                                <Star className="h-6 w-6 text-yellow-400" />
-                            </div>
-                        </CardContent>
-                    </Card>
-
-                    {/* Current Status - Mobile-optimized */}
+                    {/* Current status */}
                     <Card className="border-blue-500 bg-blue-900/20">
                         <CardContent className="p-4 md:p-6">
-                            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-6 text-center">
-                                <div className="space-y-2">
-                                    <div className="text-2xl md:text-3xl font-bold text-blue-400">
+                            <div className="grid grid-cols-3 gap-4 text-center">
+                                <div className="space-y-1">
+                                    <div className="text-2xl font-bold text-blue-400">
                                         {turns?.total_turns ?? 0}
                                     </div>
-                                    <div className="text-xs md:text-sm text-gray-400">Remaining Turns</div>
+                                    <div className="text-xs text-gray-400">Remaining Turns</div>
                                 </div>
-                                <div className="space-y-2">
-                                    <div className="text-2xl md:text-3xl font-bold text-purple-400">
-                                        {getSubscriptionStatusText()}
+                                <div className="space-y-1">
+                                    <div className="text-2xl font-bold text-purple-400">
+                                        {loading ? '…' : getSubscriptionStatusText()}
                                     </div>
-                                    <div className="text-xs md:text-sm text-gray-400">Current Plan</div>
+                                    <div className="text-xs text-gray-400">Current Plan</div>
                                 </div>
-                                <div className="space-y-2">
-                                    <div className="text-2xl md:text-3xl font-bold text-green-400">
+                                <div className="space-y-1">
+                                    <div className="text-2xl font-bold text-green-400">
                                         {getDaysUntilReset()}
                                     </div>
-                                    <div className="text-xs md:text-sm text-gray-400">Days Until Reset</div>
+                                    <div className="text-xs text-gray-400">Days Until Reset</div>
                                 </div>
                             </div>
                         </CardContent>
                     </Card>
 
-                    {/* Products Grid - Mobile-first layout */}
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6 max-w-4xl mx-auto">
-                        {loading ? (
-                            Array.from({ length: 3 }).map((_, index) => (
-                                <Card key={index} className="border-gray-600 bg-gray-800/50 animate-pulse">
-                                    <CardContent className="p-4 md:p-6">
-                                        <div className="h-24 md:h-32 bg-gray-700 rounded"></div>
-                                    </CardContent>
-                                </Card>
-                            ))
-                        ) : (
-                            products.map((product) => {
-                                const isPopular = product.variant === '20_turns'; // 20 turns plan is popular
-                                return (
-                                    <Card
-                                        key={product.variant}
-                                        className={`relative transition-all duration-300 hover:scale-105 touch-manipulation ${isPopular
-                                            ? 'border-purple-500 bg-purple-900/30 ring-2 ring-purple-500/50'
-                                            : 'border-gray-600 bg-gray-800/50 hover:border-purple-500'
-                                            }`}
-                                    >
-                                        {isPopular && (
-                                            <div className="absolute -top-3 left-1/2 transform -translate-x-1/2">
-                                                <Badge className="bg-purple-600 text-white px-3 py-1 text-xs font-medium">
-                                                    MOST POPULAR
-                                                </Badge>
-                                            </div>
-                                        )}
-                                        <CardHeader className="text-center p-4 md:p-6">
-                                            <CardTitle className="text-lg md:text-xl text-white flex items-center justify-center space-x-2">
-                                                <Zap className="h-5 w-5 md:h-6 md:w-6 text-purple-400" />
-                                                <span>{product.name}</span>
-                                            </CardTitle>
-                                            <div className="space-y-2">
-                                                <div className="text-3xl md:text-4xl font-bold text-purple-400">
-                                                    {product.price}
-                                                </div>
-
-                                            </div>
-                                        </CardHeader>
-                                        <CardContent className="p-4 md:p-6 pt-0">
-                                            <div className="space-y-3 md:space-y-4 mb-4 md:mb-6">
-                                                <div className="flex items-center justify-center space-x-2">
-                                                    <Gift className="h-4 w-4 md:h-5 md:w-5 text-purple-400" />
-                                                    <span className="text-base md:text-lg font-medium text-white">
-                                                        {product.variant === '10_turns' ? '10' :
-                                                            product.variant === '20_turns' ? '20' :
-                                                                product.description?.match(/\d+/)?.[0] || '?'} Turns
-                                                    </span>
-                                                </div>
-                                                <div className="text-xs md:text-sm text-gray-400 text-center">
-                                                    Turns never expire • Use anytime
-                                                </div>
-                                            </div>
-
-                                            {/* MetaMask Payment Button */}
-                                            <div className="space-y-2">
-                                                <Button
-                                                    onClick={() => {
-                                                        const usdtAmount = product.variant === '10_turns' ? '3.99' : '5.99';
-                                                        handleUSDTPayment(product.variant, usdtAmount, product.price);
-                                                    }}
-                                                    disabled={paymentLoading === product.variant}
-                                                    className="w-full py-3 md:py-2 text-base md:text-sm touch-manipulation transition-all bg-green-600 hover:bg-green-700 text-white"
-                                                >
-                                                    {paymentLoading === product.variant ? (
-                                                        <>
-                                                            <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
-                                                            Processing...
-                                                        </>
-                                                    ) : (
-                                                        <>
-                                                            <Wallet className="h-4 w-4 mr-2" />
-                                                            Pay with MetaMask ({product.variant === '10_turns' ? '3.99' : '5.99'} USDT)
-                                                        </>
-                                                    )}
-                                                </Button>
-
-                                                {/* Credit Card Coming Soon Button */}
-                                                <Button
-                                                    disabled={true}
-                                                    className="w-full py-2 text-sm touch-manipulation transition-all bg-gray-600 hover:bg-gray-600 text-gray-400 cursor-not-allowed"
-                                                >
-                                                    <Star className="h-4 w-4 mr-2" />
-                                                    Credit Card (Coming Soon)
-                                                </Button>
-                                            </div>
-                                        </CardContent>
-                                    </Card>
-                                );
-                            })
-                        )}
-                    </div>
-
-                    {/* FAQ/Info section - Mobile-optimized */}
-                    <Card className="bg-gray-800/50 border-gray-600">
-                        <CardContent className="p-4 md:p-6">
-                            <h3 className="font-medium mb-3 md:mb-4 text-white text-lg md:text-base">How it works:</h3>
-                            <div className="space-y-3 md:space-y-2 text-sm md:text-sm text-gray-200">
-                                <div className="flex items-start space-x-3 md:space-x-2">
-                                    <div className="w-2 h-2 md:w-1.5 md:h-1.5 bg-blue-400 rounded-full mt-2 flex-shrink-0"></div>
-                                    <span className="leading-relaxed">Every user gets 3 free turns each month, regardless of subscription</span>
-                                </div>
-                                <div className="flex items-start space-x-3 md:space-x-2">
-                                    <div className="w-2 h-2 md:w-1.5 md:h-1.5 bg-blue-400 rounded-full mt-2 flex-shrink-0"></div>
-                                    <span className="leading-relaxed">Free turns are used first, then paid turns</span>
-                                </div>
-                                <div className="flex items-start space-x-3 md:space-x-2">
-                                    <div className="w-2 h-2 md:w-1.5 md:h-1.5 bg-blue-400 rounded-full mt-2 flex-shrink-0"></div>
-                                    <span className="leading-relaxed">Free turns reset on the 1st of each month</span>
-                                </div>
-                                <div className="flex items-start space-x-3 md:space-x-2">
-                                    <div className="w-2 h-2 md:w-1.5 md:h-1.5 bg-blue-400 rounded-full mt-2 flex-shrink-0"></div>
-                                    <span className="leading-relaxed">Paid turns never expire and carry over month to month</span>
-                                </div>
-                                <div className="flex items-start space-x-3 md:space-x-2">
-                                    <div className="w-2 h-2 md:w-1.5 md:h-1.5 bg-blue-400 rounded-full mt-2 flex-shrink-0"></div>
-                                    <span className="leading-relaxed">Secure payment processing will be available soon</span>
+                    {/* Watch ad to earn turn */}
+                    <Card className="border-indigo-500 bg-indigo-900/20">
+                        <CardContent className="p-4 md:p-6 space-y-4">
+                            <div className="flex items-center space-x-3">
+                                <Tv2 className="h-6 w-6 text-indigo-400 flex-shrink-0" />
+                                <div>
+                                    <h3 className="font-semibold text-white">Watch an Ad, Earn a Turn</h3>
+                                    <p className="text-sm text-gray-400 mt-0.5">
+                                        Watch a 15-second ad and get +1 turn instantly. Up to 5 times per day.
+                                    </p>
                                 </div>
                             </div>
+
+                            <WatchAdButton
+                                adTurnsEarnedToday={adStatusLoading ? 0 : adTurnsEarnedToday}
+                                onTurnEarned={handleTurnEarned}
+                                className="w-full justify-center py-3"
+                            />
+
+                            {/* Daily progress bar */}
+                            <div className="space-y-1">
+                                <div className="flex justify-between text-xs text-gray-400">
+                                    <span>Daily ad turns used</span>
+                                    <span>{adTurnsEarnedToday}/5</span>
+                                </div>
+                                <div className="w-full bg-gray-700 rounded-full h-2">
+                                    <div
+                                        className="bg-indigo-500 h-2 rounded-full transition-all duration-300"
+                                        style={{ width: `${Math.min((adTurnsEarnedToday / 5) * 100, 100)}%` }}
+                                    />
+                                </div>
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    {/* Earn free turns info */}
+                    <Card className="border-green-500 bg-green-900/20">
+                        <CardContent className="p-4 md:p-6">
+                            <div className="flex items-center space-x-3 mb-3">
+                                <Zap className="h-5 w-5 text-green-400" />
+                                <h3 className="font-semibold text-green-300">Free Turns You Already Get</h3>
+                            </div>
+                            <ul className="space-y-2 text-sm text-gray-300">
+                                <li className="flex items-start space-x-2">
+                                    <div className="w-1.5 h-1.5 bg-green-400 rounded-full mt-1.5 flex-shrink-0" />
+                                    <span>3 free turns every month, auto-reset on the 1st</span>
+                                </li>
+                                <li className="flex items-start space-x-2">
+                                    <div className="w-1.5 h-1.5 bg-indigo-400 rounded-full mt-1.5 flex-shrink-0" />
+                                    <span>Up to 5 ad-earned turns per day (never expire)</span>
+                                </li>
+                                <li className="flex items-start space-x-2">
+                                    <div className="w-1.5 h-1.5 bg-blue-400 rounded-full mt-1.5 flex-shrink-0" />
+                                    <span>Free turns reset monthly, ad-earned turns carry over</span>
+                                </li>
+                            </ul>
+                        </CardContent>
+                    </Card>
+
+                    {/* MetaMask still available */}
+                    <Card className="border-gray-600 bg-gray-800/40">
+                        <CardContent className="p-4">
+                            <p className="text-xs text-gray-500 text-center">
+                                Prefer to pay directly?{' '}
+                                <Button
+                                    variant="link"
+                                    size="sm"
+                                    className="text-purple-400 p-0 h-auto text-xs"
+                                    onClick={() => {
+                                        onClose();
+                                        // MetaMask payment is still wired elsewhere if needed
+                                    }}
+                                >
+                                    MetaMask payments are still available on request.
+                                </Button>
+                            </p>
                         </CardContent>
                     </Card>
                 </div>

--- a/frontend/src/components/SubscriptionModal.tsx
+++ b/frontend/src/components/SubscriptionModal.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { useSubscription } from '@/hooks/useSubscription';
+import { useMetaMask } from '@/hooks/useMetaMask';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
 import {
     Dialog,
     DialogContent,
@@ -9,8 +11,16 @@ import {
     DialogHeader,
     DialogTitle
 } from '@/components/ui/dialog';
-import { Zap, Crown, Star, Tv2 } from 'lucide-react';
-import { ads } from '@/lib/api';
+import {
+    Zap,
+    Crown,
+    Star,
+    Gift,
+    Wallet,
+    Tv2,
+} from 'lucide-react';
+import { subscription, ads } from '@/lib/api';
+import { toast } from 'react-hot-toast';
 import { WatchAdButton } from '@/components/WatchAdButton';
 
 interface SubscriptionModalProps {
@@ -21,12 +31,22 @@ interface SubscriptionModalProps {
 export function SubscriptionModal({ isOpen, onClose }: SubscriptionModalProps) {
     const {
         turns,
+        products,
         loading,
         getSubscriptionStatusText,
         getDaysUntilReset,
         refreshData,
     } = useSubscription();
 
+    const {
+        isConnected,
+        account,
+        isLoading,
+        connect: connectMetaMask,
+        sendPayment,
+    } = useMetaMask();
+
+    const [paymentLoading, setPaymentLoading] = useState<string | null>(null);
     const [adTurnsEarnedToday, setAdTurnsEarnedToday] = useState(0);
     const [adStatusLoading, setAdStatusLoading] = useState(false);
 
@@ -36,9 +56,40 @@ export function SubscriptionModal({ isOpen, onClose }: SubscriptionModalProps) {
         setAdStatusLoading(true);
         ads.getStatus()
             .then((status) => setAdTurnsEarnedToday(status.ad_turns_earned_today))
-            .catch(() => {/* non-critical */ })
+            .catch(() => {/* non-critical */})
             .finally(() => setAdStatusLoading(false));
     }, [isOpen]);
+
+    const handleUSDTPayment = async (productVariant: string, usdtAmount: string, usdPrice: string) => {
+        setPaymentLoading(productVariant);
+        try {
+            if (!isConnected) {
+                await connectMetaMask();
+                return;
+            }
+
+            const transactionHash = await sendPayment({
+                productVariant,
+                ethAmount: '0.001',
+                usdPrice,
+            });
+
+            await subscription.processEthereumPayment(
+                transactionHash,
+                productVariant,
+                usdtAmount,
+                account!
+            );
+
+            toast.success('Payment successful! Your turns have been added.');
+            await refreshData();
+            onClose();
+        } catch (error) {
+            console.error('Payment failed:', error);
+        } finally {
+            setPaymentLoading(null);
+        }
+    };
 
     const handleTurnEarned = async () => {
         setAdTurnsEarnedToday((prev) => prev + 1);
@@ -47,56 +98,59 @@ export function SubscriptionModal({ isOpen, onClose }: SubscriptionModalProps) {
 
     return (
         <Dialog open={isOpen} onOpenChange={onClose}>
-            <DialogContent className="max-w-2xl max-h-[95vh] overflow-y-auto bg-gray-900 border-purple-700">
-                <DialogHeader className="space-y-3">
-                    <DialogTitle className="text-xl md:text-2xl font-bold text-center bg-gradient-to-r from-purple-400 via-purple-600 to-indigo-600 bg-clip-text text-transparent">
-                        <div className="flex items-center justify-center space-x-2">
-                            <Crown className="h-6 w-6 text-purple-500" />
+            <DialogContent className="max-w-5xl max-h-[95vh] overflow-y-auto bg-gray-900 border-purple-700">
+                <DialogHeader className="space-y-3 md:space-y-4">
+                    <DialogTitle className="text-xl md:text-2xl lg:text-3xl font-bold text-center bg-gradient-to-r from-purple-400 via-purple-600 to-indigo-600 bg-clip-text text-transparent">
+                        <div className="flex items-center justify-center space-x-2 md:space-x-3">
+                            <Crown className="h-6 w-6 md:h-7 md:w-7 lg:h-8 lg:w-8 text-purple-500" />
                             <span>Get More Turns</span>
-                            <Star className="h-6 w-6 text-purple-500" />
+                            <Star className="h-6 w-6 md:h-7 md:w-7 lg:h-8 lg:w-8 text-purple-500" />
                         </div>
                     </DialogTitle>
-                    <DialogDescription className="text-base text-purple-300 text-center">
-                        Watch a short ad to earn a free turn — no payment needed.
+                    <DialogDescription className="text-base md:text-lg text-purple-300 text-center">
+                        Pay with MetaMask or watch a short ad to earn free turns.
                     </DialogDescription>
                 </DialogHeader>
 
                 <div className="space-y-4 md:space-y-6">
-                    {/* Current status */}
-                    <Card className="border-blue-500 bg-blue-900/20">
+                    {/* MetaMask Status */}
+                    <Card className="border-green-500 bg-green-900/20">
                         <CardContent className="p-4 md:p-6">
-                            <div className="grid grid-cols-3 gap-4 text-center">
-                                <div className="space-y-1">
-                                    <div className="text-2xl font-bold text-blue-400">
-                                        {turns?.total_turns ?? 0}
+                            <div className="flex items-center justify-between">
+                                <div className="flex items-center space-x-3">
+                                    <Wallet className="h-6 w-6 text-green-400" />
+                                    <div>
+                                        <h3 className="font-medium text-green-400">MetaMask Wallet — USDT Payment</h3>
+                                        <p className="text-sm text-green-300">
+                                            {isConnected
+                                                ? `Connected: ${account?.slice(0, 6)}...${account?.slice(-4)}`
+                                                : 'Pay instantly with USDT stablecoin'
+                                            }
+                                        </p>
                                     </div>
-                                    <div className="text-xs text-gray-400">Remaining Turns</div>
                                 </div>
-                                <div className="space-y-1">
-                                    <div className="text-2xl font-bold text-purple-400">
-                                        {loading ? '…' : getSubscriptionStatusText()}
-                                    </div>
-                                    <div className="text-xs text-gray-400">Current Plan</div>
-                                </div>
-                                <div className="space-y-1">
-                                    <div className="text-2xl font-bold text-green-400">
-                                        {getDaysUntilReset()}
-                                    </div>
-                                    <div className="text-xs text-gray-400">Days Until Reset</div>
-                                </div>
+                                {!isConnected && (
+                                    <Button
+                                        onClick={connectMetaMask}
+                                        disabled={isLoading}
+                                        className="bg-green-600 hover:bg-green-700 text-white px-4 py-2"
+                                    >
+                                        {isLoading ? 'Connecting...' : 'Connect'}
+                                    </Button>
+                                )}
                             </div>
                         </CardContent>
                     </Card>
 
-                    {/* Watch ad to earn turn */}
+                    {/* Watch Ad — replaces Credit Card Coming Soon */}
                     <Card className="border-indigo-500 bg-indigo-900/20">
                         <CardContent className="p-4 md:p-6 space-y-4">
                             <div className="flex items-center space-x-3">
                                 <Tv2 className="h-6 w-6 text-indigo-400 flex-shrink-0" />
                                 <div>
-                                    <h3 className="font-semibold text-white">Watch an Ad, Earn a Turn</h3>
-                                    <p className="text-sm text-gray-400 mt-0.5">
-                                        Watch a 15-second ad and get +1 turn instantly. Up to 5 times per day.
+                                    <h3 className="font-medium text-indigo-300 text-lg">Watch an Ad, Earn a Turn</h3>
+                                    <p className="text-sm text-indigo-200 mt-1">
+                                        Watch a 15-second ad and get +1 turn instantly. Up to 20 times per day, completely free.
                                     </p>
                                 </div>
                             </div>
@@ -111,59 +165,150 @@ export function SubscriptionModal({ isOpen, onClose }: SubscriptionModalProps) {
                             <div className="space-y-1">
                                 <div className="flex justify-between text-xs text-gray-400">
                                     <span>Daily ad turns used</span>
-                                    <span>{adTurnsEarnedToday}/5</span>
+                                    <span>{adTurnsEarnedToday}/20</span>
                                 </div>
                                 <div className="w-full bg-gray-700 rounded-full h-2">
                                     <div
                                         className="bg-indigo-500 h-2 rounded-full transition-all duration-300"
-                                        style={{ width: `${Math.min((adTurnsEarnedToday / 5) * 100, 100)}%` }}
+                                        style={{ width: `${Math.min((adTurnsEarnedToday / 20) * 100, 100)}%` }}
                                     />
                                 </div>
                             </div>
                         </CardContent>
                     </Card>
 
-                    {/* Earn free turns info */}
-                    <Card className="border-green-500 bg-green-900/20">
+                    {/* Current Status */}
+                    <Card className="border-blue-500 bg-blue-900/20">
                         <CardContent className="p-4 md:p-6">
-                            <div className="flex items-center space-x-3 mb-3">
-                                <Zap className="h-5 w-5 text-green-400" />
-                                <h3 className="font-semibold text-green-300">Free Turns You Already Get</h3>
+                            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-6 text-center">
+                                <div className="space-y-2">
+                                    <div className="text-2xl md:text-3xl font-bold text-blue-400">
+                                        {turns?.total_turns ?? 0}
+                                    </div>
+                                    <div className="text-xs md:text-sm text-gray-400">Remaining Turns</div>
+                                </div>
+                                <div className="space-y-2">
+                                    <div className="text-2xl md:text-3xl font-bold text-purple-400">
+                                        {getSubscriptionStatusText()}
+                                    </div>
+                                    <div className="text-xs md:text-sm text-gray-400">Current Plan</div>
+                                </div>
+                                <div className="space-y-2">
+                                    <div className="text-2xl md:text-3xl font-bold text-green-400">
+                                        {getDaysUntilReset()}
+                                    </div>
+                                    <div className="text-xs md:text-sm text-gray-400">Days Until Reset</div>
+                                </div>
                             </div>
-                            <ul className="space-y-2 text-sm text-gray-300">
-                                <li className="flex items-start space-x-2">
-                                    <div className="w-1.5 h-1.5 bg-green-400 rounded-full mt-1.5 flex-shrink-0" />
-                                    <span>3 free turns every month, auto-reset on the 1st</span>
-                                </li>
-                                <li className="flex items-start space-x-2">
-                                    <div className="w-1.5 h-1.5 bg-indigo-400 rounded-full mt-1.5 flex-shrink-0" />
-                                    <span>Up to 5 ad-earned turns per day (never expire)</span>
-                                </li>
-                                <li className="flex items-start space-x-2">
-                                    <div className="w-1.5 h-1.5 bg-blue-400 rounded-full mt-1.5 flex-shrink-0" />
-                                    <span>Free turns reset monthly, ad-earned turns carry over</span>
-                                </li>
-                            </ul>
                         </CardContent>
                     </Card>
 
-                    {/* MetaMask still available */}
-                    <Card className="border-gray-600 bg-gray-800/40">
-                        <CardContent className="p-4">
-                            <p className="text-xs text-gray-500 text-center">
-                                Prefer to pay directly?{' '}
-                                <Button
-                                    variant="link"
-                                    size="sm"
-                                    className="text-purple-400 p-0 h-auto text-xs"
-                                    onClick={() => {
-                                        onClose();
-                                        // MetaMask payment is still wired elsewhere if needed
-                                    }}
-                                >
-                                    MetaMask payments are still available on request.
-                                </Button>
-                            </p>
+                    {/* Products Grid — MetaMask only */}
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6 max-w-4xl mx-auto">
+                        {loading ? (
+                            Array.from({ length: 2 }).map((_, index) => (
+                                <Card key={index} className="border-gray-600 bg-gray-800/50 animate-pulse">
+                                    <CardContent className="p-4 md:p-6">
+                                        <div className="h-24 md:h-32 bg-gray-700 rounded"></div>
+                                    </CardContent>
+                                </Card>
+                            ))
+                        ) : (
+                            products.map((product) => {
+                                const isPopular = product.variant === '20_turns';
+                                return (
+                                    <Card
+                                        key={product.variant}
+                                        className={`relative transition-all duration-300 hover:scale-105 touch-manipulation ${
+                                            isPopular
+                                                ? 'border-purple-500 bg-purple-900/30 ring-2 ring-purple-500/50'
+                                                : 'border-gray-600 bg-gray-800/50 hover:border-purple-500'
+                                        }`}
+                                    >
+                                        {isPopular && (
+                                            <div className="absolute -top-3 left-1/2 transform -translate-x-1/2">
+                                                <Badge className="bg-purple-600 text-white px-3 py-1 text-xs font-medium">
+                                                    MOST POPULAR
+                                                </Badge>
+                                            </div>
+                                        )}
+                                        <CardHeader className="text-center p-4 md:p-6">
+                                            <CardTitle className="text-lg md:text-xl text-white flex items-center justify-center space-x-2">
+                                                <Zap className="h-5 w-5 md:h-6 md:w-6 text-purple-400" />
+                                                <span>{product.name}</span>
+                                            </CardTitle>
+                                            <div className="text-3xl md:text-4xl font-bold text-purple-400">
+                                                {product.price}
+                                            </div>
+                                        </CardHeader>
+                                        <CardContent className="p-4 md:p-6 pt-0">
+                                            <div className="space-y-3 md:space-y-4 mb-4 md:mb-6">
+                                                <div className="flex items-center justify-center space-x-2">
+                                                    <Gift className="h-4 w-4 md:h-5 md:w-5 text-purple-400" />
+                                                    <span className="text-base md:text-lg font-medium text-white">
+                                                        {product.variant === '10_turns' ? '10' :
+                                                            product.variant === '20_turns' ? '20' :
+                                                                product.description?.match(/\d+/)?.[0] || '?'} Turns
+                                                    </span>
+                                                </div>
+                                                <div className="text-xs md:text-sm text-gray-400 text-center">
+                                                    Turns never expire • Use anytime
+                                                </div>
+                                            </div>
+
+                                            <Button
+                                                onClick={() => {
+                                                    const usdtAmount = product.variant === '10_turns' ? '3.99' : '5.99';
+                                                    handleUSDTPayment(product.variant, usdtAmount, product.price);
+                                                }}
+                                                disabled={paymentLoading === product.variant}
+                                                className="w-full py-3 md:py-2 text-base md:text-sm touch-manipulation transition-all bg-green-600 hover:bg-green-700 text-white"
+                                            >
+                                                {paymentLoading === product.variant ? (
+                                                    <>
+                                                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
+                                                        Processing...
+                                                    </>
+                                                ) : (
+                                                    <>
+                                                        <Wallet className="h-4 w-4 mr-2" />
+                                                        Pay with MetaMask ({product.variant === '10_turns' ? '3.99' : '5.99'} USDT)
+                                                    </>
+                                                )}
+                                            </Button>
+                                        </CardContent>
+                                    </Card>
+                                );
+                            })
+                        )}
+                    </div>
+
+                    {/* How it works */}
+                    <Card className="bg-gray-800/50 border-gray-600">
+                        <CardContent className="p-4 md:p-6">
+                            <h3 className="font-medium mb-3 md:mb-4 text-white text-lg md:text-base">How it works:</h3>
+                            <div className="space-y-3 md:space-y-2 text-sm md:text-sm text-gray-200">
+                                <div className="flex items-start space-x-3 md:space-x-2">
+                                    <div className="w-2 h-2 md:w-1.5 md:h-1.5 bg-blue-400 rounded-full mt-2 flex-shrink-0"></div>
+                                    <span className="leading-relaxed">Every user gets 3 free turns each month, regardless of plan</span>
+                                </div>
+                                <div className="flex items-start space-x-3 md:space-x-2">
+                                    <div className="w-2 h-2 md:w-1.5 md:h-1.5 bg-blue-400 rounded-full mt-2 flex-shrink-0"></div>
+                                    <span className="leading-relaxed">Free turns are used first, then paid/ad-earned turns</span>
+                                </div>
+                                <div className="flex items-start space-x-3 md:space-x-2">
+                                    <div className="w-2 h-2 md:w-1.5 md:h-1.5 bg-blue-400 rounded-full mt-2 flex-shrink-0"></div>
+                                    <span className="leading-relaxed">Free turns reset on the 1st of each month</span>
+                                </div>
+                                <div className="flex items-start space-x-3 md:space-x-2">
+                                    <div className="w-2 h-2 md:w-1.5 md:h-1.5 bg-indigo-400 rounded-full mt-2 flex-shrink-0"></div>
+                                    <span className="leading-relaxed">Watch ads to earn up to 20 free turns per day — turns never expire</span>
+                                </div>
+                                <div className="flex items-start space-x-3 md:space-x-2">
+                                    <div className="w-2 h-2 md:w-1.5 md:h-1.5 bg-green-400 rounded-full mt-2 flex-shrink-0"></div>
+                                    <span className="leading-relaxed">Paid turns via MetaMask never expire and carry over month to month</span>
+                                </div>
+                            </div>
                         </CardContent>
                     </Card>
                 </div>

--- a/frontend/src/components/TurnCounter.tsx
+++ b/frontend/src/components/TurnCounter.tsx
@@ -148,15 +148,15 @@ export function TurnCounter({ onPurchaseClick, showDetails = true, className = '
                             )}
                         </div>
 
-                        {/* Always show Buy More button unless unlimited turns */}
+                        {/* Show "Get Turns" button (ad-watching) unless unlimited */}
                         {!hasUnlimitedTurns && (
                             <Button
                                 size="sm"
                                 onClick={onPurchaseClick}
-                                className="flex items-center space-x-1 bg-purple-600 hover:bg-purple-700 text-white ml-4"
+                                className="flex items-center space-x-1 bg-indigo-600 hover:bg-indigo-700 text-white ml-4"
                             >
                                 <Plus className="h-4 w-4" />
-                                <span>Buy More</span>
+                                <span>Get Turns</span>
                             </Button>
                         )}
                     </div>
@@ -201,14 +201,14 @@ export function TurnCounter({ onPurchaseClick, showDetails = true, className = '
                                     {/* No turns warning */}
                                     {turns.total_turns === 0 && (
                                         <div className="text-xs text-orange-200 bg-orange-800/50 dark:text-orange-200 dark:bg-orange-800/50 p-2 rounded">
-                                            You&apos;ve used all your turns! Purchase more to continue drawing cards.
+                                            You&apos;ve used all your turns! Watch an ad to earn more.
                                         </div>
                                     )}
 
                                     {/* Low turns warning */}
                                     {hasLowTurns && turns.total_turns > 0 && (
                                         <div className="text-xs text-orange-200 bg-orange-800/50 dark:text-orange-200 dark:bg-orange-800/50 p-2 rounded">
-                                            Running low on turns! Consider purchasing more to avoid interruptions.
+                                            Running low! Watch an ad to earn a free turn.
                                         </div>
                                     )}
                                 </>

--- a/frontend/src/components/WatchAdButton.tsx
+++ b/frontend/src/components/WatchAdButton.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogDescription,
+} from '@/components/ui/dialog';
+import { Tv2, Clock, CheckCircle2, XCircle } from 'lucide-react';
+import { ads } from '@/lib/api';
+import { toast } from 'react-hot-toast';
+
+// Adsterra zone ID — set NEXT_PUBLIC_ADSTERRA_ZONE_ID in your .env
+const ADSTERRA_ZONE_ID = process.env.NEXT_PUBLIC_ADSTERRA_ZONE_ID ?? '';
+const AD_WATCH_SECONDS = 15;
+const DAILY_LIMIT = 5;
+
+interface WatchAdButtonProps {
+    adTurnsEarnedToday: number;
+    onTurnEarned: () => void;
+    className?: string;
+}
+
+export function WatchAdButton({ adTurnsEarnedToday, onTurnEarned, className = '' }: WatchAdButtonProps) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [secondsLeft, setSecondsLeft] = useState(AD_WATCH_SECONDS);
+    const [canClaim, setCanClaim] = useState(false);
+    const [claiming, setClaiming] = useState(false);
+    const [adStarted, setAdStarted] = useState(false);
+    const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const adContainerRef = useRef<HTMLDivElement>(null);
+    const scriptRef = useRef<HTMLScriptElement | null>(null);
+
+    const remaining = DAILY_LIMIT - adTurnsEarnedToday;
+    const limitReached = remaining <= 0;
+
+    const clearTimer = useCallback(() => {
+        if (timerRef.current) {
+            clearInterval(timerRef.current);
+            timerRef.current = null;
+        }
+    }, []);
+
+    const startCountdown = useCallback(() => {
+        setAdStarted(true);
+        setSecondsLeft(AD_WATCH_SECONDS);
+        setCanClaim(false);
+
+        timerRef.current = setInterval(() => {
+            setSecondsLeft((prev) => {
+                if (prev <= 1) {
+                    clearTimer();
+                    setCanClaim(true);
+                    return 0;
+                }
+                return prev - 1;
+            });
+        }, 1000);
+    }, [clearTimer]);
+
+    // Inject Adsterra script into the ad container when the modal opens
+    useEffect(() => {
+        if (!isOpen || !adContainerRef.current) return;
+
+        // Remove any previous script
+        if (scriptRef.current) {
+            scriptRef.current.remove();
+            scriptRef.current = null;
+        }
+
+        if (!ADSTERRA_ZONE_ID) {
+            // No zone ID configured — start countdown anyway (dev/test mode)
+            startCountdown();
+            return;
+        }
+
+        const script = document.createElement('script');
+        script.type = 'text/javascript';
+        // Adsterra banner/interstitial embed
+        script.src = `//www.topdisplaynetwork.com/${ADSTERRA_ZONE_ID}/invoke.js`;
+        script.async = true;
+        script.setAttribute('data-cfasync', 'false');
+        script.onload = () => startCountdown();
+        script.onerror = () => {
+            // Ad blocked or failed — still start countdown so user isn't stuck
+            startCountdown();
+        };
+
+        adContainerRef.current.appendChild(script);
+        scriptRef.current = script;
+    }, [isOpen, startCountdown]);
+
+    const handleOpen = () => {
+        if (limitReached) return;
+        setIsOpen(true);
+        setAdStarted(false);
+        setCanClaim(false);
+        setSecondsLeft(AD_WATCH_SECONDS);
+    };
+
+    const handleClose = () => {
+        clearTimer();
+        setIsOpen(false);
+        setAdStarted(false);
+        setCanClaim(false);
+    };
+
+    const handleClaim = async () => {
+        if (!canClaim || claiming) return;
+        setClaiming(true);
+        try {
+            await ads.complete('adsterra');
+            toast.success('Turn awarded! Enjoy your reading.');
+            onTurnEarned();
+            handleClose();
+        } catch (err: unknown) {
+            const msg =
+                err && typeof err === 'object' && 'response' in err
+                    ? (err as { response?: { data?: { detail?: string } } }).response?.data?.detail ?? 'Failed to claim turn.'
+                    : 'Failed to claim turn.';
+            toast.error(typeof msg === 'string' ? msg : 'Failed to claim turn.');
+        } finally {
+            setClaiming(false);
+        }
+    };
+
+    return (
+        <>
+            <Button
+                onClick={handleOpen}
+                disabled={limitReached}
+                className={`flex items-center space-x-2 bg-indigo-600 hover:bg-indigo-700 text-white disabled:opacity-50 ${className}`}
+            >
+                <Tv2 className="h-4 w-4" />
+                <span>
+                    {limitReached
+                        ? 'Ad limit reached today'
+                        : `Watch Ad (+1 turn) · ${remaining}/${DAILY_LIMIT} left today`}
+                </span>
+            </Button>
+
+            <Dialog open={isOpen} onOpenChange={handleClose}>
+                <DialogContent className="max-w-lg bg-gray-900 border-indigo-700">
+                    <DialogHeader>
+                        <DialogTitle className="text-white flex items-center space-x-2">
+                            <Tv2 className="h-5 w-5 text-indigo-400" />
+                            <span>Watch Ad to Earn 1 Turn</span>
+                        </DialogTitle>
+                        <DialogDescription className="text-gray-400">
+                            Watch the ad for {AD_WATCH_SECONDS} seconds, then claim your free turn.
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    <div className="space-y-4">
+                        {/* Ad container */}
+                        <div
+                            ref={adContainerRef}
+                            className="min-h-[100px] bg-gray-800 rounded flex items-center justify-center border border-gray-700"
+                        >
+                            {!adStarted && (
+                                <span className="text-gray-500 text-sm">Loading ad...</span>
+                            )}
+                        </div>
+
+                        {/* Countdown / status */}
+                        <div className="flex items-center justify-between">
+                            {!canClaim ? (
+                                <div className="flex items-center space-x-2 text-indigo-300">
+                                    <Clock className="h-4 w-4 animate-pulse" />
+                                    <span className="text-sm">
+                                        {adStarted
+                                            ? `Please wait ${secondsLeft}s…`
+                                            : 'Ad loading…'}
+                                    </span>
+                                </div>
+                            ) : (
+                                <div className="flex items-center space-x-2 text-green-400">
+                                    <CheckCircle2 className="h-4 w-4" />
+                                    <span className="text-sm">Ready to claim!</span>
+                                </div>
+                            )}
+
+                            <div className="flex space-x-2">
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={handleClose}
+                                    className="text-gray-400 hover:text-white"
+                                >
+                                    <XCircle className="h-4 w-4 mr-1" />
+                                    Cancel
+                                </Button>
+                                <Button
+                                    onClick={handleClaim}
+                                    disabled={!canClaim || claiming}
+                                    className="bg-green-600 hover:bg-green-700 text-white disabled:opacity-40"
+                                >
+                                    {claiming ? 'Claiming…' : 'Claim Turn'}
+                                </Button>
+                            </div>
+                        </div>
+
+                        <p className="text-xs text-gray-500 text-center">
+                            {adTurnsEarnedToday}/{DAILY_LIMIT} ad turns used today
+                        </p>
+                    </div>
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+}

--- a/frontend/src/components/WatchAdButton.tsx
+++ b/frontend/src/components/WatchAdButton.tsx
@@ -13,8 +13,9 @@ import { Tv2, Clock, CheckCircle2, XCircle } from 'lucide-react';
 import { ads } from '@/lib/api';
 import { toast } from 'react-hot-toast';
 
-// Adsterra zone ID — set NEXT_PUBLIC_ADSTERRA_ZONE_ID in your .env
-const ADSTERRA_ZONE_ID = process.env.NEXT_PUBLIC_ADSTERRA_ZONE_ID ?? '';
+// Full Adsterra script URL — copy it from the "Get Code" popup in your Adsterra dashboard
+// and set NEXT_PUBLIC_ADSTERRA_SCRIPT_URL in your .env
+const ADSTERRA_SCRIPT_URL = process.env.NEXT_PUBLIC_ADSTERRA_SCRIPT_URL ?? '';
 const AD_WATCH_SECONDS = 15;
 const DAILY_LIMIT = 20;
 
@@ -71,16 +72,15 @@ export function WatchAdButton({ adTurnsEarnedToday, onTurnEarned, className = ''
             scriptRef.current = null;
         }
 
-        if (!ADSTERRA_ZONE_ID) {
-            // No zone ID configured — start countdown anyway (dev/test mode)
+        if (!ADSTERRA_SCRIPT_URL) {
+            // No script URL configured — start countdown anyway (dev/test mode)
             startCountdown();
             return;
         }
 
         const script = document.createElement('script');
         script.type = 'text/javascript';
-        // Adsterra banner/interstitial embed
-        script.src = `//www.topdisplaynetwork.com/${ADSTERRA_ZONE_ID}/invoke.js`;
+        script.src = ADSTERRA_SCRIPT_URL;
         script.async = true;
         script.setAttribute('data-cfasync', 'false');
         script.onload = () => startCountdown();

--- a/frontend/src/components/WatchAdButton.tsx
+++ b/frontend/src/components/WatchAdButton.tsx
@@ -16,7 +16,7 @@ import { toast } from 'react-hot-toast';
 // Adsterra zone ID — set NEXT_PUBLIC_ADSTERRA_ZONE_ID in your .env
 const ADSTERRA_ZONE_ID = process.env.NEXT_PUBLIC_ADSTERRA_ZONE_ID ?? '';
 const AD_WATCH_SECONDS = 15;
-const DAILY_LIMIT = 5;
+const DAILY_LIMIT = 20;
 
 interface WatchAdButtonProps {
     adTurnsEarnedToday: number;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -24,7 +24,9 @@ import {
     JournalAnalytics,
     Reminder,
     ReminderCreate,
-    JournalFilters
+    JournalFilters,
+    AdCompleteResponse,
+    AdStatus,
 } from "@/types/tarot";
 
 // Callback function to be set by AuthProvider
@@ -479,6 +481,19 @@ export const subscription = {
 
     getSubscriptionPlans: async (): Promise<SubscriptionPlan[]> => {
         const response = await api.get("/api/subscription/plans");
+        return response.data;
+    },
+};
+
+// Ad-watching endpoints
+export const ads = {
+    complete: async (adProvider: string = "adsterra"): Promise<AdCompleteResponse> => {
+        const response = await api.post("/api/ads/complete", { ad_provider: adProvider });
+        return response.data;
+    },
+
+    getStatus: async (): Promise<AdStatus> => {
+        const response = await api.get("/api/ads/status");
         return response.data;
     },
 };

--- a/frontend/src/types/tarot.ts
+++ b/frontend/src/types/tarot.ts
@@ -382,3 +382,18 @@ export interface JournalFilters {
     sort_by?: string;
     sort_order?: 'asc' | 'desc';
 }
+
+export interface AdCompleteResponse {
+    success: boolean;
+    turns_awarded: number;
+    total_turns: number;
+    ad_turns_earned_today: number;
+    ad_turns_remaining_today: number;
+    message: string;
+}
+
+export interface AdStatus {
+    ad_turns_earned_today: number;
+    ad_turns_remaining_today: number;
+    daily_limit: number;
+}


### PR DESCRIPTION
## Summary

Payment platforms block fortune-telling apps, so this replaces the **credit card payment** slot with a **rewarded ad** model — users watch a 15-second Adsterra ad to earn +1 turn, up to 20 times per day. MetaMask/USDT payments are kept as-is.

## What Changed

### Monetisation model
| Method | Before | After |
|---|---|---|
| MetaMask USDT | ✅ active | ✅ unchanged |
| Credit card | "Coming Soon" (disabled) | **Removed** |
| Watch ad | — | **New — earns 1 turn per ad, 20/day** |

### Backend

- **`models.py`** — Added `ad_turns_earned_today`, `ad_turns_reset_date` to `User`; new `AdView` audit table; helper methods `reset_ad_turns_if_needed()`, `can_earn_ad_turn()`, `remaining_ad_turns_today()`; daily limit constant `AD_TURNS_DAILY_LIMIT = 20`
- **`routers/ads.py`** *(new)* — `POST /api/ads/complete` (awards 1 turn, enforces 20/day rate limit) and `GET /api/ads/status`
- **`schemas.py`** — `AdCompleteRequest` / `AdCompleteResponse`
- **`migrations/20260423_000000_add_ad_views_table.py`** *(new)* — adds columns to `users`, creates `ad_views` table
- **`app.py`** — registers the new `ads` router

### Frontend

- **`WatchAdButton.tsx`** *(new)* — injects Adsterra script, runs 15 s countdown, enables "Claim Turn" on completion; graceful fallback if ad fails to load
- **`SubscriptionModal.tsx`** — MetaMask section restored unchanged; "Credit Card Coming Soon" card replaced with the Watch Ad section + daily progress bar; product cards kept with MetaMask-only pay button
- **`TurnCounter.tsx`** — "Buy More" → "Get Turns"; warning copy updated to mention watching ads
- **`api.ts`** — `ads.complete()` and `ads.getStatus()`
- **`types/tarot.ts`** — `AdCompleteResponse`, `AdStatus`

## Implementation Notes

- Ad turns are awarded via the existing `add_paid_turns(1)` path, so they never expire
- Daily counter resets automatically at midnight based on `ad_turns_reset_date`
- All completions are logged as `ad_view_completed` subscription events for analytics
- Set `NEXT_PUBLIC_ADSTERRA_ZONE_ID` in the frontend `.env` to activate real ads; without it the countdown still runs (useful for local testing)

## Test Plan

- [ ] Watch ad modal opens, countdown runs for 15 s, "Claim Turn" becomes enabled
- [ ] Claiming awards +1 turn and the turn counter updates immediately
- [ ] After 20 claims in one day, the button shows "Ad limit reached today"
- [ ] Counter resets the next calendar day
- [ ] MetaMask USDT payment still works end-to-end (connect → send → turns added)
- [ ] Run `alembic upgrade head` — migration applies cleanly on a fresh DB and on existing data

https://claude.ai/code/session_017zMb7tcGLok7WHy848awCt