### PR TITLE
Add Arcana Library with card browsing and detailed card views

### DIFF
--- a/backend/routers/tarot.py
+++ b/backend/routers/tarot.py
@@ -2,7 +2,8 @@ import random
 import time
 from datetime import date
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from database import get_db
@@ -12,6 +13,7 @@ from schemas import (
     CardOfTheDayResponse,
     CardResponse,
     FeaturedCardResponse,
+    LibraryCardResponse,
     ReadingRequest,
     SpreadListResponse,
     SpreadResponse,
@@ -336,3 +338,38 @@ async def get_spread(spread_id: int, db: Session = Depends(get_db)):
         positions=spread.get_positions(),
         created_at=spread.created_at,
     )
+
+
+@router.get("/library", response_model=list[LibraryCardResponse])
+async def get_library_cards(
+    suit: str | None = Query(None, description="Filter by suit (e.g. 'Major Arcana', 'Cups')"),
+    search: str | None = Query(None, description="Search by card name or rank"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Return all cards for the Arcana Library, optionally filtered by suit or search term."""
+    deck_id = current_user.favorite_deck_id or DEFAULT_DECK_ID
+
+    query = db.query(Card).filter(Card.deck_id == deck_id)
+
+    if suit:
+        query = query.filter(Card.suit.ilike(f"%{suit}%"))
+    if search:
+        query = query.filter(
+            or_(Card.name.ilike(f"%{search}%"), Card.rank.ilike(f"%{search}%"))
+        )
+
+    cards = query.order_by(Card.suit, Card.numerology.asc().nullslast(), Card.id).all()
+
+    # Fallback: if favorite deck has no cards, use any deck
+    if not cards:
+        query = db.query(Card)
+        if suit:
+            query = query.filter(Card.suit.ilike(f"%{suit}%"))
+        if search:
+            query = query.filter(
+                or_(Card.name.ilike(f"%{search}%"), Card.rank.ilike(f"%{search}%"))
+            )
+        cards = query.order_by(Card.suit, Card.numerology.asc().nullslast(), Card.id).all()
+
+    return cards

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -568,6 +568,25 @@ class CardOfTheDayResponse(BaseModel):
     deck_id: int | None = None
 
 
+class LibraryCardResponse(BaseModel):
+    """Response schema for a card in the Arcana Library."""
+
+    id: int
+    name: str
+    suit: str | None = None
+    rank: str | None = None
+    image_url: str | None = None
+    description_short: str | None = None
+    description_upright: str | None = None
+    description_reversed: str | None = None
+    element: str | None = None
+    astrology: str | None = None
+    numerology: int | None = None
+
+    class Config:
+        from_attributes = True
+
+
 # Spread Models
 class SpreadBase(BaseModel):
     """Base schema for a tarot spread.

--- a/frontend/src/app/library/page.tsx
+++ b/frontend/src/app/library/page.tsx
@@ -52,6 +52,7 @@ function CardDetailPanel({ card, onClose }: { card: LibraryCard; onClose: () => 
                             name={card.name}
                             suit={card.suit}
                             numerology={card.numerology}
+                            imageUrl={card.image_url}
                             width={100}
                             height={158}
                         />
@@ -279,6 +280,7 @@ export default function LibraryPage() {
                                     name={card.name}
                                     suit={card.suit}
                                     numerology={card.numerology}
+                                    imageUrl={card.image_url}
                                     width={140}
                                     height={220}
                                     onClick={() => setSelectedCard(card)}

--- a/frontend/src/app/library/page.tsx
+++ b/frontend/src/app/library/page.tsx
@@ -1,0 +1,306 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/contexts/AuthContext';
+import { tarot } from '@/lib/api';
+import { EnhancedNavigation } from '@/components/EnhancedNavigation';
+import { ArcanaCard } from '@/components/ArcanaCard';
+import { Search, X } from 'lucide-react';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+interface LibraryCard {
+    id: number;
+    name: string;
+    suit: string | null;
+    rank: string | null;
+    image_url: string | null;
+    description_short: string | null;
+    description_upright: string | null;
+    description_reversed: string | null;
+    element: string | null;
+    astrology: string | null;
+    numerology: number | null;
+}
+
+// ─── Filter config ───────────────────────────────────────────────────────────
+
+const SUIT_FILTERS = [
+    { label: 'All Cards', value: '', count: 78 },
+    { label: 'Major Arcana', value: 'Major Arcana', count: 22 },
+    { label: 'Cups', value: 'Cups', count: 14 },
+    { label: 'Pentacles', value: 'Pentacles', count: 14 },
+    { label: 'Swords', value: 'Swords', count: 14 },
+    { label: 'Wands', value: 'Wands', count: 14 },
+];
+
+// ─── Card Detail Panel ───────────────────────────────────────────────────────
+
+function CardDetailPanel({ card, onClose }: { card: LibraryCard; onClose: () => void }) {
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4" onClick={onClose}>
+            <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" />
+            <div
+                className="relative z-10 bg-gray-900 border border-purple-700/50 rounded-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto shadow-2xl"
+                onClick={e => e.stopPropagation()}
+            >
+                {/* Header */}
+                <div className="flex items-start justify-between p-6 border-b border-gray-800">
+                    <div className="flex items-center gap-6">
+                        <ArcanaCard
+                            name={card.name}
+                            suit={card.suit}
+                            numerology={card.numerology}
+                            width={100}
+                            height={158}
+                        />
+                        <div>
+                            {card.suit && (
+                                <p className="text-xs font-mono text-amber-500 uppercase tracking-widest mb-1">
+                                    {card.suit}
+                                    {card.numerology !== null && card.numerology !== undefined
+                                        ? ` · ${card.numerology}`
+                                        : ''}
+                                </p>
+                            )}
+                            <h2 className="text-2xl font-mystical text-white mb-2">{card.name}</h2>
+                            {card.description_short && (
+                                <p className="text-gray-400 italic text-sm leading-relaxed max-w-xs">
+                                    {card.description_short}
+                                </p>
+                            )}
+                            <div className="flex flex-wrap gap-2 mt-3">
+                                {card.element && (
+                                    <span className="px-2 py-0.5 rounded text-xs bg-purple-900/50 text-purple-300 border border-purple-700/40">
+                                        {card.element}
+                                    </span>
+                                )}
+                                {card.astrology && (
+                                    <span className="px-2 py-0.5 rounded text-xs bg-amber-900/30 text-amber-400 border border-amber-700/30">
+                                        {card.astrology}
+                                    </span>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+                    <button
+                        onClick={onClose}
+                        className="p-2 text-gray-500 hover:text-white hover:bg-gray-800 rounded-lg transition-colors"
+                    >
+                        <X size={20} />
+                    </button>
+                </div>
+
+                {/* Meanings */}
+                <div className="p-6 grid grid-cols-1 sm:grid-cols-2 gap-6">
+                    {card.description_upright && (
+                        <div>
+                            <h3 className="text-xs font-mono uppercase tracking-widest text-amber-500 mb-2">
+                                ↑ Upright
+                            </h3>
+                            <p className="text-gray-300 text-sm leading-relaxed font-serif-alt italic">
+                                {card.description_upright}
+                            </p>
+                        </div>
+                    )}
+                    {card.description_reversed && (
+                        <div>
+                            <h3 className="text-xs font-mono uppercase tracking-widest text-purple-400 mb-2">
+                                ↓ Reversed
+                            </h3>
+                            <p className="text-gray-400 text-sm leading-relaxed font-serif-alt italic">
+                                {card.description_reversed}
+                            </p>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+// ─── Main Page ───────────────────────────────────────────────────────────────
+
+export default function LibraryPage() {
+    const { isAuthenticated, isAuthLoading } = useAuth();
+    const router = useRouter();
+
+    const [cards, setCards] = useState<LibraryCard[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [activeSuit, setActiveSuit] = useState('');
+    const [searchQuery, setSearchQuery] = useState('');
+    const [debouncedSearch, setDebouncedSearch] = useState('');
+    const [selectedCard, setSelectedCard] = useState<LibraryCard | null>(null);
+    const [counts, setCounts] = useState<Record<string, number>>({});
+
+    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // Auth guard
+    useEffect(() => {
+        if (!isAuthLoading && !isAuthenticated) {
+            router.push('/login');
+        }
+    }, [isAuthenticated, isAuthLoading, router]);
+
+    // Debounce search
+    useEffect(() => {
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(() => setDebouncedSearch(searchQuery), 300);
+        return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
+    }, [searchQuery]);
+
+    // Fetch cards
+    const fetchCards = useCallback(async () => {
+        if (!isAuthenticated) return;
+        setLoading(true);
+        try {
+            const data = await tarot.getLibraryCards(
+                activeSuit || undefined,
+                debouncedSearch || undefined,
+            );
+            setCards(data);
+        } catch (err) {
+            console.error('Failed to load library cards', err);
+        } finally {
+            setLoading(false);
+        }
+    }, [isAuthenticated, activeSuit, debouncedSearch]);
+
+    useEffect(() => { fetchCards(); }, [fetchCards]);
+
+    // Fetch counts for filter tabs (once on mount)
+    useEffect(() => {
+        if (!isAuthenticated) return;
+        const fetchCounts = async () => {
+            try {
+                const all = await tarot.getLibraryCards();
+                const c: Record<string, number> = { '': all.length };
+                for (const f of SUIT_FILTERS.slice(1)) {
+                    c[f.value] = all.filter((card: LibraryCard) => card.suit === f.value).length;
+                }
+                setCounts(c);
+            } catch { /* ignore */ }
+        };
+        fetchCounts();
+    }, [isAuthenticated]);
+
+    if (isAuthLoading) {
+        return (
+            <div className="min-h-screen flex items-center justify-center">
+                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-500" />
+            </div>
+        );
+    }
+
+    return (
+        <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-900 to-purple-950">
+            <EnhancedNavigation />
+
+            <div className="max-w-7xl mx-auto px-4 md:px-8 py-8">
+
+                {/* ── Page Header ── */}
+                <div className="mb-8">
+                    <p className="font-mono text-xs text-amber-500 uppercase tracking-[0.36em] mb-2">
+                        The Library · {counts[''] ?? 78} Cards
+                    </p>
+                    <h1 className="font-mystical font-normal leading-none tracking-tight text-5xl md:text-6xl text-white mb-4">
+                        The{' '}
+                        <em className="text-amber-500 not-italic">Arcana</em>
+                    </h1>
+                    <p className="font-serif-alt italic text-gray-400 text-lg max-w-lg">
+                        Every card in the deck — their history, their voices, and what they have to say.
+                    </p>
+                </div>
+
+                {/* ── Divider ── */}
+                <div className="flex items-center gap-3 mb-6 opacity-50">
+                    <div className="flex-1 h-px bg-gradient-to-r from-transparent via-amber-600 to-amber-600" />
+                    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="#f59e0b" strokeWidth="0.8">
+                        <path d="M5 1 L9 5 L5 9 L1 5 Z" />
+                    </svg>
+                    <div className="flex-1 h-px bg-gradient-to-l from-transparent via-amber-600 to-amber-600" />
+                </div>
+
+                {/* ── Filters + Search ── */}
+                <div className="flex flex-wrap items-center gap-2 mb-8 pb-6 border-b border-gray-800">
+                    {SUIT_FILTERS.map(f => {
+                        const active = activeSuit === f.value;
+                        const count = counts[f.value];
+                        return (
+                            <button
+                                key={f.value}
+                                onClick={() => setActiveSuit(f.value)}
+                                className={`px-3 py-1.5 border text-xs font-mono uppercase tracking-wider transition-colors rounded-sm ${
+                                    active
+                                        ? 'border-amber-500 bg-amber-500/10 text-amber-400'
+                                        : 'border-gray-700 text-gray-500 hover:border-gray-600 hover:text-gray-300'
+                                }`}
+                            >
+                                {f.label}{count !== undefined ? ` · ${count}` : ''}
+                            </button>
+                        );
+                    })}
+
+                    {/* Search */}
+                    <div className="ml-auto flex items-center gap-2 border border-gray-700 bg-gray-800/50 rounded-sm px-3 py-1.5 min-w-[200px]">
+                        <Search size={12} className="text-gray-500 flex-shrink-0" />
+                        <input
+                            type="text"
+                            placeholder="Search the arcana…"
+                            value={searchQuery}
+                            onChange={e => setSearchQuery(e.target.value)}
+                            className="bg-transparent text-sm text-gray-300 placeholder-gray-600 outline-none w-full min-h-0"
+                            style={{ minHeight: 0 }}
+                        />
+                        {searchQuery && (
+                            <button onClick={() => setSearchQuery('')} className="text-gray-500 hover:text-gray-300">
+                                <X size={12} />
+                            </button>
+                        )}
+                    </div>
+                </div>
+
+                {/* ── Card Grid ── */}
+                {loading ? (
+                    <div className="flex items-center justify-center py-24">
+                        <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-purple-500" />
+                    </div>
+                ) : cards.length === 0 ? (
+                    <div className="text-center py-24 text-gray-500">
+                        <p className="font-serif-alt italic text-xl mb-2">No cards found</p>
+                        <p className="text-sm">Try a different filter or search term.</p>
+                    </div>
+                ) : (
+                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-6 justify-items-center">
+                        {cards.map(card => (
+                            <div key={card.id} className="flex flex-col items-center gap-2">
+                                <ArcanaCard
+                                    name={card.name}
+                                    suit={card.suit}
+                                    numerology={card.numerology}
+                                    width={140}
+                                    height={220}
+                                    onClick={() => setSelectedCard(card)}
+                                />
+                                {card.suit && card.suit !== 'Major Arcana' && (
+                                    <p className="font-mono text-[9px] text-gray-600 uppercase tracking-widest text-center">
+                                        {card.suit}
+                                    </p>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+
+            {/* ── Card Detail Modal ── */}
+            {selectedCard && (
+                <CardDetailPanel
+                    card={selectedCard}
+                    onClose={() => setSelectedCard(null)}
+                />
+            )}
+        </div>
+    );
+}

--- a/frontend/src/app/library/page.tsx
+++ b/frontend/src/app/library/page.tsx
@@ -3,10 +3,10 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
-import { tarot } from '@/lib/api';
+import { tarot, auth } from '@/lib/api';
 import { EnhancedNavigation } from '@/components/EnhancedNavigation';
 import { ArcanaCard } from '@/components/ArcanaCard';
-import { Search, X } from 'lucide-react';
+import { Search, X, ChevronDown, Check, Layers } from 'lucide-react';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -24,16 +24,109 @@ interface LibraryCard {
     numerology: number | null;
 }
 
+interface Deck {
+    id: number;
+    name: string;
+    description: string | null;
+}
+
 // ─── Filter config ───────────────────────────────────────────────────────────
 
 const SUIT_FILTERS = [
-    { label: 'All Cards', value: '', count: 78 },
-    { label: 'Major Arcana', value: 'Major Arcana', count: 22 },
-    { label: 'Cups', value: 'Cups', count: 14 },
-    { label: 'Pentacles', value: 'Pentacles', count: 14 },
-    { label: 'Swords', value: 'Swords', count: 14 },
-    { label: 'Wands', value: 'Wands', count: 14 },
+    { label: 'All Cards', value: '' },
+    { label: 'Major Arcana', value: 'Major Arcana' },
+    { label: 'Cups', value: 'Cups' },
+    { label: 'Pentacles', value: 'Pentacles' },
+    { label: 'Swords', value: 'Swords' },
+    { label: 'Wands', value: 'Wands' },
 ];
+
+// ─── Deck Picker ─────────────────────────────────────────────────────────────
+
+function DeckPicker({
+    decks,
+    currentDeckId,
+    saving,
+    onChange,
+}: {
+    decks: Deck[];
+    currentDeckId: number | null;
+    saving: boolean;
+    onChange: (id: number) => void;
+}) {
+    const [open, setOpen] = useState(false);
+    const ref = useRef<HTMLDivElement>(null);
+
+    const currentDeck = decks.find(d => d.id === currentDeckId);
+
+    // Close on outside click
+    useEffect(() => {
+        const handler = (e: MouseEvent) => {
+            if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+        };
+        if (open) document.addEventListener('mousedown', handler);
+        return () => document.removeEventListener('mousedown', handler);
+    }, [open]);
+
+    if (decks.length === 0) return null;
+
+    return (
+        <div ref={ref} className="relative">
+            <button
+                onClick={() => setOpen(o => !o)}
+                disabled={saving}
+                className="flex items-center gap-2 px-3 py-1.5 border border-purple-700/60 bg-purple-900/20 hover:bg-purple-900/40 rounded-sm transition-colors text-purple-300 hover:text-purple-200 disabled:opacity-50"
+            >
+                <Layers size={12} className="flex-shrink-0" />
+                <span className="font-mono text-xs uppercase tracking-wider truncate max-w-[160px]">
+                    {saving ? 'Saving…' : (currentDeck?.name ?? 'Select deck')}
+                </span>
+                <ChevronDown
+                    size={12}
+                    className={`flex-shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
+                />
+            </button>
+
+            {open && (
+                <div className="absolute right-0 top-full mt-1 z-40 w-64 bg-gray-900 border border-purple-700/50 rounded-lg shadow-2xl overflow-hidden">
+                    <div className="px-3 py-2 border-b border-gray-800">
+                        <p className="font-mono text-[10px] text-gray-500 uppercase tracking-widest">
+                            Choose your deck
+                        </p>
+                    </div>
+                    <div className="max-h-64 overflow-y-auto">
+                        {decks.map(deck => {
+                            const active = deck.id === currentDeckId;
+                            return (
+                                <button
+                                    key={deck.id}
+                                    onClick={() => { onChange(deck.id); setOpen(false); }}
+                                    className={`w-full flex items-start gap-3 px-4 py-3 text-left transition-colors border-b border-gray-800/50 last:border-0 ${
+                                        active
+                                            ? 'bg-purple-900/30 text-purple-200'
+                                            : 'text-gray-300 hover:bg-gray-800/60 hover:text-white'
+                                    }`}
+                                >
+                                    <span className="mt-0.5 flex-shrink-0 w-4">
+                                        {active && <Check size={13} className="text-amber-500" />}
+                                    </span>
+                                    <span>
+                                        <span className="block text-sm font-medium leading-snug">{deck.name}</span>
+                                        {deck.description && (
+                                            <span className="block text-xs text-gray-500 mt-0.5 leading-snug line-clamp-2">
+                                                {deck.description}
+                                            </span>
+                                        )}
+                                    </span>
+                                </button>
+                            );
+                        })}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}
 
 // ─── Card Detail Panel ───────────────────────────────────────────────────────
 
@@ -135,6 +228,11 @@ export default function LibraryPage() {
     const [selectedCard, setSelectedCard] = useState<LibraryCard | null>(null);
     const [counts, setCounts] = useState<Record<string, number>>({});
 
+    // Deck state
+    const [decks, setDecks] = useState<Deck[]>([]);
+    const [currentDeckId, setCurrentDeckId] = useState<number | null>(null);
+    const [savingDeck, setSavingDeck] = useState(false);
+
     const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     // Auth guard
@@ -170,21 +268,52 @@ export default function LibraryPage() {
 
     useEffect(() => { fetchCards(); }, [fetchCards]);
 
-    // Fetch counts for filter tabs (once on mount)
+    // Fetch counts for filter tabs
+    const fetchCounts = useCallback(async () => {
+        if (!isAuthenticated) return;
+        try {
+            const all = await tarot.getLibraryCards();
+            const c: Record<string, number> = { '': all.length };
+            for (const f of SUIT_FILTERS.slice(1)) {
+                c[f.value] = all.filter((card: LibraryCard) => card.suit === f.value).length;
+            }
+            setCounts(c);
+        } catch { /* ignore */ }
+    }, [isAuthenticated]);
+
+    useEffect(() => { fetchCounts(); }, [fetchCounts]);
+
+    // Fetch available decks + user's current favorite deck
     useEffect(() => {
         if (!isAuthenticated) return;
-        const fetchCounts = async () => {
+        const fetchMeta = async () => {
             try {
-                const all = await tarot.getLibraryCards();
-                const c: Record<string, number> = { '': all.length };
-                for (const f of SUIT_FILTERS.slice(1)) {
-                    c[f.value] = all.filter((card: LibraryCard) => card.suit === f.value).length;
-                }
-                setCounts(c);
+                const [deckList, profile] = await Promise.all([
+                    auth.getDecks(),
+                    auth.getProfile(),
+                ]);
+                setDecks(deckList);
+                setCurrentDeckId(profile.favorite_deck_id ?? null);
             } catch { /* ignore */ }
         };
-        fetchCounts();
+        fetchMeta();
     }, [isAuthenticated]);
+
+    // Handle deck change
+    const handleDeckChange = useCallback(async (deckId: number) => {
+        if (deckId === currentDeckId || savingDeck) return;
+        setSavingDeck(true);
+        try {
+            await auth.updateProfile({ favorite_deck_id: deckId });
+            setCurrentDeckId(deckId);
+            // Re-fetch cards and counts with the new deck
+            await Promise.all([fetchCards(), fetchCounts()]);
+        } catch {
+            /* api interceptor already shows a toast */
+        } finally {
+            setSavingDeck(false);
+        }
+    }, [currentDeckId, savingDeck, fetchCards, fetchCounts]);
 
     if (isAuthLoading) {
         return (
@@ -201,17 +330,29 @@ export default function LibraryPage() {
             <div className="max-w-7xl mx-auto px-4 md:px-8 py-8">
 
                 {/* ── Page Header ── */}
-                <div className="mb-8">
-                    <p className="font-mono text-xs text-amber-500 uppercase tracking-[0.36em] mb-2">
-                        The Library · {counts[''] ?? 78} Cards
-                    </p>
-                    <h1 className="font-mystical font-normal leading-none tracking-tight text-5xl md:text-6xl text-white mb-4">
-                        The{' '}
-                        <em className="text-amber-500 not-italic">Arcana</em>
-                    </h1>
-                    <p className="font-serif-alt italic text-gray-400 text-lg max-w-lg">
-                        Every card in the deck — their history, their voices, and what they have to say.
-                    </p>
+                <div className="flex items-start justify-between gap-4 mb-8">
+                    <div>
+                        <p className="font-mono text-xs text-amber-500 uppercase tracking-[0.36em] mb-2">
+                            The Library · {counts[''] ?? 78} Cards
+                        </p>
+                        <h1 className="font-mystical font-normal leading-none tracking-tight text-5xl md:text-6xl text-white mb-4">
+                            The{' '}
+                            <em className="text-amber-500 not-italic">Arcana</em>
+                        </h1>
+                        <p className="font-serif-alt italic text-gray-400 text-lg max-w-lg">
+                            Every card in the deck — their history, their voices, and what they have to say.
+                        </p>
+                    </div>
+
+                    {/* ── Deck Picker ── */}
+                    <div className="flex-shrink-0 pt-1">
+                        <DeckPicker
+                            decks={decks}
+                            currentDeckId={currentDeckId}
+                            saving={savingDeck}
+                            onChange={handleDeckChange}
+                        />
+                    </div>
                 </div>
 
                 {/* ── Divider ── */}

--- a/frontend/src/app/library/page.tsx
+++ b/frontend/src/app/library/page.tsx
@@ -285,11 +285,9 @@ export default function LibraryPage() {
                                     height={220}
                                     onClick={() => setSelectedCard(card)}
                                 />
-                                {card.suit && card.suit !== 'Major Arcana' && (
-                                    <p className="font-mono text-[9px] text-gray-600 uppercase tracking-widest text-center">
-                                        {card.suit}
-                                    </p>
-                                )}
+                                <p className="font-mono text-[9px] text-gray-500 uppercase tracking-widest text-center leading-tight max-w-[140px]">
+                                    {card.name}
+                                </p>
                             </div>
                         ))}
                     </div>

--- a/frontend/src/components/ArcanaCard.tsx
+++ b/frontend/src/components/ArcanaCard.tsx
@@ -1,0 +1,398 @@
+'use client';
+
+import React from 'react';
+
+// ─── SVG Glyphs for all 22 Major Arcana ────────────────────────────────────
+// Hand-stylized line art; no third-party deck artwork reproduced.
+
+const MajorArcanaGlyph: Record<string, React.FC<{ size?: number }>> = {
+    'The Fool': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="50" cy="30" r="9" />
+            <path d="M44 22 L40 16 L46 18 M56 22 L60 16 L54 18" />
+            <path d="M50 39 L50 80 M50 50 L34 64 M50 50 L66 64" />
+            <path d="M50 80 L42 110 M50 80 L58 110" />
+            <path d="M70 50 L84 56 L82 60 L72 56" />
+            <circle cx="84" cy="56" r="3" />
+            <path d="M20 122 Q35 116 50 122 Q65 128 80 122" />
+        </svg>
+    ),
+    'The Magician': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="50" cy="32" r="10" />
+            <path d="M50 18 V 12 M48 14 L52 10" />
+            <path d="M34 42 Q50 40 66 42 L70 110 L30 110 Z" />
+            <path d="M50 50 V 80 M40 60 H 60" />
+            <path d="M22 60 Q26 56 30 60 M70 60 Q74 56 78 60" />
+            <path d="M50 14 Q44 8 50 4 Q56 8 50 14" />
+            <path d="M30 122 Q50 118 70 122" />
+        </svg>
+    ),
+    'The High Priestess': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="50" cy="28" r="12" />
+            <path d="M38 28 H 62 M50 16 V 8" />
+            <path d="M36 40 L36 115 M64 40 L64 115" />
+            <path d="M36 40 Q50 36 64 40" />
+            <path d="M36 115 Q50 120 64 115" />
+            <path d="M42 60 H 58 M42 75 H 58 M42 90 H 58" />
+            <path d="M44 28 A6 6 0 0 1 56 28" />
+        </svg>
+    ),
+    'The Empress': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="50" cy="38" r="14" />
+            <path d="M36 32 L50 22 L64 32" />
+            <path d="M40 30 L50 20 L60 30 M50 16 L50 22" />
+            <circle cx="50" cy="14" r="1.6" fill="currentColor" />
+            <path d="M30 52 Q50 50 70 52 L72 110 Q50 116 28 110 Z" />
+            <path d="M40 60 Q50 64 60 60 M38 75 Q50 80 62 75 M36 92 Q50 98 64 92" />
+            <path d="M22 110 Q50 132 78 110" />
+            <path d="M50 56 V 64 M44 60 H 56" />
+            <path d="M14 70 Q20 80 14 92 M86 70 Q80 80 86 92" />
+        </svg>
+    ),
+    'The Emperor': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="50" cy="28" r="10" />
+            <path d="M40 24 L50 14 L60 24" />
+            <path d="M36 38 H 64 L62 95 H 38 Z" />
+            <path d="M38 55 H 62 M38 72 H 62" />
+            <path d="M50 95 L50 115" />
+            <path d="M38 115 H 62" />
+            <path d="M26 55 L38 60 M74 55 L62 60" />
+            <path d="M26 75 L38 80 M74 75 L62 80" />
+        </svg>
+    ),
+    'The Hierophant': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="50" cy="28" r="10" />
+            <path d="M42 24 L42 16 M58 24 L58 16" />
+            <path d="M38 16 H 62" />
+            <path d="M50 38 L50 115" />
+            <path d="M36 55 H 64 M36 70 H 64" />
+            <path d="M30 90 Q50 88 70 90 L70 115 L30 115 Z" />
+            <path d="M40 102 H 60" />
+        </svg>
+    ),
+    'The Lovers': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="35" cy="50" r="10" />
+            <circle cx="65" cy="50" r="10" />
+            <path d="M26 60 L26 105 M44 60 L44 105 M56 60 L56 105 M74 60 L74 105" />
+            <path d="M50 25 L54 15 L50 8 L46 15 Z" fill="currentColor" opacity="0.6" />
+            <path d="M50 28 L35 60 M50 28 L65 60" />
+            <path d="M26 105 Q35 110 44 105 M56 105 Q65 110 74 105" />
+        </svg>
+    ),
+    'The Chariot': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="50" cy="30" r="10" />
+            <path d="M28 50 H 72 L72 95 H 28 Z" />
+            <path d="M36 50 L36 40 M64 50 L64 40" />
+            <circle cx="36" cy="38" r="3" />
+            <circle cx="64" cy="38" r="3" />
+            <path d="M28 95 L20 115 M72 95 L80 115" />
+            <circle cx="30" cy="108" r="6" />
+            <circle cx="70" cy="108" r="6" />
+            <path d="M36 108 H 64" />
+        </svg>
+    ),
+    'Strength': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="50" cy="28" r="10" />
+            <path d="M42 25 Q50 18 58 25" />
+            <path d="M30 65 Q50 45 70 65 Q80 80 70 95 Q50 105 30 95 Q20 80 30 65 Z" />
+            <path d="M40 72 Q50 62 60 72" />
+            <path d="M44 85 H 56" />
+            <path d="M36 38 L36 50 M64 38 L64 50" />
+        </svg>
+    ),
+    'The Hermit': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="50" cy="28" r="9" />
+            <path d="M40 37 Q32 60 30 115" />
+            <path d="M60 37 Q62 60 64 115" />
+            <path d="M32 60 Q50 56 68 60" />
+            <path d="M30 115 H 70" />
+            <path d="M72 50 L78 40 L78 65" strokeWidth="1.2" />
+            <path d="M78 52 L82 48" />
+        </svg>
+    ),
+    'Wheel of Fortune': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="50" cy="56" r="28" />
+            <circle cx="50" cy="56" r="20" />
+            <circle cx="50" cy="56" r="6" />
+            {[0, 1, 2, 3, 4, 5, 6, 7].map(i => {
+                const a = (i * Math.PI) / 4;
+                return <line key={i} x1={50 + Math.cos(a) * 6} y1={56 + Math.sin(a) * 6} x2={50 + Math.cos(a) * 28} y2={56 + Math.sin(a) * 28} />;
+            })}
+            <path d="M30 96 Q50 92 70 96 L72 124 L28 124 Z" />
+        </svg>
+    ),
+    'Justice': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="50" cy="28" r="9" />
+            <path d="M50 37 V 115" />
+            <path d="M30 65 H 70" />
+            <path d="M25 65 L25 85 Q35 92 30 65" />
+            <path d="M75 65 L75 85 Q65 92 70 65" />
+            <path d="M46 50 L46 35 M54 50 L54 35" />
+            <path d="M42 35 H 58" />
+        </svg>
+    ),
+    'The Hanged Man': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M26 20 H 74" />
+            <path d="M32 20 V 50 M68 20 V 50" />
+            <path d="M50 20 V 35" />
+            <circle cx="50" cy="44" r="10" />
+            <path d="M50 54 L50 85 M42 65 L35 55 M58 65 L65 55" />
+            <path d="M42 85 L35 100 M58 85 L65 100" />
+        </svg>
+    ),
+    'Death': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="50" cy="28" r="10" />
+            <path d="M42 22 H 58 M42 34 H 58" />
+            <path d="M38 55 L50 38 L62 55 L55 55 L55 115 L45 115 L45 55 Z" />
+            <path d="M24 100 Q50 95 76 100" />
+            <path d="M20 115 Q50 108 80 115" />
+        </svg>
+    ),
+    'Temperance': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="50" cy="28" r="10" />
+            <path d="M40 38 L40 115 M60 38 L60 115" />
+            <path d="M30 60 L40 55 M70 60 L60 55" />
+            <path d="M30 80 L40 75 M70 80 L60 75" />
+            <path d="M40 65 Q50 70 60 65" />
+            <path d="M40 85 Q50 90 60 85" />
+            <path d="M30 115 Q50 120 70 115" />
+        </svg>
+    ),
+    'The Devil': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="50" cy="35" r="12" />
+            <path d="M38 28 L32 18 M62 28 L68 18" />
+            <path d="M28 48 Q50 44 72 48 L72 105 L28 105 Z" />
+            <path d="M34 105 L30 120 M66 105 L70 120" />
+            <circle cx="30" cy="120" r="4" />
+            <circle cx="70" cy="120" r="4" />
+            <path d="M34 72 H 66" />
+        </svg>
+    ),
+    'The Tower': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M36 30 V 100 H 64 V 30 Z" />
+            <path d="M32 30 H 68 M30 26 H 70" />
+            <path d="M40 30 V 22 H 44 V 30 M52 30 V 22 H 56 V 30 M58 22 H 62" />
+            <path d="M44 50 H 56 M44 70 H 56" />
+            <path d="M50 18 L46 8 M50 18 L54 8 M50 8 L50 4" />
+            <path d="M28 110 Q50 106 72 110" />
+            <path d="M20 124 Q50 118 80 124" />
+        </svg>
+    ),
+    'The Star': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            {[0, 1, 2, 3, 4, 5, 6, 7].map(i => {
+                const a = (i * Math.PI) / 4;
+                return <line key={i} x1={50} y1={40} x2={50 + Math.cos(a) * 26} y2={40 + Math.sin(a) * 26} />;
+            })}
+            <circle cx="50" cy="40" r="6" />
+            <circle cx="50" cy="40" r="14" />
+            <path d="M30 75 Q50 82 70 75 L72 118 Q50 124 28 118 Z" />
+            <path d="M22 90 Q14 100 24 110 M78 90 Q86 100 76 110" />
+            <circle cx="20" cy="30" r="1.2" fill="currentColor" />
+            <circle cx="82" cy="20" r="1.2" fill="currentColor" />
+        </svg>
+    ),
+    'The Moon': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M62 40 A22 22 0 1 0 62 84 A16 16 0 1 1 62 40 Z" />
+            <circle cx="46" cy="55" r="0.8" fill="currentColor" />
+            <circle cx="52" cy="68" r="0.8" fill="currentColor" />
+            <circle cx="44" cy="74" r="0.6" fill="currentColor" />
+            <path d="M30 100 Q50 96 70 100 L72 130 L28 130 Z" />
+            <path d="M40 110 L40 130 M60 110 L60 130 M50 100 V 130" />
+            <path d="M20 130 H 80" strokeWidth="1.2" />
+        </svg>
+    ),
+    'The Sun': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="50" cy="48" r="16" />
+            {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map(i => {
+                const a = (i * Math.PI) / 6;
+                return <line key={i} x1={50 + Math.cos(a) * 20} y1={48 + Math.sin(a) * 20} x2={50 + Math.cos(a) * 30} y2={48 + Math.sin(a) * 30} />;
+            })}
+            <path d="M28 90 Q50 88 72 90 L72 124 L28 124 Z" />
+            <path d="M44 96 Q50 100 56 96 M44 110 Q50 114 56 110" />
+        </svg>
+    ),
+    'Judgement': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M30 40 H 70 L70 60 H 30 Z" />
+            <path d="M50 40 V 28 M44 28 Q50 20 56 28" />
+            <path d="M40 60 L32 90 M60 60 L68 90" />
+            <path d="M50 60 V 90" />
+            <path d="M28 90 L28 115 L72 115 L72 90 Z" />
+            <path d="M38 100 H 62 M38 108 H 62" />
+        </svg>
+    ),
+    'The World': ({ size = 120 }) => (
+        <svg width={size} height={size * 1.45} viewBox="0 0 100 145" fill="none" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round">
+            <ellipse cx="50" cy="70" rx="28" ry="42" />
+            <ellipse cx="50" cy="70" rx="18" ry="32" />
+            <path d="M24 45 Q50 40 76 45 M24 95 Q50 100 76 95" />
+            <circle cx="50" cy="70" r="6" />
+            <path d="M50 64 V 76 M44 70 H 56" />
+        </svg>
+    ),
+};
+
+// ─── Suit Symbols for Minor Arcana ──────────────────────────────────────────
+
+const SuitGlyph: Record<string, React.FC<{ size?: number }>> = {
+    'Cups': ({ size = 80 }) => (
+        <svg width={size} height={size * 1.2} viewBox="0 0 80 96" fill="none" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M24 16 Q20 50 40 58 Q60 50 56 16 Z" />
+            <path d="M36 58 V 76 M44 58 V 76" />
+            <path d="M28 76 H 52" />
+            <path d="M22 36 Q16 38 14 48 Q16 52 24 48" />
+            <path d="M58 36 Q64 38 66 48 Q64 52 56 48" />
+        </svg>
+    ),
+    'Pentacles': ({ size = 80 }) => (
+        <svg width={size} height={size * 1.2} viewBox="0 0 80 96" fill="none" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="40" cy="44" r="28" />
+            <circle cx="40" cy="44" r="22" />
+            {[0, 1, 2, 3, 4].map(i => {
+                const a = (i * 2 * Math.PI) / 5 - Math.PI / 2;
+                const x = 40 + Math.cos(a) * 18;
+                const y = 44 + Math.sin(a) * 18;
+                return <circle key={i} cx={x} cy={y} r="2" fill="currentColor" />;
+            })}
+            <path d="M40 22 L44 34 L57 34 L47 42 L51 55 L40 47 L29 55 L33 42 L23 34 L36 34 Z" />
+        </svg>
+    ),
+    'Swords': ({ size = 80 }) => (
+        <svg width={size} height={size * 1.2} viewBox="0 0 80 96" fill="none" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M40 10 V 76" strokeWidth="1.4" />
+            <path d="M38 10 L40 6 L42 10" />
+            <path d="M28 58 H 52" />
+            <path d="M34 65 H 46" />
+            <path d="M38 76 Q36 84 32 88 M42 76 Q44 84 48 88" />
+            <path d="M30 88 H 50" />
+        </svg>
+    ),
+    'Wands': ({ size = 80 }) => (
+        <svg width={size} height={size * 1.2} viewBox="0 0 80 96" fill="none" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M40 8 V 90" strokeWidth="1.6" />
+            <path d="M34 18 Q28 14 26 20 Q30 28 40 22 Q50 28 54 20 Q52 14 46 18" />
+            <path d="M32 40 Q24 36 22 44 Q28 52 40 46 Q52 52 58 44 Q56 36 48 40" />
+            <path d="M34 64 Q28 60 26 68 Q30 76 40 70 Q50 76 54 68 Q52 60 46 64" />
+        </svg>
+    ),
+};
+
+// ─── Numerals ────────────────────────────────────────────────────────────────
+
+const NUMERALS: Record<number, string> = {
+    0: '0', 1: 'I', 2: 'II', 3: 'III', 4: 'IV', 5: 'V',
+    6: 'VI', 7: 'VII', 8: 'VIII', 9: 'IX', 10: 'X',
+    11: 'XI', 12: 'XII', 13: 'XIII', 14: 'XIV', 15: 'XV',
+    16: 'XVI', 17: 'XVII', 18: 'XVIII', 19: 'XIX', 20: 'XX', 21: 'XXI',
+};
+
+// ─── Main Card Component ─────────────────────────────────────────────────────
+
+interface ArcanaCardProps {
+    name: string;
+    suit?: string | null;
+    numerology?: number | null;
+    width?: number;
+    height?: number;
+    accentColor?: string;
+    bgColor?: string;
+    borderColor?: string;
+    onClick?: () => void;
+    className?: string;
+}
+
+export function ArcanaCard({
+    name,
+    suit,
+    numerology,
+    width = 160,
+    height = 252,
+    accentColor = '#f59e0b',
+    bgColor = '#13111e',
+    borderColor = '#4a3a0a',
+    onClick,
+    className = '',
+}: ArcanaCardProps) {
+    const isMajor = suit === 'Major Arcana';
+    const Glyph = isMajor ? MajorArcanaGlyph[name] : SuitGlyph[suit ?? ''];
+    const numeral = isMajor && numerology !== undefined && numerology !== null
+        ? NUMERALS[numerology] ?? ''
+        : '';
+
+    const glyphSize = Math.min(width * 0.52, height * 0.38);
+
+    return (
+        <div
+            onClick={onClick}
+            className={`relative select-none transition-transform hover:scale-105 hover:-translate-y-1 ${onClick ? 'cursor-pointer' : ''} ${className}`}
+            style={{ width, height, borderRadius: 8, background: bgColor, boxShadow: `0 0 0 1px ${borderColor}88, 0 20px 50px -15px rgba(0,0,0,0.7)` }}
+        >
+            {/* Inner hairline frame */}
+            <div style={{ position: 'absolute', inset: 7, border: `1px solid ${borderColor}55`, borderRadius: 4, pointerEvents: 'none' }} />
+
+            {/* Numeral */}
+            {numeral && (
+                <div style={{
+                    position: 'absolute', top: 12, left: 0, right: 0, textAlign: 'center',
+                    fontFamily: '"Cormorant Garamond", "Playfair Display", serif',
+                    color: accentColor, letterSpacing: '0.3em', fontSize: 10, fontWeight: 500,
+                }}>
+                    {numeral}
+                </div>
+            )}
+
+            {/* Glyph */}
+            <div style={{
+                position: 'absolute', top: '50%', left: '50%',
+                transform: 'translate(-50%, -50%)',
+                color: accentColor, marginTop: 4,
+            }}>
+                {Glyph
+                    ? <Glyph size={glyphSize} />
+                    : (
+                        // Fallback: suit initial in a decorative circle
+                        <svg width={glyphSize} height={glyphSize} viewBox="0 0 100 100" fill="none" stroke={accentColor} strokeWidth="1.2">
+                            <circle cx="50" cy="50" r="38" />
+                            <circle cx="50" cy="50" r="28" />
+                            <text x="50" y="58" textAnchor="middle" fontSize="28" fill={accentColor} fontFamily="serif" stroke="none">
+                                {name.charAt(0)}
+                            </text>
+                        </svg>
+                    )
+                }
+            </div>
+
+            {/* Card name */}
+            <div style={{
+                position: 'absolute', bottom: 12, left: 0, right: 0, textAlign: 'center',
+                fontFamily: '"Cormorant Garamond", "Playfair Display", serif',
+                color: accentColor, fontSize: Math.max(9, width * 0.068),
+                letterSpacing: '0.12em', fontStyle: 'italic',
+                padding: '0 8px', lineHeight: 1.2,
+            }}>
+                {name}
+            </div>
+        </div>
+    );
+}
+
+export default ArcanaCard;

--- a/frontend/src/components/ArcanaCard.tsx
+++ b/frontend/src/components/ArcanaCard.tsx
@@ -311,6 +311,7 @@ interface ArcanaCardProps {
     name: string;
     suit?: string | null;
     numerology?: number | null;
+    imageUrl?: string | null;
     width?: number;
     height?: number;
     accentColor?: string;
@@ -324,6 +325,7 @@ export function ArcanaCard({
     name,
     suit,
     numerology,
+    imageUrl,
     width = 160,
     height = 252,
     accentColor = '#f59e0b',
@@ -332,6 +334,8 @@ export function ArcanaCard({
     onClick,
     className = '',
 }: ArcanaCardProps) {
+    const [imgError, setImgError] = React.useState(false);
+
     const isMajor = suit === 'Major Arcana';
     const Glyph = isMajor ? MajorArcanaGlyph[name] : SuitGlyph[suit ?? ''];
     const numeral = isMajor && numerology !== undefined && numerology !== null
@@ -339,58 +343,78 @@ export function ArcanaCard({
         : '';
 
     const glyphSize = Math.min(width * 0.52, height * 0.38);
+    const showImage = !!imageUrl && !imgError;
 
     return (
         <div
             onClick={onClick}
             className={`relative select-none transition-transform hover:scale-105 hover:-translate-y-1 ${onClick ? 'cursor-pointer' : ''} ${className}`}
-            style={{ width, height, borderRadius: 8, background: bgColor, boxShadow: `0 0 0 1px ${borderColor}88, 0 20px 50px -15px rgba(0,0,0,0.7)` }}
+            style={{ width, height, borderRadius: 8, background: bgColor, boxShadow: `0 0 0 1px ${borderColor}88, 0 20px 50px -15px rgba(0,0,0,0.7)`, overflow: 'hidden' }}
         >
-            {/* Inner hairline frame */}
-            <div style={{ position: 'absolute', inset: 7, border: `1px solid ${borderColor}55`, borderRadius: 4, pointerEvents: 'none' }} />
+            {showImage ? (
+                /* ── Real card image from the deck ── */
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                    src={imageUrl!}
+                    alt={name}
+                    onError={() => setImgError(true)}
+                    style={{
+                        width: '100%',
+                        height: '100%',
+                        objectFit: 'cover',
+                        display: 'block',
+                        borderRadius: 8,
+                    }}
+                />
+            ) : (
+                /* ── SVG glyph fallback ── */
+                <>
+                    {/* Inner hairline frame */}
+                    <div style={{ position: 'absolute', inset: 7, border: `1px solid ${borderColor}55`, borderRadius: 4, pointerEvents: 'none' }} />
 
-            {/* Numeral */}
-            {numeral && (
-                <div style={{
-                    position: 'absolute', top: 12, left: 0, right: 0, textAlign: 'center',
-                    fontFamily: '"Cormorant Garamond", "Playfair Display", serif',
-                    color: accentColor, letterSpacing: '0.3em', fontSize: 10, fontWeight: 500,
-                }}>
-                    {numeral}
-                </div>
+                    {/* Numeral */}
+                    {numeral && (
+                        <div style={{
+                            position: 'absolute', top: 12, left: 0, right: 0, textAlign: 'center',
+                            fontFamily: '"Cormorant Garamond", "Playfair Display", serif',
+                            color: accentColor, letterSpacing: '0.3em', fontSize: 10, fontWeight: 500,
+                        }}>
+                            {numeral}
+                        </div>
+                    )}
+
+                    {/* Glyph */}
+                    <div style={{
+                        position: 'absolute', top: '50%', left: '50%',
+                        transform: 'translate(-50%, -50%)',
+                        color: accentColor, marginTop: 4,
+                    }}>
+                        {Glyph
+                            ? <Glyph size={glyphSize} />
+                            : (
+                                <svg width={glyphSize} height={glyphSize} viewBox="0 0 100 100" fill="none" stroke={accentColor} strokeWidth="1.2">
+                                    <circle cx="50" cy="50" r="38" />
+                                    <circle cx="50" cy="50" r="28" />
+                                    <text x="50" y="58" textAnchor="middle" fontSize="28" fill={accentColor} fontFamily="serif" stroke="none">
+                                        {name.charAt(0)}
+                                    </text>
+                                </svg>
+                            )
+                        }
+                    </div>
+
+                    {/* Card name */}
+                    <div style={{
+                        position: 'absolute', bottom: 12, left: 0, right: 0, textAlign: 'center',
+                        fontFamily: '"Cormorant Garamond", "Playfair Display", serif',
+                        color: accentColor, fontSize: Math.max(9, width * 0.068),
+                        letterSpacing: '0.12em', fontStyle: 'italic',
+                        padding: '0 8px', lineHeight: 1.2,
+                    }}>
+                        {name}
+                    </div>
+                </>
             )}
-
-            {/* Glyph */}
-            <div style={{
-                position: 'absolute', top: '50%', left: '50%',
-                transform: 'translate(-50%, -50%)',
-                color: accentColor, marginTop: 4,
-            }}>
-                {Glyph
-                    ? <Glyph size={glyphSize} />
-                    : (
-                        // Fallback: suit initial in a decorative circle
-                        <svg width={glyphSize} height={glyphSize} viewBox="0 0 100 100" fill="none" stroke={accentColor} strokeWidth="1.2">
-                            <circle cx="50" cy="50" r="38" />
-                            <circle cx="50" cy="50" r="28" />
-                            <text x="50" y="58" textAnchor="middle" fontSize="28" fill={accentColor} fontFamily="serif" stroke="none">
-                                {name.charAt(0)}
-                            </text>
-                        </svg>
-                    )
-                }
-            </div>
-
-            {/* Card name */}
-            <div style={{
-                position: 'absolute', bottom: 12, left: 0, right: 0, textAlign: 'center',
-                fontFamily: '"Cormorant Garamond", "Playfair Display", serif',
-                color: accentColor, fontSize: Math.max(9, width * 0.068),
-                letterSpacing: '0.12em', fontStyle: 'italic',
-                padding: '0 8px', lineHeight: 1.2,
-            }}>
-                {name}
-            </div>
         </div>
     );
 }

--- a/frontend/src/components/ArcanaCard.tsx
+++ b/frontend/src/components/ArcanaCard.tsx
@@ -361,9 +361,10 @@ export function ArcanaCard({
                     style={{
                         width: '100%',
                         height: '100%',
-                        objectFit: 'cover',
+                        objectFit: 'contain',
                         display: 'block',
                         borderRadius: 8,
+                        background: bgColor,
                     }}
                 />
             ) : (

--- a/frontend/src/components/EnhancedNavigation.tsx
+++ b/frontend/src/components/EnhancedNavigation.tsx
@@ -17,7 +17,8 @@ import {
     Crown,
     Star,
     X,
-    HelpCircle
+    HelpCircle,
+    Library
 } from 'lucide-react';
 import {
     DropdownMenu,
@@ -205,6 +206,12 @@ export function EnhancedNavigation() {
                                     Journal
                                 </Link>
                             </Button>
+                            <Button variant="ghost" size="sm" asChild className="text-gray-300 hover:text-white hover:bg-gray-800 px-4 py-3 touch-manipulation">
+                                <Link href="/library">
+                                    <Library className="w-5 h-5 mr-2" />
+                                    Library
+                                </Link>
+                            </Button>
                         </div>
 
                         {/* User Menu - Mobile-optimized */}
@@ -262,6 +269,12 @@ export function EnhancedNavigation() {
                                             <Link href="/journal" className="flex items-center">
                                                 <BookOpen className="w-5 h-5 mr-3" />
                                                 Journal
+                                            </Link>
+                                        </DropdownMenuItem>
+                                        <DropdownMenuItem asChild className="px-4 py-3 text-base">
+                                            <Link href="/library" className="flex items-center">
+                                                <Library className="w-5 h-5 mr-3" />
+                                                The Library
                                             </Link>
                                         </DropdownMenuItem>
                                         <DropdownMenuSeparator className="bg-gray-700" />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -346,6 +346,15 @@ export const tarot = {
         const response = await api.get(`/tarot/card-of-the-day`);
         return response.data;
     },
+
+    getLibraryCards: async (suit?: string, search?: string) => {
+        const params = new URLSearchParams();
+        if (suit) params.set('suit', suit);
+        if (search) params.set('search', search);
+        const query = params.toString() ? `?${params.toString()}` : '';
+        const response = await api.get(`/tarot/library${query}`);
+        return response.data;
+    },
 };
 
 // Sharing endpoints


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive card library feature that allows authenticated users to browse, search, and view detailed information about all 78 tarot cards in the deck. The implementation includes custom hand-drawn SVG glyphs for all 22 Major Arcana cards and suit symbols for the Minor Arcana.

## Key Changes

### Frontend
- **New `ArcanaCard` component** (`frontend/src/components/ArcanaCard.tsx`):
  - Renders individual tarot cards with custom SVG glyphs for all 22 Major Arcana and 4 Minor Arcana suits
  - Displays card name, numerology (Roman numerals), and decorative styling
  - Supports customizable sizing, colors, and click handlers
  - Includes fallback rendering for cards without dedicated glyphs

- **New Library page** (`frontend/src/app/library/page.tsx`):
  - Full-page card browser with responsive grid layout (2-6 columns depending on viewport)
  - Filter tabs for All Cards, Major Arcana, and each Minor Arcana suit with live counts
  - Search functionality with 300ms debounce for card names and ranks
  - Modal detail panel showing card meanings (upright/reversed), element, astrology, and short descriptions
  - Authentication guard redirects unauthenticated users to login

- **Navigation updates** (`frontend/src/components/EnhancedNavigation.tsx`):
  - Added Library link to main navigation menu with Library icon

- **API client** (`frontend/src/lib/api.ts`):
  - New `getLibraryCards()` method supporting optional suit and search filters

### Backend
- **New library endpoint** (`backend/routers/tarot.py`):
  - `GET /tarot/library` returns filtered/searchable card list
  - Supports filtering by suit and full-text search on card name/rank
  - Respects user's favorite deck preference with fallback to default deck
  - Results ordered by suit, numerology, and ID

- **New response schema** (`backend/schemas.py`):
  - `LibraryCardResponse` includes all card metadata: name, suit, rank, descriptions (short/upright/reversed), element, astrology, numerology, and image URL

## Implementation Details
- All Major Arcana glyphs are hand-stylized line art (no third-party deck artwork)
- Cards use serif typography (Cormorant Garamond/Playfair Display) with amber accent colors
- Search and filter operations are optimized with debouncing and efficient database queries
- Modal overlay uses backdrop blur and semi-transparent backdrop for visual hierarchy
- Responsive design adapts card grid from 2 columns on mobile to 6 columns on extra-large screens

https://claude.ai/code/session_012ptFEkD8Ca4KNcRsXff1d2