### PR TITLE
ci: harden VPS deploy pipeline with immutable image tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,9 @@ jobs:
         with:
           context: ./backend
           push: true
-          tags: vanloc1808/tarot-backend:latest
+          tags: |
+            vanloc1808/tarot-backend:latest
+            vanloc1808/tarot-backend:${{ github.sha }}
           cache-from: type=registry,ref=vanloc1808/tarot-backend:buildcache
           cache-to: type=registry,ref=vanloc1808/tarot-backend:buildcache,mode=max
 
@@ -196,6 +198,8 @@ jobs:
         with:
           context: ./frontend
           push: true
-          tags: vanloc1808/tarot-frontend:latest
+          tags: |
+            vanloc1808/tarot-frontend:latest
+            vanloc1808/tarot-frontend:${{ github.sha }}
           cache-from: type=registry,ref=vanloc1808/tarot-frontend:buildcache
           cache-to: type=registry,ref=vanloc1808/tarot-frontend:buildcache,mode=max

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,64 +9,53 @@ on:
 
 env:
   PROJECT_DIR: ${{ secrets.VPS_PROJECT_DIR }}
+  COMPOSE_FILE: docker-compose.prod.yaml
+  IMAGE_TAG: ${{ github.event.workflow_run.head_sha }}
 
 jobs:
   deploy:
     runs-on: self-hosted
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Deploy application
         run: |
           set -e
           cd ${{ env.PROJECT_DIR }}
+
+          # Refresh the prod compose file from the repo (app code rides in the image)
           git fetch origin
           git checkout main
           git pull origin main
 
-          # Stop existing services
-          docker compose down --remove-orphans
-          docker rm -f tarot-backend tarot-frontend tarot-redis tarot-celery-worker tarot-celery-beat tarot-prometheus tarot-grafana tarot-cadvisor tarot-node-exporter || true
-          docker rmi vanloc1808/tarot-backend:latest vanloc1808/tarot-frontend:latest || true
+          export IMAGE_TAG="${IMAGE_TAG}"
+          echo "Deploying image tag: ${IMAGE_TAG}"
 
-          # Pull latest images
-          docker compose pull
+          # Pull the exact images built by CI for this commit
+          docker compose -f "${COMPOSE_FILE}" pull
 
-          # Start services
-          docker compose up -d
+          # Rolling update: only services with a changed image are recreated
+          docker compose -f "${COMPOSE_FILE}" up -d
 
-          # Wait for backend to be ready
+      - name: Run database migrations
+        run: |
+          set -e
+          cd ${{ env.PROJECT_DIR }}
           echo "Waiting for backend to be ready..."
           sleep 30
+          echo "Running database migrations..."
+          docker compose -f "${COMPOSE_FILE}" exec -T backend python migrate.py
+          echo "Database migrations completed successfully"
 
-          # Run database migrations if backend is running
-          if docker ps | grep -q tarot-backend; then
-            echo "Running database migrations..."
-            if docker exec tarot-backend python migrate.py; then
-              echo "Database migrations completed successfully"
-            else
-              echo "Warning: Database migrations failed, but continuing deployment"
-              echo "You may need to run migrations manually or check the backend logs"
-              echo "Checking backend logs for errors..."
-              docker logs tarot-backend --tail 50 || echo "Could not retrieve backend logs"
-            fi
-          else
-            echo "Backend not running, skipping migrations"
-            echo "Warning: Database migrations were not run. Check backend status."
-          fi
-
-          # Health check after deployment
-          echo "Performing health checks..."
+      - name: Health check
+        run: |
+          cd ${{ env.PROJECT_DIR }}
           echo "Service status:"
