### PR TITLE
Remove Morgan-Greer and Golden Dawn tarot decks

### DIFF
--- a/backend/migrations/versions/20260422_000000_ab1c2d3e4f56_add_additional_tarot_decks.py
+++ b/backend/migrations/versions/20260422_000000_ab1c2d3e4f56_add_additional_tarot_decks.py
@@ -34,43 +34,16 @@ DECKS = [
             "and pip-based minor arcana. The foundation from which most modern decks evolved."
         ),
     },
-    {
-        "name": "Morgan-Greer Tarot",
-        "description": (
-            "A vibrant 1979 deck inspired by Rider-Waite, featuring bold close-up imagery "
-            "with rich, warm colors and expressive borderless figures. Emphasizes emotional "
-            "depth and intuitive reading with a modern artistic sensibility."
-        ),
-    },
-    {
-        "name": "Golden Dawn Tarot",
-        "description": (
-            "Rooted in the Hermetic Order of the Golden Dawn's esoteric teachings from the "
-            "late 19th century. Blends astrology, numerology, Kabbalah, and ceremonial magic "
-            "symbolism. The intellectual ancestor of both Rider-Waite and Thoth traditions."
-        ),
-    },
 ]
 
 
-def upgrade() -> None:
-    """Add 4 new tarot decks and fix the unique constraint on cards.name."""
-    connection = op.get_bind()
-    inspector = sa_inspect(connection)
+def _swap_unique_constraint_sqlite(connection) -> None:
+    """Rebuild the cards table on SQLite to drop the unnamed UNIQUE(name) constraint.
 
-    # Step 1: Replace the single-column unique constraint on cards.name
-    # with a composite unique constraint on (name, deck_id).
-    # This allows the same card name to exist in multiple decks.
-
-    # Drop the named unique index (added in migration efa035b1f5e8)
-    existing_indexes = {idx['name'] for idx in inspector.get_indexes('cards')}
-    if 'ix_cards_name' in existing_indexes:
-        op.drop_index('ix_cards_name', table_name='cards')
-
-    # SQLite cannot drop an unnamed UNIQUE constraint via ALTER TABLE.
-    # The cards table was created with sa.UniqueConstraint("name") (no name),
-    # so batch_alter_table(recreate='always') fails when SQLAlchemy reflects
-    # that constraint and cannot render it without a name. Rebuild manually.
+    SQLite cannot drop an unnamed UNIQUE constraint via ALTER TABLE, and
+    batch_alter_table(recreate='always') fails when SQLAlchemy reflects an
+    unnamed constraint and cannot render it. Manual rebuild is required.
+    """
     connection.execute(text("ALTER TABLE cards RENAME TO cards_old"))
     connection.execute(text("""
         CREATE TABLE cards (
@@ -101,70 +74,123 @@ def upgrade() -> None:
     """))
     connection.execute(text("DROP TABLE cards_old"))
 
-    # Recreate indexes that were on the old table, plus the new composite unique
     connection.execute(text("CREATE INDEX IF NOT EXISTS ix_cards_id ON cards (id)"))
     connection.execute(text("CREATE INDEX IF NOT EXISTS ix_cards_deck_id ON cards (deck_id)"))
     connection.execute(text(
         "CREATE UNIQUE INDEX IF NOT EXISTS ix_cards_name_deck_id ON cards (name, deck_id)"
     ))
 
