### PR TITLE
Redesign header: two-tier layout, streak enhancement & profile cleanup

### DIFF
--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.14] - 2026-05-24
+
+
+### Changed
+- Global frontend header navigation is now mounted from the root app layout, so authenticated users see a consistent ArcanaAI top header across frontend pages (instead of only on the home experience)
+- Reading, compatibility reading, journal, and profile pages now include top spacing so the shared sticky header is fully visible and does not overlap page content
+
 ## [0.0.13] - 2026-05-21
 
 Covers commits from 2026-05-19 through 2026-05-21 (ISO week 2026-W21).

--- a/frontend/src/app/journal/page.tsx
+++ b/frontend/src/app/journal/page.tsx
@@ -119,7 +119,7 @@ export default function JournalPage() {
 
     if (loading) {
         return (
-            <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-purple-900 flex items-center justify-center">
+            <div className="min-h-screen pt-20 bg-gradient-to-br from-gray-900 via-gray-800 to-purple-900 flex items-center justify-center">
                 <div className="text-center">
                     <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-500 mx-auto mb-4"></div>
                     <p className="text-gray-400">Loading your journal...</p>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { Providers } from "@/components/Providers";
 import { ServiceWorkerRegistrar } from "@/components/ServiceWorkerRegistrar";
+import { EnhancedNavigation } from "@/components/EnhancedNavigation";
 
 export const metadata: Metadata = {
   title: "ArcanaAI - Mystical Guidance & Insights",
@@ -41,6 +42,7 @@ export default function RootLayout({
       <body className="font-body bg-gradient-to-br from-gray-900 via-gray-800 to-purple-900 min-h-screen" suppressHydrationWarning>
         <Providers>
           <ServiceWorkerRegistrar />
+          <EnhancedNavigation />
           {children}
         </Providers>
       </body>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -420,7 +420,9 @@ function HomeContent() {
   };
 
   useEffect(() => {
-    scrollToBottom();
+    if (messages.length > 0 || streamingContent) {
+      scrollToBottom();
+    }
   }, [messages, streamingContent]);
 
   useEffect(() => {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -8,7 +8,6 @@ import { FiPlus, FiTrash2, FiSend, FiLoader, FiEdit2, FiMessageCircle, FiX, FiCl
 import ReactMarkdown from 'react-markdown';
 
 import { SubscriptionModal } from '@/components/SubscriptionModal';
-import { EnhancedNavigation } from '@/components/EnhancedNavigation';
 import { MysticalSidebar } from '@/components/MysticalSidebar';
 import { TarotCard } from '@/components/TarotCard';
 import { DrawnCardReveal } from '@/components/DrawnCardReveal';
@@ -508,7 +507,6 @@ function HomeContent() {
   return (
     <div className="flex flex-col h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-purple-900">
       {/* Enhanced Navigation */}
-      <EnhancedNavigation />
 
       {/* Main Content Area */}
       <div className="flex flex-1 overflow-hidden relative">
@@ -818,7 +816,6 @@ function HomeContent() {
 function LoadingFallback() {
   return (
     <div className="flex flex-col h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-purple-900">
-      <EnhancedNavigation />
       <div className="flex-1 flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-500 mx-auto mb-4"></div>

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -10,15 +10,12 @@ import { SubscriptionHistory } from '@/components/SubscriptionHistory';
 import { PushNotificationToggle } from '@/components/PushNotificationToggle';
 import { useSubscription } from '@/hooks/useSubscription';
 import { AvatarUpload } from '@/components/AvatarUpload';
-import { useRouter } from 'next/navigation';
-import Link from 'next/link';
-import { TarotAgentLogo } from '@/components/icons';
 
 export default function ProfilePage() {
-    const { isAuthenticated, logout } = useAuth();
+    const { isAuthenticated } = useAuth();
     const { profile, fetchProfile, updateFullName } = useUserProfile();
     const { getSubscriptionStatusText, isPremium } = useSubscription();
-    const router = useRouter();
+
     const [activeTab, setActiveTab] = useState<'profile' | 'decks' | 'subscription' | 'history' | 'notifications'>('profile');
     const [isSubscriptionModalOpen, setIsSubscriptionModalOpen] = useState(false);
     const [isEditingFullName, setIsEditingFullName] = useState(false);
@@ -76,54 +73,16 @@ export default function ProfilePage() {
 
     return (
         <div className="min-h-screen pt-20 bg-gray-900">
-            <div className="container mx-auto px-4 pt-4">
-                <Link
-                    href="/"
-                    className="inline-flex items-center space-x-2 hover:opacity-80 transition-opacity touch-manipulation"
-                    title="Return to Homepage"
-                >
-                    <TarotAgentLogo size={32} className="text-primary-600 md:w-10 md:h-10 lg:w-12 lg:h-12" />
-                    <div>
-                        <h1 className="text-xl md:text-2xl lg:text-3xl font-mystical font-bold bg-gradient-to-r from-primary-600 to-primary-800 bg-clip-text text-transparent">
-                            ArcanaAI
-                        </h1>
-                        <p className="text-xs md:text-sm text-gray-400 -mt-1">
-                            Mystical Guidance
-                        </p>
-                    </div>
-                </Link>
-            </div>
             <div className="container mx-auto px-4 py-8">
                 <div className="max-w-4xl mx-auto">
                     {/* Header */}
                     <div className="bg-gray-800 rounded-lg shadow-md p-6 mb-6">
-                        <div className="flex items-center justify-between">
-                            <div>
-                                <h1 className="text-3xl font-bold text-white">
-                                    User Profile
-                                </h1>
-                                <p className="text-gray-400 mt-1">
-                                    Manage your account settings and preferences
-                                </p>
-                            </div>
-                            <div className="flex gap-3">
-                                <button
-                                    onClick={() => router.push('/')}
-                                    className="p-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-                                    title="Return to Homepage"
-                                >
-                                    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-                                        <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z" />
-                                    </svg>
-                                </button>
-                                <button
-                                    onClick={logout}
-                                    className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
-                                >
-                                    Logout
-                                </button>
-                            </div>
-                        </div>
+                        <h1 className="text-3xl font-bold text-white">
+                            User Profile
+                        </h1>
+                        <p className="text-gray-400 mt-1">
+                            Manage your account settings and preferences
+                        </p>
                     </div>
 
                     {/* Navigation Tabs */}

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -75,7 +75,7 @@ export default function ProfilePage() {
     }
 
     return (
-        <div className="min-h-screen bg-gray-900">
+        <div className="min-h-screen pt-20 bg-gray-900">
             <div className="container mx-auto px-4 pt-4">
                 <Link
                     href="/"

--- a/frontend/src/app/reading/compatibility/page.tsx
+++ b/frontend/src/app/reading/compatibility/page.tsx
@@ -117,7 +117,7 @@ export default function CompatibilityReadingPage() {
     };
 
     return (
-        <div className="min-h-screen bg-gradient-to-br from-gray-900 via-purple-950 to-gray-900 text-white">
+        <div className="min-h-screen pt-20 bg-gradient-to-br from-gray-900 via-purple-950 to-gray-900 text-white">
             <div className="max-w-4xl mx-auto px-4 sm:px-6 py-8">
                 <div className="flex items-center justify-between mb-6">
                     <Link href="/reading" className="inline-flex items-center gap-2 text-sm text-gray-300 hover:text-white">

--- a/frontend/src/app/reading/page.tsx
+++ b/frontend/src/app/reading/page.tsx
@@ -118,7 +118,7 @@ export default function ReadingPage() {
     };
 
     return (
-        <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-purple-900">
+        <div className="min-h-screen pt-20 bg-gradient-to-br from-gray-900 via-gray-800 to-purple-900">
             <div className="container mx-auto px-3 sm:px-4 lg:px-6 py-4 sm:py-6 lg:py-8">
                 <div className="max-w-6xl mx-auto">
                     {/* Header */}

--- a/frontend/src/components/EnhancedNavigation.tsx
+++ b/frontend/src/components/EnhancedNavigation.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 
 import { useSubscription } from '@/hooks/useSubscription';
@@ -13,11 +13,14 @@ import {
     CreditCard,
     History,
     BookOpen,
+    Library,
     LogOut,
     Crown,
     Star,
     X,
-    HelpCircle
+    HelpCircle,
+    Bell,
+    Plus,
 } from 'lucide-react';
 import {
     DropdownMenu,
@@ -29,28 +32,80 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Avatar } from '@/components/AvatarUpload';
 import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { TurnCounter, TurnCounterCompact } from '@/components/TurnCounter';
+import { TurnCounterCompact } from '@/components/TurnCounter';
 import { StreakBadge } from '@/components/StreakBadge';
 import { SubscriptionModal } from '@/components/SubscriptionModal';
 import { TarotCardIcon, TarotAgentLogo } from '@/components/icons';
 import { FiMessageCircle } from 'react-icons/fi';
 import { SupportModal } from '@/components/SupportModal';
 
+/* ── nav items ────────────────────────────────────────────── */
+const NAV_ITEMS = [
+    {
+        label: 'Reading',
+        href: '/reading',
+        Icon: TarotCardIcon,
+        match: (p: string) => p.startsWith('/reading'),
+    },
+    {
+        label: 'Journal',
+        href: '/journal',
+        Icon: BookOpen,
+        match: (p: string) => p.startsWith('/journal'),
+    },
+    {
+        label: 'Library',
+        href: '/library',
+        Icon: Library,
+        match: (p: string) => p.startsWith('/library'),
+    },
+];
+
+/* ── plan badge ───────────────────────────────────────────── */
+function PlanBadge({
+    isPremium,
+    hasUnlimited,
+    onUpgradeClick,
+}: {
+    isPremium: boolean;
+    hasUnlimited: boolean;
+    onUpgradeClick: () => void;
+}) {
+    if (hasUnlimited || isPremium) {
+        return (
+            <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-amber-400/25 bg-amber-400/8 text-xs font-semibold text-amber-200 tracking-wide select-none">
+                <Crown className="h-3 w-3 text-amber-400" aria-hidden />
+                UNLIMITED
+            </div>
+        );
+    }
+    return (
+        <button
+            onClick={onUpgradeClick}
+            className="flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-violet-400/25 bg-violet-400/8 text-xs font-semibold text-violet-200 tracking-wide hover:bg-violet-400/15 transition-colors"
+        >
+            <Crown className="h-3 w-3 text-violet-400" aria-hidden />
+            Upgrade
+        </button>
+    );
+}
+
+/* ── main component ───────────────────────────────────────── */
 export function EnhancedNavigation() {
     const router = useRouter();
+    const pathname = usePathname();
     const { user, isAuthenticated, logout } = useAuth();
-    const { isPremium, getSubscriptionStatusText } = useSubscription();
+    const { isPremium, hasUnlimitedTurns, getSubscriptionStatusText } = useSubscription();
     const { searchResults, isSearching, performSearch, clearSearch } = useSearch();
 
     const [searchQuery, setSearchQuery] = useState('');
     const [showSearchResults, setShowSearchResults] = useState(false);
     const [isSubscriptionModalOpen, setIsSubscriptionModalOpen] = useState(false);
-    const [isMobileSearchOpen, setIsMobileSearchOpen] = useState(false);
+    const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
     const [isSupportModalOpen, setIsSupportModalOpen] = useState(false);
 
-    // Debounced search
+    /* debounced search */
     useEffect(() => {
         const timer = setTimeout(() => {
             if (searchQuery.trim()) {
@@ -59,120 +114,121 @@ export function EnhancedNavigation() {
                 clearSearch();
             }
         }, 300);
-
         return () => clearTimeout(timer);
     }, [searchQuery, performSearch, clearSearch]);
 
-    // Close mobile menu on route change
+    /* close mobile menu on navigation */
     useEffect(() => {
-        setIsMobileSearchOpen(false);
-    }, [router]);
+        setIsMobileMenuOpen(false);
+    }, [pathname]);
 
-    // Handle escape key to close menus
+    /* escape key handler */
     useEffect(() => {
         const handleEscape = (e: KeyboardEvent) => {
             if (e.key === 'Escape') {
-                setIsMobileSearchOpen(false);
+                setIsMobileMenuOpen(false);
                 setShowSearchResults(false);
                 setSearchQuery('');
             }
         };
-
         document.addEventListener('keydown', handleEscape);
         return () => document.removeEventListener('keydown', handleEscape);
     }, []);
 
-    const handleSearchInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const value = e.target.value;
         setSearchQuery(value);
         setShowSearchResults(value.length > 0);
+    };
+
+    const handleSearchKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Escape') {
+            setShowSearchResults(false);
+            setSearchQuery('');
+        }
     };
 
     const handleSearchResultClick = (result: SearchResult) => {
         router.push(result.url);
         setSearchQuery('');
         setShowSearchResults(false);
-        setIsMobileSearchOpen(false);
     };
 
+    if (!isAuthenticated) return null;
 
-
-    // Handle escape key to close search results
-    const handleKeyDown = (e: React.KeyboardEvent) => {
-        if (e.key === 'Escape') {
-            setShowSearchResults(false);
-            setSearchQuery('');
-            setIsMobileSearchOpen(false);
-        }
-    };
-
-    if (!isAuthenticated) {
-        return null;
-    }
+    const isUnlimited = hasUnlimitedTurns();
+    const premium = isPremium();
 
     return (
         <>
-            <header className="sticky top-0 z-50 w-full border-b bg-gray-950/95 backdrop-blur-md border-gray-800">
-                <div className="container mx-auto px-4 md:px-6 lg:px-8 h-16 md:h-18 lg:h-20 flex items-center justify-between">
-                    {/* Logo and Brand - Mobile-first */}
-                    <div className="flex items-center space-x-2 md:space-x-3">
-                        <Link href="/" className="flex items-center space-x-2 hover:opacity-80 transition-opacity touch-manipulation">
-                            <TarotAgentLogo size={32} className="text-primary-600 md:w-10 md:h-10 lg:w-12 lg:h-12" />
-                            <div className="hidden md:block">
-                                <h1 className="text-xl md:text-2xl lg:text-3xl font-mystical font-bold bg-gradient-to-r from-primary-600 to-primary-800 bg-clip-text text-transparent">
-                                    ArcanaAI
-                                </h1>
-                                <p className="text-xs md:text-sm text-gray-400 -mt-1">
-                                    Mystical Guidance
-                                </p>
+            {/* ═══════════════════════════════════════════════════
+                TWO-TIER HEADER
+            ═══════════════════════════════════════════════════ */}
+            <header className="sticky top-0 z-50 w-full border-b border-violet-400/12 bg-[rgba(10,6,24,0.55)] backdrop-blur-md">
+
+                {/* ── TIER 1 — Utility row ─────────────────────── */}
+                <div className="flex items-center gap-4 px-4 md:px-8 py-2.5 md:py-3">
+
+                    {/* Logo */}
+                    <Link
+                        href="/"
+                        className="flex items-center gap-2.5 shrink-0 hover:opacity-85 transition-opacity"
+                    >
+                        <TarotAgentLogo size={32} className="text-violet-400 shrink-0" />
+                        <div className="hidden sm:block leading-tight">
+                            <div className="font-mystical font-semibold text-[1.2rem] bg-gradient-to-r from-violet-200 to-violet-400 bg-clip-text text-transparent tracking-[0.01em]">
+                                ArcanaAI
                             </div>
-                        </Link>
-
-                        {/* Mobile Turn Counter - positioned next to logo */}
-                        <div className="md:hidden">
-                            <TurnCounterCompact
-                                onPurchaseClick={() => setIsSubscriptionModalOpen(true)}
-                                className="scale-100"
-                            />
+                            <div className="text-[0.6rem] uppercase tracking-[0.12em] text-violet-300/60 mt-px">
+                                Mystical Guidance
+                            </div>
                         </div>
-                    </div>
+                    </Link>
 
-                    {/* Desktop Search Bar - Hidden on mobile */}
-                    <div className="hidden lg:flex flex-1 max-w-lg mx-8 relative">
+                    {/* Search — desktop */}
+                    <div className="hidden lg:flex flex-1 max-w-[520px] relative">
                         <div className="relative w-full">
-                            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
+                            <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 text-violet-300/70 w-4 h-4 pointer-events-none" />
                             <Input
                                 type="text"
-                                placeholder="Search readings, chats, journal..."
-                                className="pl-10 pr-4 py-3 bg-gray-800/50 border-gray-700 focus:border-primary-500 focus:ring-primary-500/20 text-white placeholder-gray-400"
+                                placeholder="Search readings, chats, journal…"
                                 value={searchQuery}
-                                onChange={handleSearchInputChange}
-                                onKeyDown={handleKeyDown}
+                                onChange={handleSearchChange}
+                                onKeyDown={handleSearchKeyDown}
+                                className="pl-10 pr-16 h-[34px] text-[13px] text-center bg-white/[0.04] border-violet-400/14 focus:border-violet-400/40 focus:ring-violet-400/10 text-violet-50 placeholder:text-violet-200/40 rounded-[10px]"
                             />
-                            {isSearching && (
-                                <div className="absolute right-3 top-1/2 transform -translate-y-1/2">
-                                    <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-primary-500" />
-                                </div>
-                            )}
+                            <kbd className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden sm:inline-flex items-center gap-1 rounded border border-violet-400/20 px-1.5 py-px font-mono text-[10px] text-violet-300/60">
+                                ⌘K
+                            </kbd>
                         </div>
 
-                        {/* Desktop Search Results */}
+                        {/* Search results dropdown */}
                         {showSearchResults && searchResults.length > 0 && (
-                            <div className="absolute top-full left-0 right-0 mt-2 bg-gray-900 border border-gray-700 rounded-lg shadow-xl z-50 max-h-96 overflow-y-auto">
+                            <div className="absolute top-full left-0 right-0 mt-2 bg-gray-900 border border-violet-400/20 rounded-xl shadow-2xl z-50 max-h-80 overflow-y-auto">
                                 {searchResults.map((result, index) => (
                                     <button
                                         key={index}
                                         onClick={() => handleSearchResultClick(result)}
-                                        className="w-full px-4 py-3 text-left hover:bg-gray-800 border-b border-gray-700 last:border-b-0 transition-colors"
+                                        className="w-full px-4 py-3 text-left hover:bg-violet-400/8 border-b border-violet-400/10 last:border-b-0 transition-colors"
                                     >
                                         <div className="flex items-center gap-3">
-                                            {result.type === 'chat' && <FiMessageCircle className="w-4 h-4 text-primary-500" />}
-                                            {result.type === 'shared' && <Star className="w-4 h-4 text-accent-500" />}
-                                            {result.type === 'journal' && <BookOpen className="w-4 h-4 text-green-500" />}
+                                            {result.type === 'chat' && (
+                                                <FiMessageCircle className="w-4 h-4 text-violet-400 shrink-0" />
+                                            )}
+                                            {result.type === 'shared' && (
+                                                <Star className="w-4 h-4 text-amber-400 shrink-0" />
+                                            )}
+                                            {result.type === 'journal' && (
+                                                <BookOpen className="w-4 h-4 text-emerald-400 shrink-0" />
+                                            )}
                                             <div>
-                                                <div className="text-white font-medium">{result.title}</div>
+                                                <div className="text-sm font-medium text-violet-50">
+                                                    {result.title}
+                                                </div>
                                                 {result.content && (
-                                                    <div className="text-gray-400 text-sm mt-1 line-clamp-2">{result.content}</div>
+                                                    <div className="text-xs text-violet-200/55 mt-0.5 line-clamp-1">
+                                                        {result.content}
+                                                    </div>
                                                 )}
                                             </div>
                                         </div>
@@ -182,220 +238,275 @@ export function EnhancedNavigation() {
                         )}
                     </div>
 
-                    {/* Actions - Mobile-first layout */}
-                    <div className="flex items-center space-x-2 md:space-x-3">
-                        {/* Streak Badge */}
+                    {/* Right cluster — desktop */}
+                    <div className="flex items-center gap-2 ml-auto">
+                        {/* Streak */}
                         <StreakBadge />
 
-                        {/* Turn Counter - Desktop/Tablet */}
+                        {/* Plan badge — desktop */}
                         <div className="hidden md:block">
-                            <TurnCounter
-                                onPurchaseClick={() => setIsSubscriptionModalOpen(true)}
-                                showDetails={false}
+                            <PlanBadge
+                                isPremium={premium}
+                                hasUnlimited={isUnlimited}
+                                onUpgradeClick={() => setIsSubscriptionModalOpen(true)}
                             />
                         </div>
 
-                        {/* Quick Actions - Tablet and Desktop */}
-                        <div className="hidden lg:flex items-center space-x-2">
-                            <Button variant="ghost" size="sm" asChild className="text-gray-300 hover:text-white hover:bg-gray-800 px-4 py-3 touch-manipulation">
-                                <Link href="/reading">
-                                    <TarotCardIcon size={18} className="mr-2" />
-                                    Reading
-                                </Link>
-                            </Button>
-                            <Button variant="ghost" size="sm" asChild className="text-gray-300 hover:text-white hover:bg-gray-800 px-4 py-3 touch-manipulation">
-                                <Link href="/journal">
-                                    <BookOpen className="w-5 h-5 mr-2" />
-                                    Journal
-                                </Link>
-                            </Button>
+                        {/* Turn counter — fallback for free tier on mobile */}
+                        <div className="md:hidden">
+                            <TurnCounterCompact
+                                onPurchaseClick={() => setIsSubscriptionModalOpen(true)}
+                            />
                         </div>
 
-                        {/* User Menu - Mobile-optimized */}
-                        {isAuthenticated && user ? (
+                        {/* Bell — desktop */}
+                        <button
+                            className="hidden lg:grid h-8 w-8 place-items-center rounded-lg text-violet-300/70 hover:text-violet-200 hover:bg-violet-400/8 transition-colors"
+                            aria-label="Notifications"
+                        >
+                            <Bell className="h-4 w-4" />
+                        </button>
+
+                        {/* Avatar + user dropdown */}
+                        {user ? (
                             <DropdownMenu>
                                 <DropdownMenuTrigger asChild>
-                                    <button className="flex items-center space-x-2 p-2 md:p-3 rounded-xl hover:bg-gray-800 transition-colors touch-manipulation">
-                                        <div className="flex items-center space-x-2">
-                                            <Avatar
-                                                src={user.avatar_url}
-                                                username={user.username || user.email}
-                                                size="md"
-                                                className="ring-2 ring-primary-500/20"
-                                            />
-                                            <div className="hidden md:block text-left">
-                                                <div className="text-sm font-medium text-white truncate max-w-[120px]">
-                                                    {user.username || user.email}
-                                                </div>
-                                                <div className="text-xs text-gray-400">
-                                                    {getSubscriptionStatusText()}
-                                                </div>
+                                    <button className="flex items-center gap-2 rounded-xl px-1.5 py-1 hover:bg-violet-400/8 transition-colors">
+                                        <Avatar
+                                            src={user.avatar_url}
+                                            username={user.username || user.email}
+                                            size="sm"
+                                            className="ring-2 ring-violet-400/20"
+                                        />
+                                        <div className="hidden md:block text-left leading-tight">
+                                            <div className="text-[12.5px] font-medium text-violet-50 truncate max-w-[120px]">
+                                                {user.username || user.email}
+                                            </div>
+                                            <div className="text-[10px] text-violet-300/55">
+                                                Settings
                                             </div>
                                         </div>
                                     </button>
                                 </DropdownMenuTrigger>
-                                <DropdownMenuContent align="end" className="w-64 bg-gray-900 border-gray-700">
+
+                                <DropdownMenuContent align="end" className="w-64 bg-gray-900 border-violet-400/20">
                                     <DropdownMenuLabel className="px-4 py-3">
-                                        <div className="flex flex-col space-y-1">
-                                            <p className="text-base font-medium text-white leading-none">
+                                        <div className="flex flex-col gap-1">
+                                            <p className="text-sm font-medium text-white leading-none">
                                                 {user.username || 'Mystical Seeker'}
                                             </p>
-                                            <p className="text-sm text-gray-400 leading-none">
+                                            <p className="text-xs text-violet-300/60 leading-none">
                                                 {user.email}
                                             </p>
-                                            <Badge variant={isPremium() ? 'default' : 'secondary'} className="mt-2 w-fit">
-                                                {isPremium() ? (
-                                                    <><Crown className="w-3 h-3 mr-1" /> Premium</>
+                                            <Badge
+                                                variant={premium ? 'default' : 'secondary'}
+                                                className="mt-1.5 w-fit"
+                                            >
+                                                {premium ? (
+                                                    <><Crown className="w-3 h-3 mr-1" />Premium</>
                                                 ) : (
-                                                    <><Star className="w-3 h-3 mr-1" /> Free</>
+                                                    <><Star className="w-3 h-3 mr-1" />Free</>
                                                 )}
                                             </Badge>
                                         </div>
                                     </DropdownMenuLabel>
-                                    <DropdownMenuSeparator className="bg-gray-700" />
+                                    <DropdownMenuSeparator className="bg-violet-400/15" />
 
-                                    {/* Mobile Quick Actions */}
+                                    {/* Mobile quick nav */}
                                     <div className="lg:hidden">
-                                        <DropdownMenuItem asChild className="px-4 py-3 text-base">
-                                            <Link href="/reading" className="flex items-center">
-                                                <TarotCardIcon size={20} className="mr-3" />
+                                        {NAV_ITEMS.map(({ label, href, Icon }) => (
+                                            <DropdownMenuItem key={label} asChild className="px-4 py-3">
+                                                <Link href={href} className="flex items-center gap-3">
+                                                    <Icon size={18} className="text-violet-400" />
+                                                    {label}
+                                                </Link>
+                                            </DropdownMenuItem>
+                                        ))}
+                                        <DropdownMenuItem asChild className="px-4 py-3">
+                                            <Link href="/reading" className="flex items-center gap-3">
+                                                <Plus className="w-4 h-4 text-violet-400" />
                                                 New Reading
                                             </Link>
                                         </DropdownMenuItem>
-                                        <DropdownMenuItem asChild className="px-4 py-3 text-base">
-                                            <Link href="/journal" className="flex items-center">
-                                                <BookOpen className="w-5 h-5 mr-3" />
-                                                Journal
-                                            </Link>
-                                        </DropdownMenuItem>
-                                        <DropdownMenuSeparator className="bg-gray-700" />
+                                        <DropdownMenuSeparator className="bg-violet-400/15" />
                                     </div>
 
-                                    <DropdownMenuItem asChild className="px-4 py-3 text-base">
-                                        <Link href="/profile" className="flex items-center">
-                                            <Settings className="w-5 h-5 mr-3" />
+                                    <DropdownMenuItem asChild className="px-4 py-3">
+                                        <Link href="/profile" className="flex items-center gap-3">
+                                            <Settings className="w-4 h-4" />
                                             Profile Settings
                                         </Link>
                                     </DropdownMenuItem>
 
-                                    {!isPremium() && (
+                                    {!premium && (
                                         <DropdownMenuItem
                                             onClick={() => setIsSubscriptionModalOpen(true)}
-                                            className="px-4 py-3 text-base cursor-pointer"
+                                            className="px-4 py-3 cursor-pointer"
                                         >
-                                            <CreditCard className="w-5 h-5 mr-3" />
+                                            <CreditCard className="w-4 h-4 mr-3" />
                                             Upgrade to Premium
                                         </DropdownMenuItem>
                                     )}
 
                                     <DropdownMenuItem
                                         onClick={() => setIsSupportModalOpen(true)}
-                                        className="px-4 py-3 text-base cursor-pointer"
+                                        className="px-4 py-3 cursor-pointer"
                                     >
-                                        <HelpCircle className="w-5 h-5 mr-3" />
+                                        <HelpCircle className="w-4 h-4 mr-3" />
                                         Support
                                     </DropdownMenuItem>
 
-                                    <DropdownMenuItem asChild className="px-4 py-3 text-base">
-                                        <Link href="/onboarding" className="flex items-center">
-                                            <Star className="w-5 h-5 mr-3" />
+                                    <DropdownMenuItem asChild className="px-4 py-3">
+                                        <Link href="/onboarding" className="flex items-center gap-3">
+                                            <Star className="w-4 h-4" />
                                             Take the Tour
                                         </Link>
                                     </DropdownMenuItem>
 
-                                    <DropdownMenuItem asChild className="px-4 py-3 text-base">
-                                        <Link href="/" className="flex items-center">
-                                            <History className="w-5 h-5 mr-3" />
+                                    <DropdownMenuItem asChild className="px-4 py-3">
+                                        <Link href="/" className="flex items-center gap-3">
+                                            <History className="w-4 h-4" />
                                             Reading History
                                         </Link>
                                     </DropdownMenuItem>
 
                                     {user.is_admin && (
                                         <>
-                                            <DropdownMenuSeparator className="bg-gray-700" />
-                                            <DropdownMenuItem asChild className="px-4 py-3 text-base">
-                                                <Link href="/admin" className="flex items-center text-accent-400">
-                                                    <Crown className="w-5 h-5 mr-3" />
+                                            <DropdownMenuSeparator className="bg-violet-400/15" />
+                                            <DropdownMenuItem asChild className="px-4 py-3">
+                                                <Link href="/admin" className="flex items-center gap-3 text-amber-400">
+                                                    <Crown className="w-4 h-4" />
                                                     Admin Panel
                                                 </Link>
                                             </DropdownMenuItem>
                                         </>
                                     )}
 
-                                    <DropdownMenuSeparator className="bg-gray-700" />
+                                    <DropdownMenuSeparator className="bg-violet-400/15" />
                                     <DropdownMenuItem
                                         onClick={logout}
-                                        className="px-4 py-3 text-base text-red-400 hover:text-red-300 hover:bg-red-900/20 cursor-pointer"
+                                        className="px-4 py-3 text-red-400 hover:text-red-300 hover:bg-red-900/20 cursor-pointer"
                                     >
-                                        <LogOut className="w-5 h-5 mr-3" />
+                                        <LogOut className="w-4 h-4 mr-3" />
                                         Sign Out
                                     </DropdownMenuItem>
                                 </DropdownMenuContent>
                             </DropdownMenu>
                         ) : (
-                            <div className="flex items-center space-x-2">
-                                <Button variant="ghost" size="sm" asChild className="text-gray-300 hover:text-white hover:bg-gray-800 px-4 py-3 touch-manipulation">
-                                    <Link href="/login">Sign In</Link>
-                                </Button>
-                                <Button size="sm" asChild className="bg-primary-600 hover:bg-primary-700 px-4 py-3 touch-manipulation">
-                                    <Link href="/register">Get Started</Link>
-                                </Button>
+                            <div className="flex items-center gap-2">
+                                <Link
+                                    href="/login"
+                                    className="text-sm text-violet-200/70 hover:text-violet-100 px-3 py-1.5 rounded-lg hover:bg-violet-400/8 transition-colors"
+                                >
+                                    Sign In
+                                </Link>
+                                <Link
+                                    href="/register"
+                                    className="text-sm font-medium bg-violet-600 hover:bg-violet-500 text-white px-3 py-1.5 rounded-lg transition-colors"
+                                >
+                                    Get Started
+                                </Link>
                             </div>
                         )}
                     </div>
                 </div>
+
+                {/* ── TIER 2 — Navigation tabs (desktop only) ──── */}
+                <div className="hidden lg:flex items-end gap-4 px-8 border-t border-violet-400/8">
+                    {NAV_ITEMS.map(({ label, href, Icon, match }) => {
+                        const active = match(pathname ?? '');
+                        return (
+                            <Link
+                                key={label}
+                                href={href}
+                                className={`relative flex items-center gap-2 px-4 pt-2.5 pb-3 text-[15px] font-medium transition-colors ${
+                                    active
+                                        ? 'text-violet-50'
+                                        : 'text-violet-200/60 hover:text-violet-200/90'
+                                }`}
+                            >
+                                <Icon
+                                    size={16}
+                                    className={active ? 'text-violet-400' : 'text-violet-300/55'}
+                                />
+                                {label}
+                                {active && (
+                                    <span
+                                        aria-hidden
+                                        className="absolute bottom-0 left-2.5 right-2.5 h-0.5 rounded-full"
+                                        style={{
+                                            background:
+                                                'linear-gradient(90deg, transparent, #a78bfa 30%, #a78bfa 70%, transparent)',
+                                        }}
+                                    />
+                                )}
+                            </Link>
+                        );
+                    })}
+
+                </div>
             </header>
 
-            {/* Mobile Search Overlay - Full screen for better mobile UX */}
-            {isMobileSearchOpen && (
+            {/* ═══════════════════════════════════════════════════
+                MOBILE SEARCH OVERLAY
+            ═══════════════════════════════════════════════════ */}
+            {isMobileMenuOpen && (
                 <div className="lg:hidden fixed inset-0 z-[100] bg-gray-950/98 backdrop-blur-md">
                     <div className="flex flex-col h-full">
-                        {/* Mobile Search Header */}
-                        <div className="flex items-center gap-4 p-4 border-b border-gray-800">
+                        <div className="flex items-center gap-4 p-4 border-b border-violet-400/15">
                             <button
-                                onClick={() => setIsMobileSearchOpen(false)}
-                                className="p-3 rounded-xl hover:bg-gray-800 transition-colors touch-manipulation"
+                                onClick={() => setIsMobileMenuOpen(false)}
+                                className="p-2.5 rounded-xl hover:bg-violet-400/8 transition-colors"
                                 aria-label="Close search"
                             >
-                                <X className="w-6 h-6 text-gray-300" />
+                                <X className="w-5 h-5 text-violet-200" />
                             </button>
                             <div className="flex-1 relative">
-                                <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 text-gray-400 w-6 h-6" />
+                                <Search className="absolute left-4 top-1/2 -translate-y-1/2 text-violet-300/60 w-5 h-5" />
                                 <Input
                                     type="text"
-                                    placeholder="Search readings, chats, journal..."
-                                    className="pl-12 pr-4 py-4 text-lg bg-gray-800/50 border-gray-700 focus:border-primary-500 focus:ring-primary-500/20 text-white placeholder-gray-400 rounded-2xl"
+                                    placeholder="Search readings, chats, journal…"
+                                    className="pl-11 pr-4 py-3.5 text-base bg-violet-400/6 border-violet-400/20 focus:border-violet-400/45 text-white placeholder:text-violet-300/50 rounded-2xl"
                                     value={searchQuery}
-                                    onChange={handleSearchInputChange}
-                                    onKeyDown={handleKeyDown}
+                                    onChange={handleSearchChange}
+                                    onKeyDown={handleSearchKeyDown}
                                     autoFocus
                                 />
                                 {isSearching && (
-                                    <div className="absolute right-4 top-1/2 transform -translate-y-1/2">
-                                        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary-500" />
+                                    <div className="absolute right-4 top-1/2 -translate-y-1/2">
+                                        <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-violet-400" />
                                     </div>
                                 )}
                             </div>
                         </div>
 
-                        {/* Mobile Search Results */}
                         <div className="flex-1 overflow-y-auto">
                             {searchResults.length > 0 ? (
-                                <div className="p-4 space-y-3">
+                                <div className="p-4 space-y-2.5">
                                     {searchResults.map((result, index) => (
                                         <button
                                             key={index}
                                             onClick={() => handleSearchResultClick(result)}
-                                            className="w-full p-4 text-left bg-gray-800/50 hover:bg-gray-800 rounded-xl border border-gray-700 transition-colors touch-manipulation"
+                                            className="w-full p-4 text-left bg-violet-400/6 hover:bg-violet-400/12 rounded-xl border border-violet-400/14 transition-colors"
                                         >
-                                            <div className="flex items-center gap-4">
-                                                {result.type === 'chat' && <FiMessageCircle className="w-6 h-6 text-primary-500 flex-shrink-0" />}
-                                                {result.type === 'shared' && <Star className="w-6 h-6 text-accent-500 flex-shrink-0" />}
-                                                {result.type === 'journal' && <BookOpen className="w-6 h-6 text-green-500 flex-shrink-0" />}
+                                            <div className="flex items-center gap-3">
+                                                {result.type === 'chat' && (
+                                                    <FiMessageCircle className="w-5 h-5 text-violet-400 shrink-0" />
+                                                )}
+                                                {result.type === 'shared' && (
+                                                    <Star className="w-5 h-5 text-amber-400 shrink-0" />
+                                                )}
+                                                {result.type === 'journal' && (
+                                                    <BookOpen className="w-5 h-5 text-emerald-400 shrink-0" />
+                                                )}
                                                 <div className="flex-1 min-w-0">
-                                                    <div className="text-white font-medium text-base truncate">{result.title}</div>
+                                                    <div className="text-white font-medium text-sm truncate">
+                                                        {result.title}
+                                                    </div>
                                                     {result.content && (
-                                                        <div className="text-gray-400 text-sm mt-1 line-clamp-2">{result.content}</div>
+                                                        <div className="text-violet-200/55 text-xs mt-0.5 line-clamp-2">
+                                                            {result.content}
+                                                        </div>
                                                     )}
                                                 </div>
                                             </div>
@@ -404,34 +515,38 @@ export function EnhancedNavigation() {
                                 </div>
                             ) : searchQuery ? (
                                 <div className="flex flex-col items-center justify-center h-full text-center p-8">
-                                    <Search className="w-16 h-16 text-gray-600 mb-4" />
-                                    <h3 className="text-xl font-medium text-white mb-2">No results found</h3>
-                                    <p className="text-gray-400">Try searching with different keywords</p>
+                                    <Search className="w-12 h-12 text-violet-400/30 mb-4" />
+                                    <h3 className="text-lg font-medium text-white mb-2">No results found</h3>
+                                    <p className="text-violet-200/55 text-sm">Try different keywords</p>
                                 </div>
                             ) : (
                                 <div className="p-4">
-                                    <h3 className="text-lg font-medium text-white mb-4">Quick Access</h3>
-                                    <div className="space-y-3">
+                                    <h3 className="text-sm font-medium text-violet-200/70 uppercase tracking-widest mb-4">
+                                        Quick Access
+                                    </h3>
+                                    <div className="space-y-2.5">
+                                        {NAV_ITEMS.map(({ label, href, Icon }) => (
+                                            <Link
+                                                key={label}
+                                                href={href}
+                                                onClick={() => setIsMobileMenuOpen(false)}
+                                                className="flex items-center gap-3 p-4 bg-violet-400/6 rounded-xl border border-violet-400/14 hover:bg-violet-400/12 transition-colors"
+                                            >
+                                                <Icon size={20} className="text-violet-400 shrink-0" />
+                                                <div>
+                                                    <div className="text-white font-medium">{label}</div>
+                                                </div>
+                                            </Link>
+                                        ))}
                                         <Link
                                             href="/reading"
-                                            onClick={() => setIsMobileSearchOpen(false)}
-                                            className="flex items-center gap-4 p-4 bg-gray-800/50 rounded-xl border border-gray-700 hover:bg-gray-800 transition-colors touch-manipulation"
+                                            onClick={() => setIsMobileMenuOpen(false)}
+                                            className="flex items-center gap-3 p-4 bg-violet-400/10 rounded-xl border border-violet-400/25 hover:bg-violet-400/18 transition-colors"
                                         >
-                                            <TarotCardIcon size={24} className="text-primary-500" />
+                                            <Plus className="w-5 h-5 text-violet-300 shrink-0" />
                                             <div>
                                                 <div className="text-white font-medium">New Reading</div>
-                                                <div className="text-gray-400 text-sm">Get mystical guidance</div>
-                                            </div>
-                                        </Link>
-                                        <Link
-                                            href="/journal"
-                                            onClick={() => setIsMobileSearchOpen(false)}
-                                            className="flex items-center gap-4 p-4 bg-gray-800/50 rounded-xl border border-gray-700 hover:bg-gray-800 transition-colors touch-manipulation"
-                                        >
-                                            <BookOpen className="w-6 h-6 text-green-500" />
-                                            <div>
-                                                <div className="text-white font-medium">Journal</div>
-                                                <div className="text-gray-400 text-sm">Track your insights</div>
+                                                <div className="text-violet-200/55 text-sm">Get mystical guidance</div>
                                             </div>
                                         </Link>
                                     </div>

--- a/frontend/src/components/StreakBadge.tsx
+++ b/frontend/src/components/StreakBadge.tsx
@@ -49,13 +49,16 @@ export function StreakBadge() {
             href="/profile?tab=achievements"
             title={title}
             aria-label={title}
-            className={`inline-flex items-center gap-1 rounded-full border border-amber-400/40 px-2 py-1 text-xs font-medium transition-colors ${
+            className={`inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm font-bold transition-all min-w-[72px] justify-center ${
                 isDim
-                    ? 'bg-amber-400/5 text-amber-300/70 hover:text-amber-200'
-                    : 'bg-amber-400/15 text-amber-300 hover:bg-amber-400/25'
+                    ? 'border-amber-500/30 bg-amber-500/8 text-amber-400/60 hover:text-amber-300'
+                    : 'border-amber-400/60 bg-gradient-to-r from-amber-500/20 to-orange-500/20 text-amber-300 hover:from-amber-500/30 hover:to-orange-500/30 shadow-[0_0_10px_rgba(251,146,60,0.25)]'
             }`}
         >
-            <Flame className={`h-3.5 w-3.5 ${isDim ? 'opacity-60' : ''}`} aria-hidden />
+            <Flame
+                className={`h-5 w-5 ${isDim ? 'opacity-50' : 'text-orange-400 drop-shadow-[0_0_4px_rgba(251,146,60,0.7)]'}`}
+                aria-hidden
+            />
             <span>{streak.current_streak}</span>
         </Link>
     );


### PR DESCRIPTION
### Motivation
The previous single-row header was crowded — logo, search, plan badge, nav links, and account all competing for the same horizontal space, giving users no clear visual hierarchy. This PR replaces it with a spacious two-tier design and cleans up pages that were rendering redundant UI now covered by the global header.

### Changes

#### Header redesign — `EnhancedNavigation.tsx`, `StreakBadge.tsx`
- **Two-tier layout**: top row holds utility items (logo → search → streak → plan badge → bell → avatar/settings); bottom row holds navigation tabs (Reading · Journal · Library) with an active-route underline indicator driven by `usePathname()`.
- **Search bar**: centered placeholder text, properly padded to avoid icon overlap, capped at `max-w-[520px]`.
- **Streak badge**: larger flame icon (`h-5 w-5`), wider pill (`min-w-[72px]`), warm amber-to-orange gradient with glow shadow when active; dims gracefully on broken streak.
- **Plan badge**: gold `UNLIMITED` crown pill for premium/unlimited users; purple `Upgrade` CTA for free tier.
- **Nav tabs**: increased font size to `15px`, icon size to 16, wider spacing (`gap-4`) between Reading / Journal / Library.
- **Mobile**: single utility row collapses nav into the avatar dropdown; mobile search overlay retained.

#### Auto-scroll fix — `page.tsx` (home/reading)
- `scrollToBottom()` now only fires when `messages.length > 0 || streamingContent`, preventing the page from jumping to the bottom on initial load with an empty session.

#### Profile page cleanup — `profile/page.tsx`
- Removed the redundant ArcanaAI logo block (duplicated the global header logo).
- Removed the Home (🏠) button and the Logout button from the profile card header — both actions are now accessible via the avatar dropdown in the global header.
- Cleaned up unused imports (`Link`, `TarotAgentLogo`, `useRouter`) and destructured values.

#### Library page fix — `library/page.tsx`
- Removed the inline `<EnhancedNavigation />` render that was producing a duplicate header; the root layout already mounts it globally.

#### Merge conflict resolution — `EnhancedNavigation.tsx`
- Resolved three conflict blocks after merging `main`: kept `Bell` + `Plus` imports, kept mobile `TurnCounterCompact`, kept HEAD's dropdown separator (main's duplicate nav items were already covered by the `NAV_ITEMS` loop).

### Testing
- `tsc --noEmit` passes with zero errors.
- `next build` completes cleanly across all routes.
- Visually verified header on `/`, `/reading`, `/journal`, `/library`, and `/profile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)