### PR TITLE
fix: hardcode Adsterra script URL in docker-compose build arg

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       dockerfile: Dockerfile
       args:
         NEXT_PUBLIC_API_URL: https://backend-arcanaai.nguyenvanloc.com
-        NEXT_PUBLIC_ADSTERRA_SCRIPT_URL: ${NEXT_PUBLIC_ADSTERRA_SCRIPT_URL}
+        NEXT_PUBLIC_ADSTERRA_SCRIPT_URL: https://pl29229406.profitablecpmratenetwork.com/32/89/36/32893685fabdcae9cb06752690f16352.js
     image: vanloc1808/tarot-frontend:latest
     container_name: tarot-frontend
     restart: always


### PR DESCRIPTION
${NEXT_PUBLIC_ADSTERRA_SCRIPT_URL} was resolving to empty because docker-compose variable substitution reads from the shell env or the project root .env — not from env_file entries which are runtime-only.

The script URL is a public non-secret value so hardcoding it in the build args is the reliable approach.

https://claude.ai/code/session_01F1gCYAzRHGnc6DaJCzuqWT