### PR TITLE
Remove header search icon button

### DIFF
--- a/frontend/src/components/EnhancedNavigation.tsx
+++ b/frontend/src/components/EnhancedNavigation.tsx
@@ -183,15 +183,6 @@ export function EnhancedNavigation() {
 
                     {/* Actions - Mobile-first layout */}
                     <div className="flex items-center space-x-2 md:space-x-3">
-                        {/* Mobile Search Button */}
-                        <button
-                            onClick={() => setIsMobileSearchOpen(!isMobileSearchOpen)}
-                            className="lg:hidden p-3 rounded-xl hover:bg-gray-800 transition-colors touch-manipulation"
-                            aria-label="Search"
-                        >
-                            <Search className="w-6 h-6 text-gray-300" />
-                        </button>
-
                         {/* Turn Counter - Desktop/Tablet */}
                         <div className="hidden md:block">
                             <TurnCounter


### PR DESCRIPTION
### Motivation
- Remove the extra standalone search icon in the header actions so the UI shows only the primary search input without a duplicate magnifier button.

### Description
- Deleted the mobile search button JSX from `EnhancedNavigation` in `frontend/src/components/EnhancedNavigation.tsx` (removes the `<button>` containing the `Search` icon).

### Testing
- No automated tests were run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0da9e72fb8832891ac4da986d10401)