### PR TITLE
Add Card of the Day endpoint with personalized deck support

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -40,6 +40,7 @@ from utils.rate_limiter import RATE_LIMITS, limiter
 router = APIRouter(prefix="/auth", tags=["authentication"])
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/token")
+optional_oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/token", auto_error=False)
 
 
 def create_access_token(data: dict):
@@ -147,6 +148,28 @@ async def get_current_user(
     response.headers["Access-Control-Expose-Headers"] = "X-Access-Token"
 
     return user
+
+
+async def get_optional_current_user(
+    token: str | None = Depends(optional_oauth2_scheme),
+    db: Session = Depends(get_db),
+) -> User | None:
+    """Return the authenticated user when a valid token is present, otherwise None.
+
+    Used by endpoints that personalize behavior for logged-in users but remain
+    accessible to anonymous visitors.
+    """
+    if not token:
+        return None
+    try:
+        payload = jwt.decode(token, settings.JWT_SECRET_KEY, algorithms=[settings.JWT_ALGORITHM])
+        username: str | None = payload.get("sub")
+        if username is None or payload.get("type") == "refresh":
+            return None
+    except JWTError:
+        return None
+
+    return db.query(User).filter(User.username == username).first()
 
 
 async def get_admin_user(current_user: User = Depends(get_current_user)) -> User:

--- a/backend/routers/tarot.py
+++ b/backend/routers/tarot.py
@@ -1,13 +1,21 @@
 import random
 import time
+from datetime import date
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlalchemy.orm import Session
 
 from database import get_db
 from models import Card, Spread, User
-from routers.auth import get_current_user
-from schemas import CardResponse, FeaturedCardResponse, ReadingRequest, SpreadListResponse, SpreadResponse
+from routers.auth import get_current_user, get_optional_current_user
+from schemas import (
+    CardOfTheDayResponse,
+    CardResponse,
+    FeaturedCardResponse,
+    ReadingRequest,
+    SpreadListResponse,
+    SpreadResponse,
+)
 from services.subscription_service import SubscriptionService
 from tarot_reader import TarotReader
 from utils.error_handlers import TarotAPIException, ValidationError, logger
@@ -17,10 +25,28 @@ from utils.rate_limiter import RATE_LIMITS, limiter
 router = APIRouter(prefix="/tarot", tags=["tarot"])
 
 
+DEFAULT_DECK_ID = 1
+
+
 @router.get("/featured-cards", response_model=list[FeaturedCardResponse])
-async def get_featured_cards(count: int = 3, db: Session = Depends(get_db)):
-    """Return a random selection of Major Arcana cards for the homepage."""
-    major_arcana = db.query(Card).filter(Card.suit == "Major Arcana").all()
+async def get_featured_cards(
+    count: int = 3,
+    db: Session = Depends(get_db),
+    current_user: User | None = Depends(get_optional_current_user),
+):
+    """Return a random selection of Major Arcana cards for the homepage.
+
+    When the request is authenticated, cards are drawn from the user's
+    favorite deck; otherwise the default deck is used.
+    """
+    deck_id = (current_user.favorite_deck_id if current_user else None) or DEFAULT_DECK_ID
+    major_arcana = (
+        db.query(Card)
+        .filter(Card.suit == "Major Arcana", Card.deck_id == deck_id)
+        .all()
+    )
+    if not major_arcana:
+        major_arcana = db.query(Card).filter(Card.suit == "Major Arcana").all()
     if not major_arcana:
         return []
     count = max(1, min(count, len(major_arcana)))
@@ -34,6 +60,57 @@ async def get_featured_cards(count: int = 3, db: Session = Depends(get_db)):
         )
         for card in selected
     ]