-    # Step 2: Get the Rider-Waite deck id (created in migration 2d033e0e569b)
-    result = connection.execute(
+
+def _swap_unique_constraint_generic(connection, inspector) -> None:
+    """Drop any single-column UNIQUE on cards.name and add the composite UNIQUE(name, deck_id).
+
+    Used for dialects that support ALTER TABLE … DROP CONSTRAINT (e.g. PostgreSQL).
+    """
+    # Dropping a UNIQUE constraint also removes its backing index, so we must
+    # avoid re-dropping the same name when the inspector reports it twice.
+    dropped: set[str] = set()
+
+    # Drop any unique constraint whose only column is `name` (Postgres auto-names
+    # the one created by sa.UniqueConstraint("name") as `cards_name_key`).
+    for constraint in inspector.get_unique_constraints('cards'):
+        if constraint.get('column_names') == ['name'] and constraint['name'] not in dropped:
+            op.drop_constraint(constraint['name'], 'cards', type_='unique')
+            dropped.add(constraint['name'])
+
+    # Re-reflect: the previous drops may have invalidated cached index metadata.
+    inspector = sa_inspect(connection)
+    for index in inspector.get_indexes('cards'):
+        if (
+            index.get('column_names') == ['name']
+            and index.get('unique')
+            and index['name'] not in dropped
+        ):
+            op.drop_index(index['name'], table_name='cards')
+            dropped.add(index['name'])
+
+    op.create_unique_constraint('ix_cards_name_deck_id', 'cards', ['name', 'deck_id'])
+
+
+def upgrade() -> None:
+    """Add the new tarot decks and switch cards.name uniqueness to a composite key.
+
+    Idempotent so it can be retried on a database left in a partial state by a
+    previous failed run. Handles SQLite and PostgreSQL (and any other dialect
+    that supports ALTER TABLE … DROP CONSTRAINT).
+    """
+    connection = op.get_bind()
+    dialect = connection.dialect.name
+    inspector = sa_inspect(connection)
+
+    # Step 1: replace UNIQUE(name) with UNIQUE(name, deck_id).
+    # Skip if the composite constraint/index is already in place.
+    existing_index_names = {idx['name'] for idx in inspector.get_indexes('cards')}
+    existing_uniques = {c['name'] for c in inspector.get_unique_constraints('cards')}
+    if 'ix_cards_name_deck_id' not in existing_index_names and 'ix_cards_name_deck_id' not in existing_uniques:
+        if dialect == 'sqlite':
+            _swap_unique_constraint_sqlite(connection)
+        else:
+            _swap_unique_constraint_generic(connection, inspector)
+
+    # Step 2: locate the Rider-Waite deck. New decks are seeded with its cards.
+    rider_waite_id = connection.execute(
         text("SELECT id FROM decks WHERE name = 'Rider-Waite Tarot'")
-    )
-    row = result.fetchone()
-    if not row:
-        print("Warning: Rider-Waite Tarot deck not found – skipping card copy")
+    ).scalar()
+    if rider_waite_id is None:
+        print("Warning: Rider-Waite Tarot deck not found – skipping new deck creation")
         return
-    rider_waite_id = row[0]
 
-    # Step 3: Insert each new deck and copy Rider-Waite cards into it.
-    # image_url is copied from the Rider-Waite cards so every card shows a real
-    # working image immediately via the existing Cloudflare CDN.  The CDN images
-    # are the same artwork for now; replace image_url per-card once deck-specific
-    # artwork (Thoth, Marseille, etc.) is uploaded to the CDN.
+    # Step 3: insert decks that are missing and seed their cards from Rider-Waite.
     for deck_info in DECKS:
-        connection.execute(
-            text("INSERT INTO decks (name, description) VALUES (:name, :desc)"),
-            {"name": deck_info["name"], "desc": deck_info["description"]},
-        )
-
-        result = connection.execute(
+        deck_id = connection.execute(
             text("SELECT id FROM decks WHERE name = :name"),
             {"name": deck_info["name"]},
-        )
-        new_deck_id = result.fetchone()[0]
+        ).scalar()
+        if deck_id is None:
+            connection.execute(
+                text("INSERT INTO decks (name, description) VALUES (:name, :desc)"),
+                {"name": deck_info["name"], "desc": deck_info["description"]},
+            )
+            deck_id = connection.execute(
+                text("SELECT id FROM decks WHERE name = :name"),
+                {"name": deck_info["name"]},
+            ).scalar()
+            print(f"Created deck '{deck_info['name']}' (id={deck_id})")
 
-        connection.execute(
-            text("""
-                INSERT INTO cards
-                    (name, suit, rank, description_short, description_upright,
-                     description_reversed, element, astrology, numerology, deck_id,
-                     image_url)
-                SELECT
-                    name, suit, rank, description_short, description_upright,
-                    description_reversed, element, astrology, numerology, :new_deck_id,
-                    image_url
-                FROM cards
-                WHERE deck_id = :rider_waite_id
-            """),
-            {"new_deck_id": new_deck_id, "rider_waite_id": rider_waite_id},
-        )
-        print(f"Created deck '{deck_info['name']}' (id={new_deck_id}) with 78 cards")
+        existing_card_count = connection.execute(
+            text("SELECT COUNT(*) FROM cards WHERE deck_id = :deck_id"),
+            {"deck_id": deck_id},
+        ).scalar()
+        if existing_card_count == 0:
+            connection.execute(
+                text("""
+                    INSERT INTO cards
+                        (name, suit, rank, description_short, description_upright,
+                         description_reversed, element, astrology, numerology, deck_id,
+                         image_url)
+                    SELECT
+                        name, suit, rank, description_short, description_upright,
+                        description_reversed, element, astrology, numerology, :new_deck_id,
+                        image_url
+                    FROM cards
+                    WHERE deck_id = :rider_waite_id
+                """),
+                {"new_deck_id": deck_id, "rider_waite_id": rider_waite_id},
+            )
+            print(f"Copied Rider-Waite cards into deck '{deck_info['name']}' (id={deck_id})")
 
 
 def downgrade() -> None:
-    """Remove the 4 new decks and restore the single-column unique constraint."""
+    """Remove the added decks and restore the single-column unique on cards.name."""
     connection = op.get_bind()
+    dialect = connection.dialect.name
 
     for deck_info in DECKS:
-        result = connection.execute(
+        deck_id = connection.execute(
             text("SELECT id FROM decks WHERE name = :name"),
             {"name": deck_info["name"]},
-        )
-        row = result.fetchone()
-        if row:
-            deck_id = row[0]
+        ).scalar()
+        if deck_id is not None:
             connection.execute(
                 text("DELETE FROM cards WHERE deck_id = :deck_id"),
                 {"deck_id": deck_id},
@@ -174,10 +200,19 @@ def downgrade() -> None:
                 {"deck_id": deck_id},
             )
 
-    # Restore single-column unique index on name
     inspector = sa_inspect(connection)
-    existing_indexes = {idx['name'] for idx in inspector.get_indexes('cards')}
-    if 'ix_cards_name_deck_id' in existing_indexes:
-        op.drop_index('ix_cards_name_deck_id', table_name='cards')
+    existing_index_names = {idx['name'] for idx in inspector.get_indexes('cards')}
+    existing_uniques = {c['name'] for c in inspector.get_unique_constraints('cards')}
 
-    op.create_index(op.f('ix_cards_name'), 'cards', ['name'], unique=True)
+    if dialect == 'sqlite':
+        if 'ix_cards_name_deck_id' in existing_index_names:
+            op.drop_index('ix_cards_name_deck_id', table_name='cards')
+        connection.execute(text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS ix_cards_name ON cards (name)"
+        ))
+    else:
+        if 'ix_cards_name_deck_id' in existing_uniques:
+            op.drop_constraint('ix_cards_name_deck_id', 'cards', type_='unique')
+        elif 'ix_cards_name_deck_id' in existing_index_names:
+            op.drop_index('ix_cards_name_deck_id', table_name='cards')
+        op.create_index(op.f('ix_cards_name'), 'cards', ['name'], unique=True)

--- a/frontend/src/components/DeckSelector.tsx
+++ b/frontend/src/components/DeckSelector.tsx
@@ -25,16 +25,6 @@ const DECK_META: Record<string, { tradition: string; accent: string; symbol: str
         accent: 'border-red-500 bg-red-900/20',
         symbol: '⚜',
     },
-    'Morgan-Greer Tarot': {
-        tradition: 'Neo-Waite',
-        accent: 'border-emerald-500 bg-emerald-900/20',
-        symbol: '🌿',
-    },
-    'Golden Dawn Tarot': {
-        tradition: 'Hermetic Order',
-        accent: 'border-yellow-500 bg-yellow-900/20',
-        symbol: '🔯',
-    },
 };
 
 function getDeckMeta(name: string) {


### PR DESCRIPTION
## Summary
This PR removes two tarot decks (Morgan-Greer Tarot and Golden Dawn Tarot) from the migration and frontend configuration. The decks are no longer being seeded into the database, and their UI metadata has been removed.

## Key Changes
- **Backend Migration**: Removed Morgan-Greer Tarot and Golden Dawn Tarot from the `DECKS` list in the migration file
- **Migration Logic Refactored**: 
  - Extracted database-specific constraint-swapping logic into separate helper functions (`_swap_unique_constraint_sqlite` and `_swap_unique_constraint_generic`)
  - Made the upgrade process idempotent to handle retries on partially-failed runs
  - Improved robustness by checking if decks/cards already exist before inserting
  - Added dialect detection to handle SQLite and PostgreSQL differently
- **Frontend**: Removed deck metadata entries for Morgan-Greer Tarot and Golden Dawn Tarot from `DeckSelector.tsx`

## Notable Implementation Details
- The migration now gracefully handles being run multiple times without errors
- Database-specific logic is cleanly separated for maintainability
- The downgrade function also handles both SQLite and PostgreSQL dialects appropriately
- Existing card counts are checked before attempting to seed cards, preventing duplicate inserts

https://claude.ai/code/session_01CkoGHH8D74wNFY91ZrmyNK