### PR TITLE
Add pagination to chat sessions endpoint

### DIFF
--- a/backend/migrations/versions/20260524_000000_a6b7c8d9e0f1_add_chat_sessions_user_created_idx.py
+++ b/backend/migrations/versions/20260524_000000_a6b7c8d9e0f1_add_chat_sessions_user_created_idx.py
@@ -1,0 +1,41 @@
+"""add composite index on chat_sessions (user_id, created_at)
+
+Revision ID: a6b7c8d9e0f1
+Revises: e5f6a7b8c9d0
+Create Date: 2026-05-24 00:00:00.000000+00:00
+
+The GET /chat/sessions/ endpoint filters by ``user_id`` and orders by
+``created_at`` descending. Only single-column indexes existed, forcing a
+separate sort step over all of a user's rows. This composite index lets the
+database return the rows already ordered.
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+from alembic import op
+from sqlalchemy import inspect as sa_inspect
+
+revision: str = "a6b7c8d9e0f1"
+down_revision: Union[str, None] = "e5f6a7b8c9d0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+INDEX_NAME = "ix_chat_sessions_user_id_created_at"
+TABLE_NAME = "chat_sessions"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa_inspect(bind)
+    existing = {idx["name"] for idx in inspector.get_indexes(TABLE_NAME)}
+    if INDEX_NAME not in existing:
+        op.create_index(INDEX_NAME, TABLE_NAME, ["user_id", "created_at"], unique=False)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa_inspect(bind)
+    existing = {idx["name"] for idx in inspector.get_indexes(TABLE_NAME)}
+    if INDEX_NAME in existing:
+        op.drop_index(INDEX_NAME, table_name=TABLE_NAME)

--- a/backend/models.py
+++ b/backend/models.py
@@ -3,7 +3,7 @@ import uuid
 from datetime import UTC
 
 from passlib.context import CryptContext
-from sqlalchemy import JSON, Boolean, CheckConstraint, Column, Date, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy import JSON, Boolean, CheckConstraint, Column, Date, DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
@@ -186,6 +186,9 @@ class ChatSession(Base):
     """
 
     __tablename__ = "chat_sessions"
+    # Composite index backing the session-list query, which filters by user_id
+    # and orders by created_at DESC.
+    __table_args__ = (Index("ix_chat_sessions_user_id_created_at", "user_id", "created_at"),)
 
     id = Column(Integer, primary_key=True, index=True)
     title = Column(String)

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -3,7 +3,7 @@ import json
 import time
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import StreamingResponse
 from langchain_openai import ChatOpenAI
 from sqlalchemy.orm import Session, selectinload
