### PR TITLE
Make error alerts configurable per user instead of hardcoded VIP

### DIFF
--- a/backend/migrations/versions/20260523_000000_b2c3d4e5f6a7_add_is_vip_to_user.py
+++ b/backend/migrations/versions/20260523_000000_b2c3d4e5f6a7_add_is_vip_to_user.py
@@ -1,0 +1,27 @@
+"""add is_vip field to user
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-05-23 00:00:00.000000+00:00
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "b2c3d4e5f6a7"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("is_vip", sa.Boolean(), nullable=True))
+    op.execute("UPDATE users SET is_vip = false WHERE is_vip IS NULL")
+    op.execute("UPDATE users SET is_vip = true WHERE username = 'msc.mon'")
+
+
+def downgrade() -> None:
+    op.drop_column("users", "is_vip")

--- a/backend/migrations/versions/20260523_000000_b2c3d4e5f6a7_add_receive_error_alerts_to_user.py
+++ b/backend/migrations/versions/20260523_000000_b2c3d4e5f6a7_add_receive_error_alerts_to_user.py
@@ -1,4 +1,4 @@
-"""add is_vip field to user
+"""add receive_error_alerts field to user
 
 Revision ID: b2c3d4e5f6a7
 Revises: a1b2c3d4e5f6
@@ -18,10 +18,10 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.add_column("users", sa.Column("is_vip", sa.Boolean(), nullable=True))
-    op.execute("UPDATE users SET is_vip = false WHERE is_vip IS NULL")
-    op.execute("UPDATE users SET is_vip = true WHERE username = 'msc.mon'")
+    op.add_column("users", sa.Column("receive_error_alerts", sa.Boolean(), nullable=True))
+    op.execute("UPDATE users SET receive_error_alerts = false WHERE receive_error_alerts IS NULL")
+    op.execute("UPDATE users SET receive_error_alerts = true WHERE username = 'msc.mon'")
 
 
 def downgrade() -> None:
-    op.drop_column("users", "is_vip")
+    op.drop_column("users", "receive_error_alerts")

--- a/backend/models.py
+++ b/backend/models.py
@@ -58,8 +58,7 @@ class User(Base):
     # Specialized premium access (for acquaintances/VIP users)
     is_specialized_premium = Column(Boolean, default=False)
 
-    # VIP flag: receives Telegram alerts for all errors (not just 500s)
-    is_vip = Column(Boolean, default=False)
+    receive_error_alerts = Column(Boolean, default=False)
 
     # Avatar storage
     avatar_filename = Column(String, nullable=True)  # Stores the filename of the avatar

--- a/backend/models.py
+++ b/backend/models.py
@@ -58,6 +58,9 @@ class User(Base):
     # Specialized premium access (for acquaintances/VIP users)
     is_specialized_premium = Column(Boolean, default=False)
 
+    # VIP flag: receives Telegram alerts for all errors (not just 500s)
+    is_vip = Column(Boolean, default=False)
+
     # Avatar storage
     avatar_filename = Column(String, nullable=True)  # Stores the filename of the avatar
 

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -46,6 +46,7 @@ def build_admin_user_response(user: User, base_url: str = "") -> AdminUserRespon
         is_active=user.is_active,
         is_admin=user.is_admin or False,
         is_specialized_premium=user.is_specialized_premium or False,
+        is_vip=user.is_vip or False,
         favorite_deck_id=user.favorite_deck_id,
         # Subscription and turn fields (read-only)
         subscription_status=user.subscription_status or "none",

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -46,7 +46,7 @@ def build_admin_user_response(user: User, base_url: str = "") -> AdminUserRespon
         is_active=user.is_active,
         is_admin=user.is_admin or False,
         is_specialized_premium=user.is_specialized_premium or False,
-        is_vip=user.is_vip or False,
+        receive_error_alerts=user.receive_error_alerts or False,
         favorite_deck_id=user.favorite_deck_id,
         # Subscription and turn fields (read-only)
         subscription_status=user.subscription_status or "none",

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -723,6 +723,7 @@ class AdminUserResponse(BaseModel):
     is_active: bool
     is_admin: bool = False
     is_specialized_premium: bool = False
+    is_vip: bool = False
     favorite_deck_id: int | None = None
     # Subscription and turn fields (read-only)
     subscription_status: str = "none"
@@ -748,6 +749,7 @@ class AdminUserUpdate(BaseModel):
     full_name: str | None = None
     is_active: bool | None = None
     is_specialized_premium: bool | None = None
+    is_vip: bool | None = None
     favorite_deck_id: int | None = None
 
     @field_validator("username")

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -723,7 +723,7 @@ class AdminUserResponse(BaseModel):
     is_active: bool
     is_admin: bool = False
     is_specialized_premium: bool = False
-    is_vip: bool = False
+    receive_error_alerts: bool = False
     favorite_deck_id: int | None = None
     # Subscription and turn fields (read-only)
     subscription_status: str = "none"
@@ -749,7 +749,7 @@ class AdminUserUpdate(BaseModel):
     full_name: str | None = None
     is_active: bool | None = None
     is_specialized_premium: bool | None = None
-    is_vip: bool | None = None
+    receive_error_alerts: bool | None = None
     favorite_deck_id: int | None = None
 
     @field_validator("username")

--- a/backend/utils/error_handlers.py
+++ b/backend/utils/error_handlers.py
@@ -70,6 +70,7 @@ class StructuredLogger:
 # Initialize logger
 logger = StructuredLogger()
 
+
 def get_username_from_request(request: Request) -> str | None:
     """Extract username from the JWT Bearer token in the Authorization header."""
     try:
@@ -90,26 +91,33 @@ def get_username_from_request(request: Request) -> str | None:
         return None
 
 
-def _is_vip_user(username: str) -> bool:
-    """Return True if the user has the is_vip flag set in the database."""
+def _should_receive_error_alerts(username: str) -> bool:
+    """Return True if the user has receive_error_alerts set in the database.
+
+    Runs inside the error-handling path (including database error handlers), so any
+    failure here is swallowed to avoid masking the original error being reported.
+    """
     # Lazy imports avoid a circular dependency: database.py imports logger from this module.
     from database import SessionLocal
     from models import User
 
-    db = SessionLocal()
     try:
-        user = db.query(User).filter(User.username == username).first()
-        return bool(user and user.is_vip)
-    finally:
-        db.close()
+        db = SessionLocal()
+        try:
+            user = db.query(User).filter(User.username == username).first()
+            return bool(user and user.receive_error_alerts)
+        finally:
+            db.close()
+    except Exception:
+        return False
 
 
 async def maybe_send_vip_error_alert(request: Request, status_code: int, error: Exception) -> None:
-    """Log the request payload and send a Telegram alert when a VIP user hits any error."""
+    """Log the request payload and send a Telegram alert when the user hits any error."""
     if not is_telegram_configured(settings.TELEGRAM_BOT_TOKEN, settings.TELEGRAM_CHAT_ID):
         return
     username = get_username_from_request(request)
-    if not username or not _is_vip_user(username):
+    if not username or not _should_receive_error_alerts(username):
         return
 
     request_payload = await extract_request_payload(request)

--- a/backend/utils/error_handlers.py
+++ b/backend/utils/error_handlers.py
@@ -70,10 +70,6 @@ class StructuredLogger:
 # Initialize logger
 logger = StructuredLogger()
 
-# Username of the VIP user who receives alerts for all 4xx/5xx errors
-VIP_USERNAME = "msc.mon"
-
-
 def get_username_from_request(request: Request) -> str | None:
     """Extract username from the JWT Bearer token in the Authorization header."""
     try:
@@ -94,12 +90,26 @@ def get_username_from_request(request: Request) -> str | None:
         return None
 
 
+def _is_vip_user(username: str) -> bool:
+    """Return True if the user has the is_vip flag set in the database."""
+    # Lazy imports avoid a circular dependency: database.py imports logger from this module.
+    from database import SessionLocal
+    from models import User
+
+    db = SessionLocal()
+    try:
+        user = db.query(User).filter(User.username == username).first()
+        return bool(user and user.is_vip)
+    finally:
+        db.close()
+
+
 async def maybe_send_vip_error_alert(request: Request, status_code: int, error: Exception) -> None:
-    """Log the request payload and send a Telegram alert when the VIP user hits any error."""
+    """Log the request payload and send a Telegram alert when a VIP user hits any error."""
     if not is_telegram_configured(settings.TELEGRAM_BOT_TOKEN, settings.TELEGRAM_CHAT_ID):
         return
     username = get_username_from_request(request)
-    if username != VIP_USERNAME:
+    if not username or not _is_vip_user(username):
         return
 
     request_payload = await extract_request_payload(request)

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -18,6 +18,7 @@ interface AdminUser {
     created_at: string;
     is_active: boolean;
     is_specialized_premium: boolean;
+    receive_error_alerts: boolean;
     favorite_deck_id: number;
     chat_sessions_count: number;
     shared_readings_count: number;
@@ -209,6 +210,7 @@ export default function AdminUsersPage() {
                                                                 full_name: fd.get('full_name'),
                                                                 is_active: fd.get('is_active') === 'on',
                                                                 is_specialized_premium: fd.get('is_specialized_premium') === 'on',
+                                                                receive_error_alerts: fd.get('receive_error_alerts') === 'on',
                                                                 favorite_deck_id: parseInt(fd.get('favorite_deck_id') as string),
                                                             });
                                                             loadData();
@@ -233,8 +235,9 @@ export default function AdminUsersPage() {
                                                     ))}
                                                     <div className="flex flex-col gap-3">
                                                         {[
-                                                            { name: 'is_active',              label: 'Active User',               checked: u.is_active              },
-                                                            { name: 'is_specialized_premium', label: 'VIP Access (Unlimited Turns)', checked: u.is_specialized_premium },
+                                                            { name: 'is_active',              label: 'Active User',                  checked: u.is_active              },
+                                                            { name: 'is_specialized_premium', label: 'VIP Access (Unlimited Turns)',   checked: u.is_specialized_premium },
+                                                            { name: 'receive_error_alerts',   label: 'Error Alert Monitoring',        checked: u.receive_error_alerts   },
                                                         ].map(ck => (
                                                             <label key={ck.name} className="flex items-center gap-2 cursor-pointer">
                                                                 <input


### PR DESCRIPTION
## Summary
This PR replaces the hardcoded VIP user error alert system with a flexible, database-driven approach that allows any user to opt-in to error alert monitoring through an admin interface.

## Key Changes
- **Removed hardcoded VIP username**: Deleted the `VIP_USERNAME = "msc.mon"` constant from error handlers
- **Added database-driven configuration**: Introduced `receive_error_alerts` boolean field to the User model with a database migration that:
  - Adds the new column to the users table
  - Sets it to `false` by default for all users
  - Sets it to `true` for the legacy VIP user ("msc.mon") to maintain backward compatibility
- **Implemented dynamic alert logic**: Created `_should_receive_error_alerts()` function that queries the database to determine if a user should receive alerts, with proper error handling to avoid masking original errors
- **Updated admin interface**: 
  - Added `receive_error_alerts` field to the AdminUser schema and response types
  - Added UI checkbox in the admin users page to toggle error alert monitoring per user
  - Updated the admin router to handle the new field in user updates
- **Updated error alert function**: Modified `maybe_send_vip_error_alert()` to use the new database-driven check instead of hardcoded username comparison

## Implementation Details
- The `_should_receive_error_alerts()` function uses lazy imports to avoid circular dependencies with the database module
- All exceptions in the alert check are silently caught to prevent masking the original error being reported
- The migration maintains backward compatibility by automatically enabling alerts for the existing VIP user

https://claude.ai/code/session_01Cvdd7CANXfbyHYGrY6YpXo