### PR TITLE
fix(deploy): activate venv before running migrate.py in container

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -45,7 +45,7 @@ jobs:
           sleep 30
           echo "Running database migrations..."
           docker compose -f "${COMPOSE_FILE}" exec -T backend \
-            bash -c "source /app/.venv/bin/activate && python migrate.py"
+            uv run python migrate.py
           echo "Database migrations completed successfully"
 
       - name: Health check

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -44,7 +44,8 @@ jobs:
           echo "Waiting for backend to be ready..."
           sleep 30
           echo "Running database migrations..."
-          docker compose -f "${COMPOSE_FILE}" exec -T backend python migrate.py
+          docker compose -f "${COMPOSE_FILE}" exec -T backend \
+            bash -c "source /app/.venv/bin/activate && python migrate.py"
           echo "Database migrations completed successfully"
 
       - name: Health check


### PR DESCRIPTION
The backend image installs all dependencies in a uv venv at /app/.venv.
Calling 'python migrate.py' via 'docker compose exec' used the bare system
Python which has no alembic/sqlalchemy, causing the migration step to fail
with exit code 1.

Fix: wrap the command in 'bash -c "source /app/.venv/bin/activate && python migrate.py"'
so the correct interpreter and packages are used.

https://claude.ai/code/session_01Nxt5pD9Q8AvJaW6sqQnrGH