### PR TITLE
Hide enhanced navigation on admin routes

### DIFF
--- a/frontend/src/components/EnhancedNavigation.tsx
+++ b/frontend/src/components/EnhancedNavigation.tsx
@@ -155,6 +155,7 @@ export function EnhancedNavigation() {
     };
 
     if (!isAuthenticated) return null;
+    if (pathname?.startsWith('/admin')) return null;
 
     const isUnlimited = hasUnlimitedTurns();
     const premium = isPremium();


### PR DESCRIPTION
## Summary
Added a check to prevent the EnhancedNavigation component from rendering when the user is on admin routes.

## Key Changes
- Added early return condition to hide EnhancedNavigation when pathname starts with '/admin'
- This check is placed immediately after the existing authentication check for consistency

## Implementation Details
The navigation component now skips rendering for any routes under the `/admin` path prefix, ensuring admin pages have a clean interface without the enhanced navigation UI. This follows the same pattern as the existing unauthenticated user check.

https://claude.ai/code/session_01LjbZp3897QHW2yUqkqiTFf