+
+
+@router.get("/card-of-the-day", response_model=CardOfTheDayResponse)
+async def get_card_of_the_day(
+    db: Session = Depends(get_db),
+    current_user: User | None = Depends(get_optional_current_user),
+):
+    """Return today's deterministic Major Arcana card from the user's favorite deck.
+
+    The same card is returned for every request made on the same calendar day
+    for a given deck. When the request is unauthenticated, the default deck is
+    used. Falls back to any Major Arcana card if the favorite deck has none.
+    """
+    deck_id = (current_user.favorite_deck_id if current_user else None) or DEFAULT_DECK_ID
+
+    major_arcana = (
+        db.query(Card)
+        .filter(Card.suit == "Major Arcana", Card.deck_id == deck_id)
+        .order_by(Card.numerology.asc().nullslast(), Card.id.asc())
+        .all()
+    )
+    if not major_arcana:
+        major_arcana = (
+            db.query(Card)
+            .filter(Card.suit == "Major Arcana")
+            .order_by(Card.id.asc())
+            .all()
+        )
+    if not major_arcana:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No Major Arcana cards available",
+        )
+
+    today = date.today()
+    day_of_year = today.timetuple().tm_yday
+    card = major_arcana[day_of_year % len(major_arcana)]
+
+    return CardOfTheDayResponse(
+        name=card.name,
+        suit=card.suit,
+        rank=card.rank,
+        image_url=card.image_url,
+        description_short=card.description_short,
+        description_upright=card.description_upright,
+        description_reversed=card.description_reversed,
+        element=card.element,
+        astrology=card.astrology,
+        numerology=card.numerology,
+        deck_id=card.deck_id,
+    )
 
 
 @router.post("/reading", response_model=list[CardResponse])

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -547,6 +547,27 @@ class FeaturedCardResponse(BaseModel):
     element: str | None = None
 
 
+class CardOfTheDayResponse(BaseModel):
+    """Response schema for the daily card shown on the homepage.
+
+    Includes the deck identifier so the client can confirm which deck the
+    card was sourced from (the user's favorite deck when authenticated,
+    or the default deck otherwise).
+    """
+
+    name: str
+    suit: str | None = None
+    rank: str | None = None
+    image_url: str | None = None
+    description_short: str | None = None
+    description_upright: str | None = None
+    description_reversed: str | None = None
+    element: str | None = None
+    astrology: str | None = None
+    numerology: int | None = None
+    deck_id: int | None = None
+
+
 # Spread Models
 class SpreadBase(BaseModel):
     """Base schema for a tarot spread.

--- a/backend/tests/test_tarot.py
+++ b/backend/tests/test_tarot.py
@@ -556,3 +556,52 @@ def test_tarot_reading_different_users_different_decks(client, auth_headers, aut
         assert "name" in card
         assert "orientation" in card
         assert "meaning" in card
+
+
+# Card of the Day Tests
+def test_card_of_the_day_anonymous(client, test_cards):
+    """Card of the day works without authentication and uses the default deck."""
+    response = client.get("/tarot/card-of-the-day")
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["name"]
+    assert data["deck_id"] == 1
+
+
+def test_card_of_the_day_uses_favorite_deck(client, auth_headers, test_cards, db_session, test_user):
+    """Authenticated requests return a card from the user's favorite deck."""
+    from models import Card, Deck
+
+    other_deck = Deck(name="Card of the Day Deck", description="alt deck")
+    db_session.add(other_deck)
+    db_session.commit()
+    db_session.refresh(other_deck)
+    other_deck_id = other_deck.id
+
+    db_session.add(
+        Card(
+            name="The Fool",
+            suit="Major Arcana",
+            rank="0",
+            description_upright="A new journey begins",
+            element="Air",
+            numerology=0,
+            deck_id=other_deck_id,
+        )
+    )
+    test_user.favorite_deck_id = other_deck_id
+    db_session.commit()
+
+    response = client.get("/tarot/card-of-the-day", headers=auth_headers)
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["deck_id"] == other_deck_id
+    assert data["name"] == "The Fool"
+
+
+def test_card_of_the_day_is_stable_within_day(client, test_cards):
+    """Repeat calls on the same day return the same card."""
+    first = client.get("/tarot/card-of-the-day").json()
+    second = client.get("/tarot/card-of-the-day").json()
+    assert first["name"] == second["name"]
+    assert first["deck_id"] == second["deck_id"]

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -13,111 +13,40 @@ import { MysticalSidebar } from '@/components/MysticalSidebar';
 import { TarotCard } from '@/components/TarotCard';
 import { tarot } from '@/lib/api';
 