@@ -402,20 +402,25 @@ def create_chat_session(
 def get_chat_sessions(
     request: Request,
     response: Response,
+    skip: int = Query(0, ge=0, description="Number of sessions to skip (offset)."),
+    limit: int = Query(30, ge=1, le=100, description="Maximum number of sessions to return."),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     """
     Get User's Chat Sessions
 
-    Retrieve all chat sessions belonging to the authenticated user,
-    ordered by creation date (most recent first).
+    Retrieve the authenticated user's chat sessions, ordered by creation date
+    (most recent first). Results are paginated to keep the response bounded for
+    users with a large history.
 
     Args:
+        skip (int): Number of sessions to skip, for offset-based pagination.
+        limit (int): Maximum number of sessions to return (1-100, default 30).
         current_user (User): Authenticated user (automatically injected)
 
     Returns:
-        List[ChatSessionResponse]: List of user's chat sessions
+        List[ChatSessionResponse]: A page of the user's chat sessions
             Each session contains:
             - id (int): Unique session ID
             - title (str): Session title
@@ -451,12 +456,19 @@ def get_chat_sessions(
             db.query(ChatSession)
             .filter(ChatSession.user_id == current_user.id)
             .order_by(ChatSession.created_at.desc())
+            .offset(skip)
+            .limit(limit)
             .all()
         )
 
         logger.logger.info(
             "Retrieved chat sessions",
-            extra={"user_id": current_user.id, "session_count": len(sessions)},
+            extra={
+                "user_id": current_user.id,
+                "session_count": len(sessions),
+                "skip": skip,
+                "limit": limit,
+            },
         )
         return sessions
     except RateLimitExceededError:

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -376,6 +376,8 @@ const MessageContent = ({ content }: { content: string }) => {
 function HomeContent() {
   const {
     sessions,
+    hasMoreSessions,
+    isLoadingMoreSessions,
     currentSession,
     messages,
     loading,
@@ -388,6 +390,7 @@ function HomeContent() {
     fetchMessages,
     sendMessage,
     renameSession,
+    loadMoreSessions,
   } = useChatSessions();
 
   const [input, setInput] = useState('');
@@ -648,6 +651,18 @@ function HomeContent() {
                   </div>
                 ))}
               </div>
+
+              {hasMoreSessions && (
+                <div className="mt-3 md:mt-4 flex justify-center">
+                  <button
+                    onClick={loadMoreSessions}
+                    disabled={isLoadingMoreSessions}
+                    className="card-mystical px-4 py-2 text-sm text-purple-300 hover:text-purple-200 hover:border-purple-600/50 transition-colors touch-manipulation disabled:opacity-60"
+                  >
+                    {isLoadingMoreSessions ? 'Loading…' : 'Load more'}
+                  </button>
+                </div>
+              )}
 
               {sessions.length === 0 && (
                 <div className="text-center py-8 md:py-12">

--- a/frontend/src/hooks/useChatSessions.ts
+++ b/frontend/src/hooks/useChatSessions.ts
@@ -48,10 +48,15 @@ interface StreamResponse {
 // How long the card-drawing animation plays before cards/reading are revealed.
 export const CARD_DRAW_ANIMATION_MS = 5000;
 
+// Number of sessions fetched per page by the paginated /chat/sessions/ endpoint.
+export const SESSIONS_PAGE_SIZE = 30;
+
 export const useChatSessions = () => {
     const { token, logout } = useAuth();
     const { refreshDataWithProfile: refreshSubscriptionData } = useSubscription();
     const [sessions, setSessions] = useState<ChatSession[]>([]);
+    const [hasMoreSessions, setHasMoreSessions] = useState(false);
+    const [isLoadingMoreSessions, setIsLoadingMoreSessions] = useState(false);
     const [currentSession, setCurrentSession] = useState<ChatSession | null>(null);
     const [messages, setMessages] = useState<Message[]>([]);
     const [loading, setLoading] = useState(false);
@@ -101,9 +106,10 @@ export const useChatSessions = () => {
         hasAttemptedFetch.current = true;
         try {
             logDebug('Fetching sessions', { hook: 'useChatSessions', hasToken: !!token });
-            const data = await chat.getSessions();
+            const data: ChatSession[] = await chat.getSessions(0, SESSIONS_PAGE_SIZE);
             logDebug('Sessions fetched successfully', { hook: 'useChatSessions', count: data.length });
             setSessions(data);
+            setHasMoreSessions(data.length === SESSIONS_PAGE_SIZE);
         } catch (error: unknown) {
             if (error instanceof Error && 'response' in error && (error as { response?: { status?: number } }).response?.status === 401) {
                 logDebug('Unauthorized - redirecting to login', { hook: 'useChatSessions' });
@@ -114,6 +120,30 @@ export const useChatSessions = () => {
             setError(error instanceof Error ? error.message : 'Failed to load chat sessions');
         }
     }, [handleUnauthorized, token]);
+
+    const loadMoreSessions = useCallback(async () => {
+        if (isLoadingMoreSessions || !hasMoreSessions) {
+            return;
+        }
+        setIsLoadingMoreSessions(true);
+        try {
+            const data: ChatSession[] = await chat.getSessions(sessions.length, SESSIONS_PAGE_SIZE);
+            setSessions(prev => {
+                const seen = new Set(prev.map(s => s.id));
+                return [...prev, ...data.filter(s => !seen.has(s.id))];
+            });
+            setHasMoreSessions(data.length === SESSIONS_PAGE_SIZE);
+        } catch (error: unknown) {
+            if (error instanceof Error && 'response' in error && (error as { response?: { status?: number } }).response?.status === 401) {
+                handleUnauthorized();
+                return;
+            }
+            logHookError('useChatSessions', 'loadMoreSessions', error);
+            setError(error instanceof Error ? error.message : 'Failed to load more chat sessions');
+        } finally {
+            setIsLoadingMoreSessions(false);
+        }
+    }, [handleUnauthorized, hasMoreSessions, isLoadingMoreSessions, sessions.length]);
 
     const createSession = async () => {
         try {
@@ -440,6 +470,8 @@ export const useChatSessions = () => {
 
     return {
         sessions,
+        hasMoreSessions,
+        isLoadingMoreSessions,
         currentSession,
         messages,
         loading,
@@ -454,6 +486,7 @@ export const useChatSessions = () => {
         sendMessage,
         renameSession,
         refreshSessions: fetchSessions,
+        loadMoreSessions,
         clearCurrentCards,
     };
 };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -272,8 +272,8 @@ export const auth = {
 
 // Chat endpoints
 export const chat = {
-    getSessions: async () => {
-        const response = await api.get("/chat/sessions/");
+    getSessions: async (skip: number = 0, limit: number = 30) => {
+        const response = await api.get("/chat/sessions/", { params: { skip, limit } });
         return response.data;
     },
 


### PR DESCRIPTION
## Summary
Implement offset-based pagination for the chat sessions endpoint to improve performance and user experience for users with large session histories. This includes a database index optimization, backend pagination support, and frontend infinite-scroll functionality.

## Key Changes

**Backend:**
- Added `skip` and `limit` query parameters to `GET /chat/sessions/` endpoint (limit: 1-100, default 30)
- Updated database query to use `.offset()` and `.limit()` for pagination
- Added composite index on `chat_sessions(user_id, created_at)` to optimize the filtered, ordered query
- Updated logging to include pagination parameters

**Frontend:**
- Added `SESSIONS_PAGE_SIZE` constant (30 sessions per page)
- Introduced `hasMoreSessions` and `isLoadingMoreSessions` state to track pagination status
- Implemented `loadMoreSessions()` callback with duplicate detection to append new sessions
- Updated initial fetch to use pagination parameters
- Added "Load more" button in the UI that appears when additional sessions are available
- Exported new state and callback from `useChatSessions` hook

**Database:**
- Created migration to add composite index `ix_chat_sessions_user_id_created_at` on `(user_id, created_at)` columns
- Added index definition to `ChatSession` model via `__table_args__`

## Implementation Details
- The composite index allows the database to return results already ordered by `created_at DESC`, eliminating the need for a separate sort step
- Duplicate detection in `loadMoreSessions()` prevents duplicate sessions if pagination boundaries shift between requests
- The "Load more" button only appears when `hasMoreSessions` is true (i.e., when the last page returned exactly `SESSIONS_PAGE_SIZE` results)
- Migration includes idempotency checks to safely handle re-runs

https://claude.ai/code/session_019nBzhWHV5pjwpidyNQSsXw