### PR TITLE
Remove decorative "ArcanaAI · Admin console" watermark from admin UI

### DIFF
--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Admin sidebar "Card of the day" is now dynamic, sourced from the daily card-of-the-day endpoint (matching the user-facing sidebar) instead of a hardcoded card
 - Admin Users, Decks, and Cards rows/objects are now clickable to open the edit dialog, in addition to the existing Edit button
 - Admin Chat Sessions page now shows engagement metrics (total sessions, total messages, average messages per session, active users, most active users, busiest session, empty sessions, and new-this-week counts)
+- Removed the decorative "ArcanaAI · Admin console" watermark text from admin pages for a cleaner workspace view
 
 ### Fixed
 - Admin Chat Sessions page no longer shows an empty list and zeroed stats: it now calls the correct `/admin/chat-sessions` endpoint (previously requested a non-existent `/admin/chat_sessions` path)

--- a/frontend/src/app/admin/admin.css
+++ b/frontend/src/app/admin/admin.css
@@ -786,20 +786,6 @@
 .admin-shell .muted { color: var(--text-3); }
 .admin-shell .mono { font-family: var(--mono-font); font-variant-numeric: tabular-nums; }
 
-/* footer ornament strip */
-.admin-shell .footer-mark {
-  display: flex; align-items: center; justify-content: center; gap: 14px;
-  padding: 32px 0 8px;
-  color: var(--text-4);
-  font-family: var(--display-font);
-  font-size: 12.5px; letter-spacing: 0.16em; text-transform: uppercase;
-}
-.admin-shell .footer-mark::before, .admin-shell .footer-mark::after {
-  content: ""; height: 1px; width: 60px;
-  background: linear-gradient(90deg, transparent, var(--border-2));
-}
-.admin-shell .footer-mark::after { background: linear-gradient(90deg, var(--border-2), transparent); }
-
 /* ─── Settings panel (theme switcher) ────────────────────────────────── */
 .admin-shell .settings-pop {
   position: absolute; top: 52px; right: 0;

--- a/frontend/src/components/AdminLayout.tsx
+++ b/frontend/src/components/AdminLayout.tsx
@@ -295,7 +295,6 @@ export default function AdminLayout({ children, activePath, breadcrumb, username
 
                     <div className="content">
                         {children}
-                        <div className="footer-mark">ArcanaAI · Admin console</div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### Motivation
- The decorative footer text `ArcanaAI · Admin console` in the admin content area was making the UI look cluttered and should be removed for a cleaner workspace view.

### Description
- Remove the footer markup from `frontend/src/components/AdminLayout.tsx` so the watermark no longer renders in the admin content area.
- Delete the unused `.footer-mark` CSS block from `frontend/src/app/admin/admin.css` to avoid dead styles.
- Add a changelog entry in `backend/docs/CHANGELOG.md` under `0.0.14` (Changed) documenting the user-visible cleanup.

### Testing
- No automated tests were run for this visual-only change; changes were validated via diffs and a local commit (`git diff`/`git status` and `git commit`) to ensure the files were updated correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12d670a9bc83288e0e62ced3cc5cda)