-          docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
-
-          # Check if services are responding
-          if docker ps | grep -q tarot-backend; then
-            echo "Backend container is running"
-            echo "Checking backend health endpoint..."
-            sleep 10  # Give backend time to fully start
-            if curl -f http://localhost:8000/health; then
-              echo "Backend health check passed"
-            else
-              echo "Warning: Backend health check failed"
-            fi
+          docker compose -f "${COMPOSE_FILE}" ps
+          echo "Checking backend health endpoint..."
+          sleep 10
+          if curl -f http://localhost:8000/health; then
+            echo "Backend health check passed"
+          else
+            echo "Warning: Backend health check failed"
           fi

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,0 +1,91 @@
+services:
+  backend:
+    image: vanloc1808/tarot-backend:${IMAGE_TAG:-latest}
+    container_name: tarot-backend
+    env_file:
+      - ./backend/.env
+    volumes:
+      - ./user-avatars:/avatar
+    depends_on:
+      - redis
+    restart: always
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.tarot-backend.rule=Host(`backend-tarotreader.nguyenvanloc.com`) || Host(`backend-arcanaai.nguyenvanloc.com`)"
+      - "traefik.http.routers.tarot-backend.entrypoints=websecure"
+      - "traefik.http.routers.tarot-backend.tls=true"
+      - "traefik.http.services.tarot-backend.loadbalancer.server.port=8000"
+    networks:
+      - localnet
+
+  frontend:
+    image: vanloc1808/tarot-frontend:${IMAGE_TAG:-latest}
+    container_name: tarot-frontend
+    restart: always
+    env_file:
+      - ./frontend/.env
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.tarot-frontend.rule=Host(`tarot-reader.nguyenvanloc.com`) || Host(`arcanaai.nguyenvanloc.com`)"
+      - "traefik.http.routers.tarot-frontend.entrypoints=websecure"
+      - "traefik.http.routers.tarot-frontend.tls=true"
+      - "traefik.http.services.tarot-frontend.loadbalancer.server.port=3000"
+    networks:
+      - localnet
+
+  redis:
+    image: redis:7-alpine
+    container_name: tarot-redis
+    volumes:
+      - redis_data:/data
+    restart: always
+    command: redis-server --appendonly yes
+    networks:
+      - localnet
+
+  celery-worker:
+    image: vanloc1808/tarot-backend:${IMAGE_TAG:-latest}
+    container_name: tarot-celery-worker
+    env_file:
+      - ./backend/.env
+    volumes:
+      - ./user-avatars:/avatar
+    depends_on:
+      - redis
+      - backend
+    restart: always
+    command: >
+      bash -c "source .venv/bin/activate &&
+               /app/wait-for-it.sh tarot-redis:6379 --timeout=60 --strict -- echo 'Redis is up' &&
+               cd /app &&
+               PYTHONPATH=/app celery -A celery_app worker --loglevel=info --queues=email,notifications,celery"
+    networks:
+      - localnet
+
+  celery-beat:
+    image: vanloc1808/tarot-backend:${IMAGE_TAG:-latest}
+    container_name: tarot-celery-beat
+    env_file:
+      - ./backend/.env
+    volumes:
+      - ./user-avatars:/avatar
+      - celery_beat_data:/app/celerybeat-schedule
+    depends_on:
+      - redis
+      - backend
+    restart: always
+    command: >
+      bash -c "source .venv/bin/activate &&
+              /app/wait-for-it.sh tarot-redis:6379 --timeout=60 --strict -- echo 'Redis is up' &&
+              cd /app &&
+              PYTHONPATH=/app celery -A celery_app beat --loglevel=info --schedule=/app/celerybeat-schedule"
+    networks:
+      - localnet
+
+volumes:
+  redis_data:
+  celery_beat_data:
+
+networks:
+  localnet:
+    external: true


### PR DESCRIPTION
Separate the dev compose from the deploy unit and make the push-based
deploy safe:

- Tag CI images with the git SHA (plus latest) so prod pulls an exact,
  rollback-able version instead of a mutable latest tag.
- Add docker-compose.prod.yaml that references images only (no host-side
  builds) and reuses the backend image for the Celery worker/beat.
- Guard the deploy job on CI success (conclusion == 'success') so a red
  build can no longer ship to production.
- Pin the deploy to the commit CI built via workflow_run.head_sha.
- Replace the down/rmi/up teardown with a rolling pull + up to avoid
  full-stack downtime on every deploy.
- Fail the deploy when database migrations fail instead of warning and
  continuing.

https://claude.ai/code/session_017TPquD8NuSzuttA9hjc2B1