### PR TITLE
Add card image display to daily card ornament

### DIFF
--- a/frontend/src/app/admin/admin.css
+++ b/frontend/src/app/admin/admin.css
@@ -256,6 +256,16 @@
   font-size: 10.5px; letter-spacing: 0.08em;
   text-transform: uppercase; color: var(--text-3);
 }
+.admin-shell .ornament-card-image {
+  display: block;
+  width: 88px;
+  height: auto;
+  margin: 10px auto 4px;
+  border-radius: 8px;
+  border: 1px solid var(--border-2);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
+  object-fit: contain;
+}
 .admin-shell .ornament-card-name {
   font-family: var(--display-font);
   font-size: 19px; color: var(--text-1);

--- a/frontend/src/components/AdminLayout.tsx
+++ b/frontend/src/components/AdminLayout.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import "@/app/admin/admin.css";
 import api, { tarot } from "@/lib/api";
 import { Icon, SearchInput, type IconName } from "@/components/admin/AdminUI";
@@ -146,6 +147,29 @@ function useDailyCard(): DailyCard {
     return card;
 }
 
+function OrnamentCard({ card }: { card: DailyCard }) {
+    const [imageError, setImageError] = useState(false);
+
+    return (
+        <div className="ornament-card">
+            <div className="ornament-glyph">✦</div>
+            <div className="ornament-title">Card of the day</div>
+            {card.image_url && !imageError && (
+                <Image
+                    src={card.image_url}
+                    alt={card.name}
+                    width={88}
+                    height={154}
+                    className="ornament-card-image"
+                    onError={() => setImageError(true)}
+                />
+            )}
+            <div className="ornament-card-name">{card.name}</div>
+            <div className="ornament-card-meaning">{card.meaning}</div>
+        </div>
+    );
+}
+
 /* ─── Sidebar nav ───────────────────────────────────────────────────────── */
 interface SidebarCounts {
     total_users?: number;
@@ -234,12 +258,7 @@ export default function AdminLayout({ children, activePath, breadcrumb, username
                     </nav>
 
                     <div className="sidebar-ornament">
-                        <div className="ornament-card">
-                            <div className="ornament-glyph">✦</div>
-                            <div className="ornament-title">Card of the day</div>
-                            <div className="ornament-card-name">{dailyCard.name}</div>
-                            <div className="ornament-card-meaning">{dailyCard.meaning}</div>
-                        </div>
+                        <OrnamentCard card={dailyCard} />
                     </div>
 
                     <div className="sidebar-footer">


### PR DESCRIPTION
## Summary
Enhanced the daily card ornament in the admin sidebar to display the tarot card image alongside the existing card name and meaning information.

## Key Changes
- Extracted the ornament card markup into a new `OrnamentCard` component for better reusability and maintainability
- Integrated Next.js `Image` component to display card images with proper optimization
- Added error handling for failed image loads with `imageError` state
- Added CSS styling for the card image with rounded corners, border, and shadow effects
- Image dimensions set to 88x154px with `object-fit: contain` to maintain aspect ratio

## Implementation Details
- The `OrnamentCard` component accepts a `DailyCard` object and conditionally renders the image only when `card.image_url` exists and no image load error has occurred
- Image error state prevents broken image placeholders from displaying
- CSS styling includes responsive sizing and visual polish with border and shadow effects to match the admin UI design language

https://claude.ai/code/session_01FKivr5YReMgZo1BK7eYHXt