### PR TITLE
Complete Major Arcana tarot cards and add API merge logic

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -13,7 +13,7 @@ import { TarotCard } from '@/components/TarotCard';
 import { DrawnCardReveal } from '@/components/DrawnCardReveal';
 import { CardDrawingAnimation } from '@/components/CardDrawingAnimation';
 import { tarot } from '@/lib/api';
-import { getDailyCard, type DailyCard } from '@/lib/dailyCard';
+import { getDailyCard, mergeDailyCard, type DailyCard } from '@/lib/dailyCard';
 
 const mysticalQuotes = [
   "The cards reveal what the heart already knows.",
@@ -95,13 +95,7 @@ const EnhancedWelcome = ({ onStartReading }: { onStartReading: () => void }) => 
       .getCardOfTheDay()
       .then((card) => {
         if (cancelled || !card) return;
-        setDailyCard((prev) => ({
-          ...prev,
-          name: card.name ?? prev.name,
-          image_url: card.image_url ?? prev.image_url,
-          description_upright: card.description_upright ?? prev.description_upright,
-          element: card.element ?? prev.element,
-        }));
+        setDailyCard((prev) => mergeDailyCard(prev, card));
       })
       .catch(() => {
         // Keep the hardcoded fallback card if the request fails.

--- a/frontend/src/components/AdminLayout.tsx
+++ b/frontend/src/components/AdminLayout.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import "@/app/admin/admin.css";
 import api, { tarot } from "@/lib/api";
 import { Icon, SearchInput, type IconName } from "@/components/admin/AdminUI";
-import { getDailyCard } from "@/lib/dailyCard";
+import { getDailyCard, mergeDailyCard, type DailyCard } from "@/lib/dailyCard";
 
 /* ─── Theme handling ────────────────────────────────────────────────────── */
 type ThemePref = "system" | "dark" | "light" | "hc";
@@ -126,27 +126,16 @@ function SettingsPopover({ theme }: { theme: ReturnType<typeof useAdminTheme> })
 }
 
 /* ─── Card of the day ───────────────────────────────────────────────────── */
-function meaningLine(words: string[]): string {
-    return words
-        .map((w) => w.trim())
-        .filter(Boolean)
-        .slice(0, 3)
-        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-        .join(" · ");
-}
-
-function useDailyCard() {
-    const initial = getDailyCard();
-    const [card, setCard] = useState({ name: initial.name, meaning: meaningLine(initial.keywords) });
+function useDailyCard(): DailyCard {
+    const [card, setCard] = useState<DailyCard>(getDailyCard);
 
     useEffect(() => {
         let cancelled = false;
         tarot
             .getCardOfTheDay()
             .then((res) => {
-                if (cancelled || !res?.name) return;
-                const meaning = meaningLine(String(res.description_upright ?? "").split(","));
-                setCard((prev) => ({ name: res.name ?? prev.name, meaning: meaning || prev.meaning }));
+                if (cancelled || !res) return;
+                setCard((prev) => mergeDailyCard(prev, res));
             })
             .catch(() => {
                 // Keep the deterministic local fallback if the request fails.

--- a/frontend/src/components/MysticalSidebar.tsx
+++ b/frontend/src/components/MysticalSidebar.tsx
@@ -16,7 +16,7 @@ import { Badge } from '@/components/ui/badge';
 import { TarotCard } from '@/components/TarotCard';
 import { useAuth } from '@/contexts/AuthContext';
 import { tarot } from '@/lib/api';
-import { getDailyCard, type DailyCard } from '@/lib/dailyCard';
+import { getDailyCard, mergeDailyCard, type DailyCard } from '@/lib/dailyCard';
 
 interface MysticalSidebarProps {
     className?: string;
@@ -51,13 +51,7 @@ export function MysticalSidebar({ className = '' }: MysticalSidebarProps) {
             .getCardOfTheDay()
             .then((card) => {
                 if (cancelled || !card) return;
-                setDailyCard((prev) => ({
-                    ...prev,
-                    name: card.name ?? prev.name,
-                    image_url: card.image_url ?? prev.image_url,
-                    description_upright: card.description_upright ?? prev.description_upright,
-                    element: card.element ?? prev.element,
-                }));
+                setDailyCard((prev) => mergeDailyCard(prev, card));
             })
             .catch(() => {
                 // Keep the hardcoded fallback card if the request fails.

--- a/frontend/src/lib/dailyCard.ts
+++ b/frontend/src/lib/dailyCard.ts
@@ -7,6 +7,19 @@ export interface DailyCard {
   keywords: string[];
 }
 
+// Shape of the /tarot/card-of-the-day response we rely on for display.
+export interface CardOfTheDayApi {
+  name?: string | null;
+  image_url?: string | null;
+  description_upright?: string | null;
+  description_short?: string | null;
+  element?: string | null;
+}
+
+// All 22 Major Arcana in numerology order, matching the backend's
+// `/tarot/card-of-the-day` rotation (Card.numerology asc). Used as a
+// deterministic offline fallback and as the source of the human-readable
+// guidance sentence the API does not provide.
 const featuredCards: DailyCard[] = [
   {
     name: "The Fool",
@@ -97,12 +110,92 @@ const featuredCards: DailyCard[] = [
     keywords: ["fortune", "cycles", "destiny", "change"],
   },
   {
+    name: "Justice",
+    image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m11.jpg",
+    description_upright: "Justice, fairness, truth, cause and effect, law",
+    meaning: "Weigh your choices with honesty today. Fair outcomes follow when you act with integrity and accountability.",
+    element: "Air",
+    keywords: ["justice", "fairness", "truth", "balance"],
+  },
+  {
+    name: "The Hanged Man",
+    image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m12.jpg",
+    description_upright: "Surrender, letting go, new perspectives, pause",
+    meaning: "Pause and see things from a new angle. Surrender control and let understanding arrive in its own time.",
+    element: "Water",
+    keywords: ["surrender", "perspective", "letting go", "pause"],
+  },
+  {
+    name: "Death",
+    image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m13.jpg",
+    description_upright: "Endings, change, transformation, transition",
+    meaning: "An ending clears the way for renewal. Release what no longer serves you and welcome transformation.",
+    element: "Water",
+    keywords: ["endings", "transformation", "change", "renewal"],
+  },
+  {
+    name: "Temperance",
+    image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m14.jpg",
+    description_upright: "Balance, moderation, patience, purpose",
+    meaning: "Seek balance and patience in all things. Blend opposing forces with calm and moderation.",
+    element: "Fire",
+    keywords: ["balance", "moderation", "patience", "harmony"],
+  },
+  {
+    name: "The Devil",
+    image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m15.jpg",
+    description_upright: "Shadow self, attachment, addiction, restriction",
+    meaning: "Notice what binds you today. Awareness of your attachments is the first step toward freedom.",
+    element: "Earth",
+    keywords: ["attachment", "shadow", "temptation", "restriction"],
+  },
+  {
+    name: "The Tower",
+    image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m16.jpg",
+    description_upright: "Sudden upheaval, broken pride, disaster, revelation",
+    meaning: "Sudden change may shake your foundations. Let what is unstable fall so something truer can rise.",
+    element: "Fire",
+    keywords: ["upheaval", "revelation", "change", "awakening"],
+  },
+  {
     name: "The Star",
     image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m17.jpg",
     description_upright: "Hope, faith, purpose, renewal, spirituality",
     meaning: "Hope and inspiration illuminate your path. Trust in the universe's plan and follow your dreams.",
     element: "Air",
     keywords: ["hope", "inspiration", "faith", "renewal"],
+  },
+  {
+    name: "The Moon",
+    image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m18.jpg",
+    description_upright: "Illusion, fear, anxiety, subconscious, intuition",
+    meaning: "Trust your intuition through uncertainty. Look beyond illusion to find the truth hidden in the shadows.",
+    element: "Water",
+    keywords: ["intuition", "illusion", "mystery", "subconscious"],
+  },
+  {
+    name: "The Sun",
+    image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m19.jpg",
+    description_upright: "Positivity, fun, warmth, success, vitality",
+    meaning: "Joy and clarity light your path. Embrace optimism and let your authentic self shine.",
+    element: "Fire",
+    keywords: ["joy", "success", "vitality", "positivity"],
+  },
+  {
+    name: "Judgement",
+    image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m20.jpg",
+    description_upright: "Judgement, rebirth, inner calling, absolution",
+    meaning: "A moment of reckoning calls you forward. Reflect, forgive, and rise renewed toward your higher purpose.",
+    element: "Fire",
+    keywords: ["rebirth", "reckoning", "awakening", "absolution"],
+  },
+  {
+    name: "The World",
+    image_url: "https://cdn.nguyenvanloc.com/kaggle_tarot_images/cards/m21.jpg",
+    description_upright: "Completion, integration, accomplishment, travel",
+    meaning: "A cycle reaches its fulfillment. Celebrate completion and step whole into your next great journey.",
+    element: "Earth",
+    keywords: ["completion", "fulfillment", "achievement", "wholeness"],
   },
 ];
 
@@ -112,4 +205,27 @@ export const getDailyCard = (): DailyCard => {
     (today.getTime() - new Date(today.getFullYear(), 0, 0).getTime()) / 86400000
   );
   return featuredCards[dayOfYear % featuredCards.length];
+};
+
+// Merge the API card-of-the-day response onto a fallback card, producing a
+// single consistent DailyCard for every view. The backend has no guidance
+// "meaning" sentence, so it is resolved from the local catalog by card name
+// (with description text as a final fallback) instead of leaving the previous
+// card's stale meaning in place.
+export const mergeDailyCard = (
+  fallback: DailyCard,
+  api: CardOfTheDayApi | null | undefined,
+): DailyCard => {
+  if (!api?.name) return fallback;
+  const known = featuredCards.find((card) => card.name === api.name);
+  return {
+    name: api.name,
+    image_url: api.image_url ?? known?.image_url ?? fallback.image_url,
+    description_upright:
+      api.description_upright ?? known?.description_upright ?? fallback.description_upright,
+    element: api.element ?? known?.element ?? fallback.element,
+    meaning:
+      known?.meaning ?? api.description_short ?? api.description_upright ?? fallback.meaning,
+    keywords: known?.keywords ?? fallback.keywords,
+  };
 };


### PR DESCRIPTION
## Summary
This PR completes the Major Arcana tarot card catalog (cards 11-21) and introduces a new `mergeDailyCard` utility function to intelligently merge API responses with local fallback data. This ensures consistent card data across the application while gracefully handling API failures.

## Key Changes

- **Expanded `featuredCards` array**: Added 11 missing Major Arcana cards (Justice through The World, cards 11-21) with complete metadata including name, image URL, upright description, custom guidance meaning, element, and keywords
- **New `CardOfTheDayApi` interface**: Defined the shape of the backend's `/tarot/card-of-the-day` API response for type safety
- **New `mergeDailyCard` function**: Intelligently merges API card data with local fallback data, with a priority chain:
  - Uses API values when available
  - Falls back to local catalog data (by card name match) for missing fields
  - Uses the local catalog's human-readable `meaning` field (which the API doesn't provide)
  - Falls back to the original card's values as a final safety net
- **Updated all card-of-the-day consumers**: Replaced manual field-by-field merging in `AdminLayout.tsx`, `page.tsx`, and `MysticalSidebar.tsx` with the new `mergeDailyCard` function for consistency and maintainability
- **Improved `useDailyCard` hook**: Simplified to use the new merge function and properly type the state as `DailyCard`

## Notable Implementation Details

- The `mergeDailyCard` function ensures that stale data from previous cards is never carried forward—the `meaning` field is always resolved fresh from the local catalog or API
- The complete 22-card Major Arcana catalog now serves as both a deterministic offline fallback and the source of guidance sentences that the backend API doesn't provide
- All three components that fetch the card-of-the-day now use identical merge logic, reducing code duplication and potential inconsistencies

https://claude.ai/code/session_01MtF29FokW9HDdUYraUuP2A