### PR TITLE
Refactor ad injection to use document.body instead of dialog ref

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -6,5 +6,10 @@ NEXT_PUBLIC_API_URL=https://backend-arcanaai.nguyenvanloc.com
 # Environment (optional)
 NODE_ENV=development
 
+# Adsterra ad network — copy the script src URL from your Adsterra dashboard
+# (Site → Get Code → Popunder zone). Leave empty to run in dev/test mode
+# (countdown works but no real ad is shown and no impressions are recorded).
+NEXT_PUBLIC_ADSTERRA_SCRIPT_URL=
+
 # Note: Payment configuration is handled on the backend
 # See ../backend/.env.example for Lemon Squeezy and MetaMask settings

--- a/frontend/src/components/WatchAdButton.tsx
+++ b/frontend/src/components/WatchAdButton.tsx
@@ -82,13 +82,15 @@ export function WatchAdButton({ adTurnsEarnedToday, onTurnEarned, className = ''
     const handleOpen = () => {
         if (limitReached) return;
 
+        console.log('[WatchAd] handleOpen — ADSTERRA_SCRIPT_URL:', ADSTERRA_SCRIPT_URL || '(not set)');
+
         setIsOpen(true);
         setAdStarted(false);
         setCanClaim(false);
         setSecondsLeft(AD_WATCH_SECONDS);
 
         if (!ADSTERRA_SCRIPT_URL) {
-            // No ad URL configured — dev/test mode, just run the countdown
+            console.warn('[WatchAd] No ADSTERRA_SCRIPT_URL configured — running countdown in dev/test mode (no real ad)');
             setTimeout(startCountdown, 0);
             return;
         }
@@ -106,16 +108,21 @@ export function WatchAdButton({ adTurnsEarnedToday, onTurnEarned, className = ''
         script.src = ADSTERRA_SCRIPT_URL;
         script.async = true;
         script.setAttribute('data-cfasync', 'false');
-        script.onload = () => startCountdown();
-        script.onerror = () => {
-            // Ad blocked or failed — still start countdown so user isn't stuck
+        script.onload = () => {
+            console.log('[WatchAd] Adsterra script loaded successfully — starting countdown');
             startCountdown();
         };
+        script.onerror = (err) => {
+            console.error('[WatchAd] Adsterra script failed to load (blocked or network error):', err);
+            startCountdown();
+        };
+        console.log('[WatchAd] Appending Adsterra script to document.body');
         document.body.appendChild(script);
         scriptRef.current = script;
     };
 
     const handleClose = () => {
+        console.log('[WatchAd] handleClose — cleaning up timer and script');
         clearTimer();
         removeAdScript();
         setIsOpen(false);
@@ -125,13 +132,16 @@ export function WatchAdButton({ adTurnsEarnedToday, onTurnEarned, className = ''
 
     const handleClaim = async () => {
         if (!canClaim || claiming) return;
+        console.log('[WatchAd] handleClaim — calling ads.complete');
         setClaiming(true);
         try {
-            await ads.complete('adsterra');
+            const result = await ads.complete('adsterra');
+            console.log('[WatchAd] ads.complete response:', result);
             toast.success('Turn awarded! Enjoy your reading.');
             onTurnEarned();
             handleClose();
         } catch (err: unknown) {
+            console.error('[WatchAd] ads.complete failed:', err);
             const msg =
                 err && typeof err === 'object' && 'response' in err
                     ? (err as { response?: { data?: { detail?: string } } }).response?.data?.detail ?? 'Failed to claim turn.'

--- a/frontend/src/components/WatchAdButton.tsx
+++ b/frontend/src/components/WatchAdButton.tsx
@@ -32,7 +32,6 @@ export function WatchAdButton({ adTurnsEarnedToday, onTurnEarned, className = ''
     const [claiming, setClaiming] = useState(false);
     const [adStarted, setAdStarted] = useState(false);
     const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-    const adContainerRef = useRef<HTMLDivElement | null>(null);
     const scriptRef = useRef<HTMLScriptElement | null>(null);
 
     const remaining = DAILY_LIMIT - adTurnsEarnedToday;
@@ -62,54 +61,63 @@ export function WatchAdButton({ adTurnsEarnedToday, onTurnEarned, className = ''
         }, 1000);
     }, [clearTimer]);
 
-    // Defer ad init by one task so the Dialog portal has mounted before we
-    // read adContainerRef or inject a script. The cleanup cancels the timeout
-    // on unmount, which also prevents React StrictMode's double-invocation
-    // from calling startCountdown twice.
+    // Cleanup on unmount
     useEffect(() => {
-        if (!isOpen) return;
-
-        const initTimer = setTimeout(() => {
-            if (!adContainerRef.current) return;
-
+        return () => {
+            clearTimer();
             if (scriptRef.current) {
                 scriptRef.current.remove();
                 scriptRef.current = null;
             }
+        };
+    }, [clearTimer]);
 
-            if (!ADSTERRA_SCRIPT_URL) {
-                startCountdown();
-                return;
-            }
-
-            const script = document.createElement('script');
-            script.type = 'text/javascript';
-            script.src = ADSTERRA_SCRIPT_URL;
-            script.async = true;
-            script.setAttribute('data-cfasync', 'false');
-            script.onload = () => startCountdown();
-            script.onerror = () => {
-                // Ad blocked or failed — still start countdown so user isn't stuck
-                startCountdown();
-            };
-
-            adContainerRef.current.appendChild(script);
-            scriptRef.current = script;
-        }, 0);
-
-        return () => clearTimeout(initTimer);
-    }, [isOpen, startCountdown]);
+    const removeAdScript = useCallback(() => {
+        if (scriptRef.current) {
+            scriptRef.current.remove();
+            scriptRef.current = null;
+        }
+    }, []);
 
     const handleOpen = () => {
         if (limitReached) return;
+
         setIsOpen(true);
         setAdStarted(false);
         setCanClaim(false);
         setSecondsLeft(AD_WATCH_SECONDS);
+
+        if (!ADSTERRA_SCRIPT_URL) {
+            // No ad URL configured — dev/test mode, just run the countdown
+            setTimeout(startCountdown, 0);
+            return;
+        }
+
+        // Remove any leftover script from a previous ad view
+        removeAdScript();
+
+        // Inject the Adsterra popunder script directly into document.body here,
+        // inside the synchronous click handler. Popunder scripts must live at the
+        // body level (not inside a dialog subtree) and injecting them within a
+        // user-gesture call stack gives them the best chance of passing the
+        // browser's popup-blocker check.
+        const script = document.createElement('script');
+        script.type = 'text/javascript';
+        script.src = ADSTERRA_SCRIPT_URL;
+        script.async = true;
+        script.setAttribute('data-cfasync', 'false');
+        script.onload = () => startCountdown();
+        script.onerror = () => {
+            // Ad blocked or failed — still start countdown so user isn't stuck
+            startCountdown();
+        };
+        document.body.appendChild(script);
+        scriptRef.current = script;
     };
 
     const handleClose = () => {
         clearTimer();
+        removeAdScript();
         setIsOpen(false);
         setAdStarted(false);
         setCanClaim(false);
@@ -162,14 +170,13 @@ export function WatchAdButton({ adTurnsEarnedToday, onTurnEarned, className = ''
                     </DialogHeader>
 
                     <div className="space-y-4">
-                        {/* Ad container */}
-                        <div
-                            ref={adContainerRef}
-                            className="min-h-[100px] bg-gray-800 rounded flex items-center justify-center border border-gray-700"
-                        >
-                            {!adStarted && (
-                                <span className="text-gray-500 text-sm">Loading ad...</span>
-                            )}
+                        {/* Ad placeholder — the Adsterra popunder opens in a new tab/window */}
+                        <div className="min-h-[100px] bg-gray-800 rounded flex items-center justify-center border border-gray-700">
+                            <span className="text-gray-500 text-sm">
+                                {adStarted
+                                    ? 'Ad opened — please watch it in the new tab'
+                                    : 'Loading ad…'}
+                            </span>
                         </div>
 
                         {/* Countdown / status */}


### PR DESCRIPTION
## Summary
Refactored the Adsterra ad script injection mechanism to inject directly into `document.body` during the click handler instead of deferring injection into a dialog-scoped container. This change improves popup-blocker compatibility and simplifies the component logic.

## Key Changes
- **Removed dialog container ref**: Eliminated `adContainerRef` which was used to inject the ad script into the dialog DOM
- **Moved script injection to click handler**: The `handleOpen` function now directly injects the Adsterra script into `document.body` synchronously within the user gesture call stack, which gives popunder scripts the best chance of bypassing browser popup blockers
- **Simplified effect logic**: Removed the deferred initialization effect that waited for the dialog portal to mount; cleanup is now handled in a simpler unmount-only effect
- **Added `removeAdScript` utility**: New callback to cleanly remove leftover scripts from previous ad views
- **Enhanced logging**: Added comprehensive console logs throughout the ad flow for debugging (open, script load/error, claim, close)
- **Updated placeholder UI**: Changed the ad container from a ref-based element to a static div with dynamic messaging that indicates the ad opened in a new tab
- **Updated `.env.example`**: Added documentation for the `NEXT_PUBLIC_ADSTERRA_SCRIPT_URL` environment variable with guidance on dev/test mode

## Implementation Details
- The script is now injected at the `document.body` level rather than within the dialog subtree, which is required for popunder ads to function correctly
- Injection happens synchronously within the click event handler to maximize popup-blocker compatibility
- The component gracefully falls back to countdown-only mode when `ADSTERRA_SCRIPT_URL` is not configured, enabling development and testing without a real ad network
- Script cleanup is performed both on dialog close and component unmount to prevent memory leaks

https://claude.ai/code/session_01QNyiMmo4cAjYXNQe5B3gac