-// Daily Card and Featured Cards Data
-const getDailyCard = () => {
-  const today = new Date();
-  const dayOfYear = Math.floor((today.getTime() - new Date(today.getFullYear(), 0, 0).getTime()) / 86400000);
+// Daily inspirational meaning text keyed by Major Arcana card name. The card
+// itself (artwork, element, descriptions) comes from the user's favorite deck
+// via the /tarot/card-of-the-day endpoint; this lookup just provides the
+// "today brings..." prose the UI displays alongside it.
+const DAILY_MEANINGS: Record<string, string> = {
+  "The Fool": "Today brings fresh opportunities and new adventures. Trust your instincts and embrace the unknown with an open heart.",
+  "The Magician": "You have all the tools you need to manifest your desires. Focus your energy and take inspired action today.",
+  "The High Priestess": "Listen to your inner wisdom today. The answers you seek lie within your intuitive knowing.",
+  "The Empress": "Embrace your creative and nurturing side. Abundance flows naturally when you align with love.",
+  "The Emperor": "Take charge of your situation with confidence and structure. Leadership comes naturally to you today.",
+  "The Hierophant": "Seek guidance from trusted mentors or spiritual practices. Traditional wisdom offers valuable insights.",
+  "The Lovers": "Important choices in love and relationships await. Follow your heart while honoring your values.",
+  "The Chariot": "Victory is within reach through focused determination. Stay in control and move forward with purpose.",
+  "Strength": "True strength comes from compassion and inner courage. Face challenges with a gentle but firm heart.",
+  "The Hermit": "Turn inward for the answers you seek. Solitude and reflection will illuminate your path forward.",
+  "Wheel of Fortune": "A fortunate turn of events is approaching. Trust in the natural cycles and embrace positive change.",
+  "Justice": "Seek balance and fairness in your decisions today. Truth and integrity will guide you to the right path.",
+  "The Hanged Man": "Pause and see things from a new perspective. Surrender brings clarity and unexpected insight.",
+  "Death": "Release what no longer serves you. Transformation opens the door to a powerful new beginning.",
+  "Temperance": "Find harmony through patience and moderation. Blending opposites brings peace today.",
+  "The Devil": "Examine what binds you. Awareness of limiting patterns is the first step toward freedom.",
+  "The Tower": "Sudden change clears the way for truth. Trust that what falls away makes room for something stronger.",
+  "The Star": "Hope and inspiration illuminate your path. Trust in the universe's plan and follow your dreams.",
+  "The Moon": "Trust your intuition through uncertainty. Hidden truths surface when you listen to your dreams.",
+  "The Sun": "Joy and clarity shine on you today. Celebrate the warmth of your own light.",
+  "Judgement": "A moment of awakening calls you forward. Answer the call and step into your higher purpose.",
+  "The World": "A cycle completes and a new horizon opens. Celebrate how far you have come.",
+};
 
-  const featuredCards = [
-    {
-      name: "The Fool",
-      image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m00.jpg",
-      description_upright: "New beginnings, innocence, spontaneity, a leap of faith",
-      meaning: "Today brings fresh opportunities and new adventures. Trust your instincts and embrace the unknown with an open heart.",
-      element: "Air",
-      keywords: ["freedom", "faith", "innocence", "new beginnings"]
-    },
-    {
-      name: "The Magician",
-      image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m01.jpg",
-      description_upright: "Manifestation, resourcefulness, power, inspired action",
-      meaning: "You have all the tools you need to manifest your desires. Focus your energy and take inspired action today.",
-      element: "Air",
-      keywords: ["power", "manifestation", "action", "skill"]
-    },
-    {
-      name: "The High Priestess",
-      image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m02.jpg",
-      description_upright: "Intuition, sacred knowledge, divine feminine, subconscious mind",
-      meaning: "Listen to your inner wisdom today. The answers you seek lie within your intuitive knowing.",
-      element: "Water",
-      keywords: ["intuition", "mystery", "knowledge", "feminine"]
-    },
-    {
-      name: "The Empress",
-      image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m03.jpg",
-      description_upright: "Femininity, beauty, nature, nurturing, abundance",
-      meaning: "Embrace your creative and nurturing side. Abundance flows naturally when you align with love.",
-      element: "Earth",
-      keywords: ["abundance", "creativity", "nurturing", "beauty"]
-    },
-    {
-      name: "The Emperor",
-      image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m04.jpg",
-      description_upright: "Authority, establishment, structure, father figure",
-      meaning: "Take charge of your situation with confidence and structure. Leadership comes naturally to you today.",
-      element: "Fire",
-      keywords: ["authority", "structure", "leadership", "stability"]
-    },
-    {
-      name: "The Hierophant",
-      image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m05.jpg",
-      description_upright: "Spiritual wisdom, religious beliefs, conformity, tradition",
-      meaning: "Seek guidance from trusted mentors or spiritual practices. Traditional wisdom offers valuable insights.",
-      element: "Earth",
-      keywords: ["tradition", "wisdom", "guidance", "spirituality"]
-    },
-    {
-      name: "The Lovers",
-      image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m06.jpg",
-      description_upright: "Love, harmony, relationships, values alignment",
-      meaning: "Important choices in love and relationships await. Follow your heart while honoring your values.",
-      element: "Air",
-      keywords: ["love", "choice", "harmony", "relationships"]
-    },
-    {
-      name: "The Chariot",
-      image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m07.jpg",
-      description_upright: "Control, willpower, success, determination",
-      meaning: "Victory is within reach through focused determination. Stay in control and move forward with purpose.",
-      element: "Water",
-      keywords: ["victory", "control", "determination", "success"]
-    },
-    {
-      name: "Strength",
-      image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m08.jpg",
-      description_upright: "Strength, courage, persuasion, influence, compassion",
-      meaning: "True strength comes from compassion and inner courage. Face challenges with a gentle but firm heart.",
-      element: "Fire",
-      keywords: ["courage", "strength", "compassion", "influence"]
-    },
-    {
-      name: "The Hermit",
-      image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m09.jpg",
-      description_upright: "Soul searching, introspection, inner guidance",
-      meaning: "Turn inward for the answers you seek. Solitude and reflection will illuminate your path forward.",
-      element: "Earth",
-      keywords: ["introspection", "guidance", "solitude", "wisdom"]
-    },
-    {
-      name: "Wheel of Fortune",
-      image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m10.jpg",
-      description_upright: "Good luck, karma, life cycles, destiny, a turning point",
-      meaning: "A fortunate turn of events is approaching. Trust in the natural cycles and embrace positive change.",
-      element: "Fire",
-      keywords: ["fortune", "cycles", "destiny", "change"]
-    },
-    {
-      name: "The Star",
-      image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m17.jpg",
-      description_upright: "Hope, faith, purpose, renewal, spirituality",
-      meaning: "Hope and inspiration illuminate your path. Trust in the universe's plan and follow your dreams.",
-      element: "Air",
-      keywords: ["hope", "inspiration", "faith", "renewal"]
-    }
-  ];
-
-  return featuredCards[dayOfYear % featuredCards.length];
+const FALLBACK_DAILY_CARD: DailyCard = {
+  name: "Strength",
+  image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m08.jpg",
+  description_upright: "Strength, courage, persuasion, influence, compassion",
+  element: "Fire",
 };
 
 const mysticalQuotes = [
@@ -163,6 +92,13 @@ type FeaturedCard = {
   element: string | null;
 };
 
+type DailyCard = {
+  name: string;
+  image_url: string | null;
+  description_upright: string | null;
+  element: string | null;
+};
+
 const FALLBACK_CARDS: FeaturedCard[] = [
   { name: "The Sun", image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m19.jpg", description_upright: "Joy, success, celebration, positivity", element: "Fire" },
   { name: "The Moon", image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m18.jpg", description_upright: "Intuition, dreams, subconscious, mystery", element: "Water" },
@@ -171,7 +107,7 @@ const FALLBACK_CARDS: FeaturedCard[] = [
 
 // Enhanced Welcome Component
 const EnhancedWelcome = ({ onStartReading }: { onStartReading: () => void }) => {
-  const [dailyCard] = useState(getDailyCard());
+  const [dailyCard, setDailyCard] = useState<DailyCard>(FALLBACK_DAILY_CARD);
   const [dailyQuote] = useState(getDailyQuote());
   const [dailyFact] = useState(getDailyFact());
   const [hoveredCard, setHoveredCard] = useState<number | null>(null);
@@ -193,6 +129,23 @@ const EnhancedWelcome = ({ onStartReading }: { onStartReading: () => void }) => 
       if (cards && cards.length > 0) setFeaturedCards(cards);
     });
   }, [loadFeaturedCards]);
+
+  useEffect(() => {
+    let cancelled = false;
+    tarot
+      .getCardOfTheDay()
+      .then((card: DailyCard) => {
+        if (!cancelled && card) setDailyCard(card);
+      })
+      .catch(() => {
+        // Keep the fallback card if the request fails.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const dailyMeaning = DAILY_MEANINGS[dailyCard.name] ?? dailyCard.description_upright ?? "";
 
   const shuffleCards = async () => {
     if (shuffling) return;
@@ -294,7 +247,7 @@ const EnhancedWelcome = ({ onStartReading }: { onStartReading: () => void }) => 
 
                 <h4 className="text-base md:text-lg font-bold text-white mb-2">{dailyCard.name}</h4>
                 <p className="text-purple-300 text-sm mb-2 md:mb-3">{dailyCard.description_upright}</p>
-                <p className="text-gray-400 text-xs md:text-sm leading-relaxed">{dailyCard.meaning}</p>
+                <p className="text-gray-400 text-xs md:text-sm leading-relaxed">{dailyMeaning}</p>
 
                 <div className="flex items-center justify-center gap-2 mt-3 md:mt-4 pt-3 md:pt-4 border-t border-purple-700/50">
                   <span className="text-xs text-purple-400">Element:</span>

--- a/frontend/src/components/MysticalSidebar.tsx
+++ b/frontend/src/components/MysticalSidebar.tsx
@@ -11,9 +11,11 @@ import {
     FiZap,
     FiHeart
 } from 'react-icons/fi';
+import Image from 'next/image';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { useAuth } from '@/contexts/AuthContext';
+import { tarot } from '@/lib/api';
 
 interface MysticalSidebarProps {
     className?: string;
@@ -22,8 +24,15 @@ interface MysticalSidebarProps {
 interface DailyCard {
     name: string;
     meaning: string;
-    image_url?: string;
+    image_url?: string | null;
+    description_upright?: string | null;
 }
+
+const DEFAULT_DAILY_CARD: DailyCard = {
+    name: "The Star",
+    meaning: "Hope, inspiration, and spiritual guidance illuminate your path today.",
+    image_url: null,
+};
 
 interface MoonPhase {
     phase: string;
@@ -46,11 +55,28 @@ export function MysticalSidebar({ className = '' }: MysticalSidebarProps) {
     const { user } = useAuth();
     const [dailyQuote, setDailyQuote] = useState('');
     const [moonPhase, setMoonPhase] = useState<MoonPhase>({ phase: 'New Moon', illumination: 0, emoji: '🌑' });
-    const [dailyCard] = useState<DailyCard>({
-        name: "The Star",
-        meaning: "Hope, inspiration, and spiritual guidance illuminate your path today.",
-        image_url: undefined
-    });
+    const [dailyCard, setDailyCard] = useState<DailyCard>(DEFAULT_DAILY_CARD);
+
+    useEffect(() => {
+        let cancelled = false;
+        tarot
+            .getCardOfTheDay()
+            .then((card) => {
+                if (cancelled || !card) return;
+                setDailyCard({
+                    name: card.name,
+                    meaning: card.description_upright || DEFAULT_DAILY_CARD.meaning,
+                    image_url: card.image_url ?? null,
+                    description_upright: card.description_upright ?? null,
+                });
+            })
+            .catch(() => {
+                // Keep the default card if the request fails.
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
 
     useEffect(() => {
         // Set daily quote based on date to ensure consistency
@@ -96,9 +122,18 @@ export function MysticalSidebar({ className = '' }: MysticalSidebarProps) {
                             </h3>
                         </div>
 
-                        {/* Card placeholder */}
-                        <div className="w-20 h-32 mx-auto mb-3 bg-gradient-to-b from-purple-600 to-purple-800 rounded-lg border border-yellow-400/30 flex items-center justify-center">
-                            <span className="text-2xl">✨</span>
+                        <div className="w-20 h-32 mx-auto mb-3 rounded-lg border border-yellow-400/30 overflow-hidden bg-gradient-to-b from-purple-600 to-purple-800 flex items-center justify-center">
+                            {dailyCard.image_url ? (
+                                <Image
+                                    src={dailyCard.image_url}
+                                    alt={dailyCard.name}
+                                    width={80}
+                                    height={128}
+                                    className="object-cover w-full h-full"
+                                />
+                            ) : (
+                                <span className="text-2xl">✨</span>
+                            )}
                         </div>
 
                         <h4 className="font-semibold text-purple-300 mb-2">{dailyCard.name}</h4>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -343,6 +343,11 @@ export const tarot = {
         const response = await api.get(`/tarot/featured-cards?count=${count}`);
         return response.data;
     },
+
+    getCardOfTheDay: async () => {
+        const response = await api.get(`/tarot/card-of-the-day`);
+        return response.data;
+    },
 };
 
 // Sharing endpoints


### PR DESCRIPTION
## Summary
This PR introduces a new "Card of the Day" feature that returns a deterministic Major Arcana card based on the calendar day. Authenticated users receive cards from their favorite deck, while anonymous users get cards from the default deck. The feature includes both backend API implementation and frontend integration.

## Key Changes

**Backend:**
- Added new `/tarot/card-of-the-day` endpoint that returns a stable card selection based on the current date
- Implemented `get_optional_current_user()` dependency in auth router to support endpoints that work for both authenticated and anonymous users
- Added `CardOfTheDayResponse` schema with comprehensive card details including deck identifier
- Updated `/featured-cards` endpoint to respect user's favorite deck when authenticated
- Added fallback logic to use default deck or any available Major Arcana cards if preferred deck has none
- Introduced `DEFAULT_DECK_ID` constant for consistent default deck handling

**Frontend:**
- Integrated Card of the Day API calls in both `MysticalSidebar` and homepage `EnhancedWelcome` components
- Implemented graceful fallback to hardcoded daily card if API request fails
- Added proper cleanup with cancellation tokens to prevent state updates on unmounted components
- Updated API client with `getCardOfTheDay()` method

## Implementation Details

- The card selection uses `date.today().timetuple().tm_yday` (day of year) to ensure the same card is returned for all requests on the same calendar day
- Cards are ordered by numerology (with nulls last) then by ID to provide consistent ordering within a deck
- The endpoint respects user preferences (favorite deck) while remaining accessible to anonymous visitors
- Frontend components maintain a fallback card state that persists if the API is unavailable

https://claude.ai/code/session_01W19GW6EozLjcG3snF5UJjx