### PR TITLE
Add VIP user error alerts for 4xx/5xx responses

### DIFF
--- a/backend/utils/error_handlers.py
+++ b/backend/utils/error_handlers.py
@@ -6,10 +6,11 @@ from typing import Any
 from fastapi import Request, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+from jose import JWTError, jwt
 from sqlalchemy.exc import IntegrityError, OperationalError, SQLAlchemyError
 
 from config import settings
-from utils.telegram_alerts import is_telegram_configured, send_500_error_alert
+from utils.telegram_alerts import is_telegram_configured, send_500_error_alert, send_user_error_alert
 
 
 # Configure structured logging
@@ -68,6 +69,64 @@ class StructuredLogger:
 
 # Initialize logger
 logger = StructuredLogger()
+
+# Username of the VIP user who receives alerts for all 4xx/5xx errors
+VIP_USERNAME = "msc.mon"
+
+
+def get_username_from_request(request: Request) -> str | None:
+    """Extract username from the JWT Bearer token in the Authorization header."""
+    try:
+        auth_header = request.headers.get("authorization", "")
+        if not auth_header.startswith("Bearer "):
+            return None
+        token = auth_header[7:]
+        # Decode without expiry verification so we can still identify the user
+        # even when the token has expired.
+        payload = jwt.decode(
+            token,
+            settings.JWT_SECRET_KEY,
+            algorithms=[settings.JWT_ALGORITHM],
+            options={"verify_exp": False},
+        )
+        return payload.get("sub")
+    except Exception:
+        return None
+
+
+async def maybe_send_vip_error_alert(request: Request, status_code: int, error: Exception) -> None:
+    """Log the request payload and send a Telegram alert when the VIP user hits any error."""
+    if not is_telegram_configured(settings.TELEGRAM_BOT_TOKEN, settings.TELEGRAM_CHAT_ID):
+        return
+    username = get_username_from_request(request)
+    if username != VIP_USERNAME:
+        return
+
+    request_payload = await extract_request_payload(request)
+
+    logger.logger.warning(
+        "VIP user error",
+        extra={
+            "username": username,
+            "status_code": status_code,
+            "method": request.method,
+            "url": str(request.url),
+            "payload": request_payload,
+            "error": str(error),
+        },
+    )
+
+    send_user_error_alert(
+        username=username,
+        status_code=status_code,
+        request_method=request.method,
+        request_url=str(request.url),
+        error=error,
+        telegram_bot_token=settings.TELEGRAM_BOT_TOKEN,
+        chat_id=settings.TELEGRAM_CHAT_ID,
+        client_host=request.client.host if request.client else None,
+        request_payload=request_payload,
+    )
 
 
 # Custom exceptions
@@ -271,6 +330,8 @@ async def tarot_exception_handler(request: Request, exc: TarotAPIException):
             request_headers=request_headers,
         )
 
