### PR TITLE
Fix ad container script injection timing issue

### DIFF
--- a/frontend/src/components/WatchAdButton.tsx
+++ b/frontend/src/components/WatchAdButton.tsx
@@ -37,6 +37,11 @@ export function WatchAdButton({ adTurnsEarnedToday, onTurnEarned, className = ''
     // Track actual DOM mount — refs don't trigger effects, so we need state
     const [adContainerMounted, setAdContainerMounted] = useState(false);
 
+    const adContainerCallbackRef = useCallback((node: HTMLDivElement | null) => {
+        adContainerRef.current = node;
+        if (node) setAdContainerMounted(true);
+    }, []);
+
     const remaining = DAILY_LIMIT - adTurnsEarnedToday;
     const limitReached = remaining <= 0;
 
@@ -160,10 +165,7 @@ export function WatchAdButton({ adTurnsEarnedToday, onTurnEarned, className = ''
                     <div className="space-y-4">
                         {/* Ad container */}
                         <div
-                            ref={(node) => {
-                                adContainerRef.current = node;
-                                if (node && !adContainerMounted) setAdContainerMounted(true);
-                            }}
+                            ref={adContainerCallbackRef}
                             className="min-h-[100px] bg-gray-800 rounded flex items-center justify-center border border-gray-700"
                         >
                             {!adStarted && (

--- a/frontend/src/components/WatchAdButton.tsx
+++ b/frontend/src/components/WatchAdButton.tsx
@@ -32,8 +32,10 @@ export function WatchAdButton({ adTurnsEarnedToday, onTurnEarned, className = ''
     const [claiming, setClaiming] = useState(false);
     const [adStarted, setAdStarted] = useState(false);
     const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-    const adContainerRef = useRef<HTMLDivElement>(null);
+    const adContainerRef = useRef<HTMLDivElement | null>(null);
     const scriptRef = useRef<HTMLScriptElement | null>(null);
+    // Track actual DOM mount — refs don't trigger effects, so we need state
+    const [adContainerMounted, setAdContainerMounted] = useState(false);
 
     const remaining = DAILY_LIMIT - adTurnsEarnedToday;
     const limitReached = remaining <= 0;
@@ -62,9 +64,9 @@ export function WatchAdButton({ adTurnsEarnedToday, onTurnEarned, className = ''
         }, 1000);
     }, [clearTimer]);
 
-    // Inject Adsterra script into the ad container when the modal opens
+    // Inject Adsterra script once the ad container div is actually in the DOM
     useEffect(() => {
-        if (!isOpen || !adContainerRef.current) return;
+        if (!isOpen || !adContainerMounted || !adContainerRef.current) return;
 
         // Remove any previous script
         if (scriptRef.current) {
@@ -91,7 +93,7 @@ export function WatchAdButton({ adTurnsEarnedToday, onTurnEarned, className = ''
 
         adContainerRef.current.appendChild(script);
         scriptRef.current = script;
-    }, [isOpen, startCountdown]);
+    }, [isOpen, adContainerMounted, startCountdown]);
 
     const handleOpen = () => {
         if (limitReached) return;
@@ -106,6 +108,7 @@ export function WatchAdButton({ adTurnsEarnedToday, onTurnEarned, className = ''
         setIsOpen(false);
         setAdStarted(false);
         setCanClaim(false);
+        setAdContainerMounted(false);
     };
 
     const handleClaim = async () => {
@@ -157,7 +160,10 @@ export function WatchAdButton({ adTurnsEarnedToday, onTurnEarned, className = ''
                     <div className="space-y-4">
                         {/* Ad container */}
                         <div
-                            ref={adContainerRef}
+                            ref={(node) => {
+                                adContainerRef.current = node;
+                                if (node && !adContainerMounted) setAdContainerMounted(true);
+                            }}
                             className="min-h-[100px] bg-gray-800 rounded flex items-center justify-center border border-gray-700"
                         >
                             {!adStarted && (


### PR DESCRIPTION
## Summary
Fixed a race condition in the WatchAdButton component where the Adsterra ad script was being injected before the ad container DOM element was fully mounted, causing the ad to fail to load.

## Key Changes
- Added `adContainerMounted` state to track when the ad container div is actually present in the DOM
- Updated the ad container ref callback to set `adContainerMounted` to true once the node is mounted
- Modified the script injection effect to depend on `adContainerMounted` state in addition to `isOpen`
- Reset `adContainerMounted` to false when the modal closes to ensure proper cleanup
- Updated effect dependency array to include `adContainerMounted`

## Implementation Details
The issue was that refs alone don't trigger effect re-runs, so checking `adContainerRef.current` in the effect wasn't sufficient to ensure the DOM element existed before script injection. By introducing a state variable that gets set via the ref callback, we now have a proper dependency that ensures the script injection effect only runs after the DOM element is actually mounted. This prevents the Adsterra script from trying to access a container that doesn't exist yet.

https://claude.ai/code/session_01F1gCYAzRHGnc6DaJCzuqWT