+    await maybe_send_vip_error_alert(request, exc.status_code, exc)
+
     return JSONResponse(
         status_code=exc.status_code,
         content={"error": exc.message, "details": exc.details},
@@ -279,6 +340,7 @@ async def tarot_exception_handler(request: Request, exc: TarotAPIException):
 
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
     logger.log_request(request, error=exc)
+    await maybe_send_vip_error_alert(request, status.HTTP_422_UNPROCESSABLE_ENTITY, exc)
     return JSONResponse(
         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
         content={
@@ -307,6 +369,8 @@ async def sqlalchemy_exception_handler(request: Request, exc: SQLAlchemyError):
             request_headers=request_headers,
         )
 
+    await maybe_send_vip_error_alert(request, status.HTTP_500_INTERNAL_SERVER_ERROR, exc)
+
     return JSONResponse(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         content={"error": "Database error", "details": str(exc)},
@@ -332,6 +396,8 @@ async def general_exception_handler(request: Request, exc: Exception):
             request_headers=request_headers,
         )
 
+    await maybe_send_vip_error_alert(request, status.HTTP_500_INTERNAL_SERVER_ERROR, exc)
+
     return JSONResponse(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         content={"error": "Internal server error", "details": str(exc)},
@@ -341,6 +407,7 @@ async def general_exception_handler(request: Request, exc: Exception):
 # Additional exception handlers
 async def integrity_error_handler(request: Request, exc: IntegrityError):
     logger.log_request(request, error=exc)
+    await maybe_send_vip_error_alert(request, status.HTTP_409_CONFLICT, exc)
     return JSONResponse(
         status_code=status.HTTP_409_CONFLICT,
         content={"error": "Database integrity error", "details": str(exc)},
@@ -349,6 +416,7 @@ async def integrity_error_handler(request: Request, exc: IntegrityError):
 
 async def operational_error_handler(request: Request, exc: OperationalError):
     logger.log_request(request, error=exc)
+    await maybe_send_vip_error_alert(request, status.HTTP_503_SERVICE_UNAVAILABLE, exc)
     return JSONResponse(
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         content={"error": "Database operational error", "details": str(exc)},

--- a/backend/utils/rate_limiter.py
+++ b/backend/utils/rate_limiter.py
@@ -49,6 +49,8 @@ from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
 
+from utils.error_handlers import maybe_send_vip_error_alert
+
 # Create a limiter instance with IP-based rate limiting
 # Uses the remote address of the client as the key for rate limiting
 limiter = Limiter(key_func=get_remote_address)
@@ -104,4 +106,5 @@ async def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) 
         The detail field contains the rate limit configuration that was exceeded,
         helping clients understand the limitation and adjust their request patterns.
     """
+    await maybe_send_vip_error_alert(request, 429, exc)
     return JSONResponse(status_code=429, content={"error": "Rate limit exceeded", "detail": str(exc)})

--- a/backend/utils/telegram_alerts.py
+++ b/backend/utils/telegram_alerts.py
@@ -145,6 +145,71 @@ def send_500_error_alert(
     return send_telegram_alert(message, telegram_bot_token, chat_id)
 
 
+def send_user_error_alert(
+    username: str,
+    status_code: int,
+    request_method: str,
+    request_url: str,
+    error: Exception,
+    telegram_bot_token: str,
+    chat_id: str,
+    client_host: str | None = None,
+    request_payload: dict[str, Any] | None = None,
+) -> bool:
+    """
+    Send a Telegram alert for a VIP user that encountered a 4xx or 5xx error.
+
+    Args:
+        username: The username of the VIP user.
+        status_code: HTTP status code of the error response.
+        request_method: HTTP method of the request.
+        request_url: URL of the request.
+        error: The exception or error that occurred.
+        telegram_bot_token: Telegram bot token.
+        chat_id: Telegram chat ID.
+        client_host: Client IP address (optional).
+        request_payload: Request body/payload for debugging (optional).
+
+    Returns:
+        bool: True if alert was sent successfully, False otherwise.
+    """
+    if not telegram_bot_token or not chat_id:
+        return False
+
+    status_emoji = "🚨" if status_code >= 500 else "⚠️"
+    client_info = f"\n👤 **Client IP:** `{client_host}`" if client_host else ""
+
+    payload_info = ""
+    if request_payload:
+        try:
+            payload_str = json.dumps(request_payload, indent=2, default=str)
+            if len(payload_str) > 500:
+                payload_str = payload_str[:500] + "\n...(truncated)"
+            payload_info = f"\n📦 **Payload:**\n```json\n{payload_str}\n```"
+        except Exception:
+            payload_info = f"\n📦 **Payload:** `{str(request_payload)[:200]}...`"
+
+    traceback_info = ""
+    if status_code >= 500:
+        tb = traceback.format_exc()
+        if tb and tb.strip() not in ("NoneType: None", "None"):
+            if len(tb) > 1500:
+                tb = tb[:1500] + "\n...(truncated)"
+            traceback_info = f"\n📋 **Traceback:**\n```\n{tb}\n```"
+
+    message = (
+        f"🌟 **VIP User Error — @{username}**\n"
+        f"{get_context_header()}\n"
+        f"{status_emoji} **HTTP {status_code}**\n"
+        f"🔗 **Request:** `{request_method} {request_url}`{client_info}\n"
+        f"❌ **Error:** `{str(error)}`"
+        f"{payload_info}"
+        f"{traceback_info}"
+    )
+
+    return send_telegram_alert(message, telegram_bot_token, chat_id)
+
+
 def update_last_error_time(path: str):
     """Update the last error timestamp file"""
     try:


### PR DESCRIPTION
## Summary
This PR adds a monitoring system to send Telegram alerts whenever a designated VIP user encounters any 4xx or 5xx HTTP errors. This enables proactive support and debugging for critical users.

## Key Changes

- **VIP User Error Tracking**: Added `maybe_send_vip_error_alert()` function that extracts the username from JWT tokens and sends alerts when the VIP user (`msc.mon`) encounters errors
- **JWT Token Parsing**: Implemented `get_username_from_request()` to safely extract usernames from Bearer tokens without requiring token expiry verification
- **Comprehensive Error Coverage**: Integrated VIP alerts into all exception handlers:
  - Custom `TarotAPIException` handler
  - Request validation errors (422)
  - SQLAlchemy database errors (500)
  - General exceptions (500)
  - Database integrity errors (409)
  - Database operational errors (503)
  - Rate limit exceeded errors (429)
- **Enhanced Alert Details**: Created `send_user_error_alert()` function that sends rich Telegram messages including:
  - HTTP status code with appropriate emoji indicators
  - Request method and URL
  - Client IP address
  - Request payload (truncated if necessary)
  - Full traceback for 5xx errors
- **Request Payload Logging**: Leverages existing `extract_request_payload()` utility to include request body in alerts for debugging

## Implementation Details

- JWT decoding is performed with `verify_exp=False` to identify users even when tokens have expired
- Alerts are only sent if Telegram is properly configured
- Payload and traceback information is truncated to prevent excessively long messages
- All error extraction is wrapped in exception handlers to prevent alert failures from affecting error responses

https://claude.ai/code/session_01HRu5y9pyZnAaiLSuL1hniA