### PR TITLE
Add profile preferences and bio to user settings

### DIFF
--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.15] - 2026-05-24
+
+### Added
+- Profile page now lets users edit and save more of their information: bio, timezone, favorite deck, and reading preferences (lunar phase awareness, card animation style, reading language, and reversed cards), in addition to the existing full name. Username and email remain read-only.
+- User profile now stores `bio`, `timezone`, `lunar_phase_awareness`, `card_animations`, `reading_language`, and `reversed_cards`, returned by `GET /auth/me` and updatable via `PUT /auth/me` (with validation for timezone, animation style, and reading language).
+
+### Changed
+- The profile "Account details" and "Reading preferences" sections are now a single editable form with Save/Discard controls and an unsaved-changes indicator, instead of static placeholder fields.
+
 ## [0.0.14] - 2026-05-24
 
 

--- a/backend/migrations/versions/20260524_010000_b7c8d9e0f1a2_add_profile_preferences_to_user.py
+++ b/backend/migrations/versions/20260524_010000_b7c8d9e0f1a2_add_profile_preferences_to_user.py
@@ -1,0 +1,51 @@
+"""add profile details and reading preferences to user model
+
+Revision ID: b7c8d9e0f1a2
+Revises: a6b7c8d9e0f1
+Create Date: 2026-05-24 01:00:00.000000+00:00
+
+Adds user-editable profile fields exposed on the /profile page: a free-text
+bio, an IANA timezone, and four reading preferences (lunar phase awareness,
+card animation style, reading language, and whether reversed cards appear).
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect as sa_inspect
+
+revision: str = "b7c8d9e0f1a2"
+down_revision: Union[str, None] = "a6b7c8d9e0f1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE_NAME = "users"
+
+
+def _new_columns():
+    return [
+        sa.Column("bio", sa.Text(), nullable=True),
+        sa.Column("timezone", sa.String(), nullable=True),
+        sa.Column("lunar_phase_awareness", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("card_animations", sa.String(), nullable=False, server_default="cinematic"),
+        sa.Column("reading_language", sa.String(), nullable=False, server_default="English"),
+        sa.Column("reversed_cards", sa.Boolean(), nullable=False, server_default=sa.true()),
+    ]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    existing = {col["name"] for col in sa_inspect(bind).get_columns(TABLE_NAME)}
+    for column in _new_columns():
+        if column.name not in existing:
+            op.add_column(TABLE_NAME, column)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = {col["name"] for col in sa_inspect(bind).get_columns(TABLE_NAME)}
+    for column in reversed(_new_columns()):
+        if column.name in existing:
+            op.drop_column(TABLE_NAME, column.name)

--- a/backend/models.py
+++ b/backend/models.py
@@ -26,6 +26,12 @@ class User(Base):
         is_active (bool): Whether the user is active.
         is_admin (bool): Whether the user has admin privileges.
         favorite_deck_id (int): Foreign key to the user's favorite deck.
+        bio (str): Optional short biography shown on the user's profile.
+        timezone (str): Optional IANA timezone name for the user.
+        lunar_phase_awareness (bool): Whether readings are colored by the current moon phase.
+        card_animations (str): Card reveal animation preference (cinematic, minimal, off).
+        reading_language (str): Preferred language for generated interpretations.
+        reversed_cards (bool): Whether cards may appear reversed in spreads.
         chat_sessions (list[ChatSession]): Related chat sessions.
         favorite_deck (Deck): The user's favorite deck.
         shared_readings (list[SharedReading]): Shared readings by the user.
@@ -62,6 +68,14 @@ class User(Base):
 
     # Avatar storage
     avatar_filename = Column(String, nullable=True)  # Stores the filename of the avatar
+
+    # Profile details and reading preferences (user-editable)
+    bio = Column(Text, nullable=True)
+    timezone = Column(String, nullable=True)  # IANA timezone name, e.g. "Asia/Ho_Chi_Minh"
+    lunar_phase_awareness = Column(Boolean, default=True, server_default="1")
+    card_animations = Column(String, default="cinematic", server_default="cinematic")  # cinematic | minimal | off
+    reading_language = Column(String, default="English", server_default="English")
+    reversed_cards = Column(Boolean, default=True, server_default="1")
 
     # Relationships
     chat_sessions = relationship("ChatSession", back_populates="user", cascade="all, delete-orphan")

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -647,6 +647,14 @@ async def get_current_user_profile(
             number_of_paid_turns=current_user.number_of_paid_turns,
             last_free_turns_reset=current_user.last_free_turns_reset,
             avatar_url=avatar_url,
+            bio=current_user.bio,
+            timezone=current_user.timezone,
+            lunar_phase_awareness=(
+                current_user.lunar_phase_awareness if current_user.lunar_phase_awareness is not None else True
+            ),
+            card_animations=current_user.card_animations or "cinematic",
+            reading_language=current_user.reading_language or "English",
+            reversed_cards=current_user.reversed_cards if current_user.reversed_cards is not None else True,
         )
         return user_response
     except Exception as e:
@@ -672,6 +680,12 @@ async def update_current_user_profile(
         user_update (UserUpdate): User update data
             - favorite_deck_id (int, optional): ID of the user's favorite tarot deck
             - full_name (str, optional): Full name of the user
+            - bio (str, optional): Short profile biography
+            - timezone (str, optional): IANA timezone name
+            - lunar_phase_awareness (bool, optional): Color readings with the moon phase
+            - card_animations (str, optional): Card reveal animation style
+            - reading_language (str, optional): Preferred interpretation language
+            - reversed_cards (bool, optional): Allow reversed cards in spreads
 
     Returns:
         UserResponse: Updated user information
@@ -694,6 +708,18 @@ async def update_current_user_profile(
         # Update full name if provided in the request
         if "full_name" in user_update.model_fields_set:
             current_user.full_name = user_update.full_name
+
+        # Update profile details and reading preferences when explicitly provided
+        for field in (
+            "bio",
+            "timezone",
+            "lunar_phase_awareness",
+            "card_animations",
+            "reading_language",
+            "reversed_cards",
+        ):
+            if field in user_update.model_fields_set:
+                setattr(current_user, field, getattr(user_update, field))
 
         db.commit()
         db.refresh(current_user)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -362,16 +362,32 @@ class UserCreate(UserBase):
         return _sanitize_string(v, "Password", min_length=8, max_length=128)
 
 
+CARD_ANIMATION_CHOICES = {"cinematic", "minimal", "off"}
+READING_LANGUAGE_CHOICES = {"English", "Vietnamese", "Spanish", "French", "German"}
+
+
 class UserUpdate(BaseModel):
     """Schema for updating user preferences.
 
     Attributes:
         favorite_deck_id (Optional[int]): ID of the user's favorite deck.
         full_name (Optional[str]): Full name of the user.
+        bio (Optional[str]): Short biography shown on the profile.
+        timezone (Optional[str]): IANA timezone name.
+        lunar_phase_awareness (Optional[bool]): Color readings with the current moon phase.
+        card_animations (Optional[str]): Card reveal animation style.
+        reading_language (Optional[str]): Preferred interpretation language.
+        reversed_cards (Optional[bool]): Allow reversed cards in spreads.
     """
 
     favorite_deck_id: int | None = None
     full_name: str | None = None
+    bio: str | None = None
+    timezone: str | None = None
+    lunar_phase_awareness: bool | None = None
+    card_animations: str | None = None
+    reading_language: str | None = None
+    reversed_cards: bool | None = None
 
     @field_validator("full_name")
     def validate_full_name(cls, v):
@@ -389,6 +405,50 @@ class UserUpdate(BaseModel):
         if not stripped:
             return None
         return _sanitize_string(v, "Full name", min_length=1, max_length=100, allow_empty=False)
+
+    @field_validator("bio")
+    def validate_bio(cls, v):
+        """Validate the bio, treating blank input as cleared."""
+        if v is None:
+            return None
+        stripped = v.strip() if isinstance(v, str) else v
+        if not stripped:
+            return None
+        return _sanitize_string(v, "Bio", min_length=1, max_length=500, allow_empty=False)
+
+    @field_validator("timezone")
+    def validate_timezone(cls, v):
+        """Validate the timezone is a known IANA name, treating blank as cleared."""
+        if v is None:
+            return None
+        stripped = v.strip() if isinstance(v, str) else v
+        if not stripped:
+            return None
+        try:
+            from zoneinfo import ZoneInfo
+
+            ZoneInfo(stripped)
+        except Exception as exc:
+            raise ValueError("Invalid timezone.") from exc
+        return stripped
+
+    @field_validator("card_animations")
+    def validate_card_animations(cls, v):
+        """Validate the card animation preference."""
+        if v is None:
+            return None
+        if v not in CARD_ANIMATION_CHOICES:
+            raise ValueError(f"Card animations must be one of: {', '.join(sorted(CARD_ANIMATION_CHOICES))}.")
+        return v
+
+    @field_validator("reading_language")
+    def validate_reading_language(cls, v):
+        """Validate the reading language preference."""
+        if v is None:
+            return None
+        if v not in READING_LANGUAGE_CHOICES:
+            raise ValueError(f"Reading language must be one of: {', '.join(sorted(READING_LANGUAGE_CHOICES))}.")
+        return v
 
 
 class UserResponse(BaseModel):
@@ -429,6 +489,12 @@ class UserResponse(BaseModel):
     number_of_paid_turns: int = 0
     last_free_turns_reset: datetime | None = None
     avatar_url: str | None = None
+    bio: str | None = None
+    timezone: str | None = None
+    lunar_phase_awareness: bool = True
+    card_animations: str = "cinematic"
+    reading_language: str = "English"
+    reversed_cards: bool = True
 
     class Config:
         """Pydantic configuration."""

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -908,3 +908,117 @@ def test_user_registration_does_not_require_full_name(client):
     assert data["email"] == "newfullname@example.com"
     # full_name should not be required or included in registration response
     assert "full_name" not in data or data.get("full_name") is None
+
+
+# Profile Management Tests (bio, timezone, reading preferences)
+def test_get_user_profile_includes_preference_defaults(client, auth_headers, test_user):
+    """A fresh profile returns the default reading preferences and empty details."""
+    response = client.get("/auth/me", headers=auth_headers)
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["bio"] is None
+    assert data["timezone"] is None
+    assert data["lunar_phase_awareness"] is True
+    assert data["card_animations"] == "cinematic"
+    assert data["reading_language"] == "English"
+    assert data["reversed_cards"] is True
+
+
+def test_update_user_profile_bio_success(client, auth_headers, test_user, db_session):
+    """Bio can be set and is persisted."""
+    response = client.put("/auth/me", headers=auth_headers, json={"bio": "Reader of the Thoth deck."})
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["bio"] == "Reader of the Thoth deck."
+
+    response = client.get("/auth/me", headers=auth_headers)
+    assert response.json()["bio"] == "Reader of the Thoth deck."
+
+
+def test_update_user_profile_bio_blank_clears(client, auth_headers, test_user, db_session):
+    """Whitespace-only bio is stored as null."""
+    client.put("/auth/me", headers=auth_headers, json={"bio": "Some bio"})
+    response = client.put("/auth/me", headers=auth_headers, json={"bio": "   "})
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["bio"] is None
+
+
+def test_update_user_profile_bio_too_long(client, auth_headers):
+    """Bio over the max length is rejected."""
+    response = client.put("/auth/me", headers=auth_headers, json={"bio": "x" * 501})
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_update_user_profile_bio_rejects_html(client, auth_headers):
+    """Bio containing HTML/script is rejected."""
+    response = client.put("/auth/me", headers=auth_headers, json={"bio": "<script>alert('x')</script>"})
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_update_user_profile_timezone_success(client, auth_headers, test_user, db_session):
+    """A valid IANA timezone is accepted and persisted."""
+    response = client.put("/auth/me", headers=auth_headers, json={"timezone": "Asia/Ho_Chi_Minh"})
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["timezone"] == "Asia/Ho_Chi_Minh"
+
+    response = client.get("/auth/me", headers=auth_headers)
+    assert response.json()["timezone"] == "Asia/Ho_Chi_Minh"
+
+
+def test_update_user_profile_timezone_invalid(client, auth_headers):
+    """An unknown timezone string is rejected."""
+    response = client.put("/auth/me", headers=auth_headers, json={"timezone": "Mars/Olympus_Mons"})
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_update_user_profile_timezone_blank_clears(client, auth_headers, test_user, db_session):
+    """Empty timezone is stored as null."""
+    client.put("/auth/me", headers=auth_headers, json={"timezone": "UTC"})
+    response = client.put("/auth/me", headers=auth_headers, json={"timezone": ""})
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["timezone"] is None
+
+
+def test_update_user_profile_reading_preferences_success(client, auth_headers, test_user, db_session):
+    """All four reading preferences can be updated together."""
+    payload = {
+        "lunar_phase_awareness": False,
+        "card_animations": "minimal",
+        "reading_language": "Vietnamese",
+        "reversed_cards": False,
+    }
+    response = client.put("/auth/me", headers=auth_headers, json=payload)
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["lunar_phase_awareness"] is False
+    assert data["card_animations"] == "minimal"
+    assert data["reading_language"] == "Vietnamese"
+    assert data["reversed_cards"] is False
+
+    response = client.get("/auth/me", headers=auth_headers)
+    data = response.json()
+    assert data["lunar_phase_awareness"] is False
+    assert data["card_animations"] == "minimal"
+    assert data["reading_language"] == "Vietnamese"
+    assert data["reversed_cards"] is False
+
+
+def test_update_user_profile_card_animations_invalid(client, auth_headers):
+    """An unsupported card animation value is rejected."""
+    response = client.put("/auth/me", headers=auth_headers, json={"card_animations": "explosion"})
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_update_user_profile_reading_language_invalid(client, auth_headers):
+    """An unsupported reading language is rejected."""
+    response = client.put("/auth/me", headers=auth_headers, json={"reading_language": "Klingon"})
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_update_user_profile_partial_preference_leaves_others(client, auth_headers, test_user, db_session):
+    """Updating one preference does not reset the others."""
+    client.put("/auth/me", headers=auth_headers, json={"card_animations": "off"})
+    response = client.put("/auth/me", headers=auth_headers, json={"reading_language": "French"})
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["card_animations"] == "off"  # unchanged by the second request
+    assert data["reading_language"] == "French"

--- a/frontend/src/app/profile/_components/ProfileInfoTab.tsx
+++ b/frontend/src/app/profile/_components/ProfileInfoTab.tsx
@@ -1,40 +1,149 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import toast from 'react-hot-toast';
 import { MysticCard, SectionHeader, FieldLabel, FieldInput, FieldSelect, FieldTextarea } from './MysticCard';
 import { ProfileIcon } from './ProfileIcon';
-import { UserProfile } from '@/types/tarot';
+import { Deck, ProfileUpdatePayload, UserProfile } from '@/types/tarot';
 import { AvatarUpload } from '@/components/AvatarUpload';
 
 interface ProfileInfoTabProps {
     profile: UserProfile | null;
+    decks?: Deck[];
     isLoading?: boolean;
     onAvatarChange?: (url: string | null) => void;
     fetchProfile?: () => Promise<void>;
-    updateFullName?: (name: string) => Promise<boolean>;
+    updateProfile?: (data: ProfileUpdatePayload) => Promise<boolean>;
 }
 
-export function ProfileInfoTab({ profile, isLoading, onAvatarChange, fetchProfile, updateFullName }: ProfileInfoTabProps) {
-    const [isEditingName, setIsEditingName] = useState(false);
-    const [fullNameValue, setFullNameValue] = useState(profile?.full_name || '');
-    const [isSavingName, setIsSavingName] = useState(false);
+interface FormState {
+    full_name: string;
+    bio: string;
+    timezone: string;
+    favorite_deck_id: number | '';
+    lunar_phase_awareness: boolean;
+    card_animations: string;
+    reading_language: string;
+    reversed_cards: boolean;
+}
+
+const TIMEZONE_OPTIONS: { value: string; label: string }[] = [
+    { value: 'UTC', label: 'UTC' },
+    { value: 'Asia/Ho_Chi_Minh', label: 'Vietnam (UTC+7)' },
+    { value: 'Asia/Singapore', label: 'Singapore (UTC+8)' },
+    { value: 'Asia/Tokyo', label: 'Japan (UTC+9)' },
+    { value: 'Asia/Kolkata', label: 'India (UTC+5:30)' },
+    { value: 'Europe/London', label: 'London (UTC+0)' },
+    { value: 'Europe/Paris', label: 'Central Europe (UTC+1)' },
+    { value: 'America/New_York', label: 'New York (UTC−5)' },
+    { value: 'America/Chicago', label: 'Chicago (UTC−6)' },
+    { value: 'America/Denver', label: 'Denver (UTC−7)' },
+    { value: 'America/Los_Angeles', label: 'Los Angeles (UTC−8)' },
+    { value: 'Australia/Sydney', label: 'Sydney (UTC+11)' },
+    { value: 'Pacific/Auckland', label: 'Auckland (UTC+13)' },
+];
+
+const CARD_ANIMATION_OPTIONS: { value: string; label: string; desc: string }[] = [
+    { value: 'cinematic', label: 'Cinematic', desc: 'Full shuffle + reveal sequence' },
+    { value: 'minimal', label: 'Minimal', desc: 'Quick fade, no shuffle' },
+    { value: 'off', label: 'Off', desc: 'Cards appear instantly' },
+];
+
+const READING_LANGUAGE_OPTIONS = ['English', 'Vietnamese', 'Spanish', 'French', 'German'];
+
+function toForm(p: UserProfile): FormState {
+    return {
+        full_name: p.full_name ?? '',
+        bio: p.bio ?? '',
+        timezone: p.timezone ?? '',
+        favorite_deck_id: p.favorite_deck_id ?? '',
+        lunar_phase_awareness: p.lunar_phase_awareness ?? true,
+        card_animations: p.card_animations ?? 'cinematic',
+        reading_language: p.reading_language ?? 'English',
+        reversed_cards: p.reversed_cards ?? true,
+    };
+}
+
+export function ProfileInfoTab({ profile, decks, isLoading, onAvatarChange, fetchProfile, updateProfile }: ProfileInfoTabProps) {
+    const baseline = useMemo(() => (profile ? toForm(profile) : null), [profile]);
+    const [form, setForm] = useState<FormState | null>(baseline);
+    const [isSaving, setIsSaving] = useState(false);
+
+    // Re-sync the editable form whenever the underlying profile changes
+    // (initial load, refetch, or after a successful save).
+    useEffect(() => {
+        setForm(baseline);
+    }, [baseline]);
 
     const memberSince = profile?.created_at
         ? new Date(profile.created_at).getFullYear()
         : '—';
 
-    const handleSaveName = async () => {
-        if (!updateFullName) return;
-        setIsSavingName(true);
+    const isDirty = useMemo(() => {
+        if (!form || !baseline) return false;
+        return JSON.stringify(form) !== JSON.stringify(baseline);
+    }, [form, baseline]);
+
+    const setField = <K extends keyof FormState>(key: K, value: FormState[K]) => {
+        setForm((prev) => (prev ? { ...prev, [key]: value } : prev));
+    };
+
+    const buildPayload = (): ProfileUpdatePayload => {
+        const payload: ProfileUpdatePayload = {};
+        if (!form || !baseline) return payload;
+
+        if (form.full_name !== baseline.full_name) {
+            const trimmed = form.full_name.trim();
+            payload.full_name = trimmed === '' ? null : trimmed;
+        }
+        if (form.bio !== baseline.bio) {
+            const trimmed = form.bio.trim();
+            payload.bio = trimmed === '' ? null : trimmed;
+        }
+        if (form.timezone !== baseline.timezone) {
+            payload.timezone = form.timezone === '' ? null : form.timezone;
+        }
+        if (form.favorite_deck_id !== baseline.favorite_deck_id && form.favorite_deck_id !== '') {
+            payload.favorite_deck_id = form.favorite_deck_id;
+        }
+        if (form.lunar_phase_awareness !== baseline.lunar_phase_awareness) {
+            payload.lunar_phase_awareness = form.lunar_phase_awareness;
+        }
+        if (form.card_animations !== baseline.card_animations) {
+            payload.card_animations = form.card_animations;
+        }
+        if (form.reading_language !== baseline.reading_language) {
+            payload.reading_language = form.reading_language;
+        }
+        if (form.reversed_cards !== baseline.reversed_cards) {
+            payload.reversed_cards = form.reversed_cards;
+        }
+        return payload;
+    };
+
+    const handleSave = async () => {
+        if (!updateProfile || !isDirty) return;
+        const payload = buildPayload();
+        if (Object.keys(payload).length === 0) return;
+
+        setIsSaving(true);
         try {
-            const ok = await updateFullName(fullNameValue);
-            if (ok) setIsEditingName(false);
+            const ok = await updateProfile(payload);
+            if (ok) {
+                toast.success('Profile updated');
+            } else {
+                toast.error('Could not save your profile. Please try again.');
+            }
         } finally {
-            setIsSavingName(false);
+            setIsSaving(false);
         }
     };
 
-    if (isLoading || !profile) {
+    const handleDiscard = () => {
+        setForm(baseline);
+    };
+
+    if (isLoading || !profile || !form) {
         return (
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 60 }}>
                 <div style={{
@@ -48,6 +157,10 @@ export function ProfileInfoTab({ profile, isLoading, onAvatarChange, fetchProfil
             </div>
         );
     }
+
+    const deckOptions = decks && decks.length > 0
+        ? decks
+        : (profile.favorite_deck ? [profile.favorite_deck] : []);
 
     return (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
@@ -110,7 +223,7 @@ export function ProfileInfoTab({ profile, isLoading, onAvatarChange, fetchProfil
                             letterSpacing: '-0.01em', fontFamily: "'Cormorant Garamond', serif",
                             color: '#f4f1ff',
                         }}>
-                            {profile.username}
+                            {profile.full_name || profile.username}
                         </h2>
                         <p style={{ margin: '6px 0 18px', color: '#b3b0d4', fontSize: 15 }}>
                             {profile.email}
@@ -136,52 +249,52 @@ export function ProfileInfoTab({ profile, isLoading, onAvatarChange, fetchProfil
                     </div>
                     <div style={{ gridColumn: '1 / -1' }}>
                         <FieldLabel>Full name (display name)</FieldLabel>
-                        {isEditingName ? (
-                            <div style={{ display: 'flex', gap: 10 }}>
-                                <FieldInput
-                                    value={fullNameValue}
-                                    onChange={(e) => setFullNameValue(e.target.value)}
-                                    placeholder="Enter your full name"
-                                    disabled={isSavingName}
-                                    style={{ flex: 1 }}
-                                />
-                                <MysticButton onClick={handleSaveName} disabled={isSavingName}>
-                                    <ProfileIcon name="check" size={14} />
-                                    {isSavingName ? 'Saving…' : 'Save'}
-                                </MysticButton>
-                                <GhostButton onClick={() => { setIsEditingName(false); setFullNameValue(profile.full_name || ''); }}>
-                                    Cancel
-                                </GhostButton>
-                            </div>
-                        ) : (
-                            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                                <FieldInput value={profile.full_name || ''} readOnly style={{ flex: 1, opacity: 0.7, cursor: 'default' }} />
-                                <GhostButton onClick={() => { setIsEditingName(true); setFullNameValue(profile.full_name || ''); }}>
-                                    Edit
-                                </GhostButton>
-                            </div>
-                        )}
+                        <FieldInput
+                            value={form.full_name}
+                            onChange={(e) => setField('full_name', e.target.value)}
+                            placeholder="Enter your full name"
+                            disabled={isSaving}
+                            maxLength={100}
+                        />
                     </div>
                     <div>
                         <FieldLabel>Timezone</FieldLabel>
-                        <FieldSelect defaultValue="Asia/Ho_Chi_Minh (UTC+7)">
-                            <option>Asia/Ho_Chi_Minh (UTC+7)</option>
-                            <option>Asia/Singapore (UTC+8)</option>
-                            <option>Europe/London (UTC+0)</option>
-                            <option>America/New_York (UTC−5)</option>
+                        <FieldSelect
+                            value={form.timezone}
+                            onChange={(e) => setField('timezone', e.target.value)}
+                            disabled={isSaving}
+                        >
+                            <option value="">Not set</option>
+                            {TIMEZONE_OPTIONS.map((tz) => (
+                                <option key={tz.value} value={tz.value}>{tz.label}</option>
+                            ))}
                         </FieldSelect>
                     </div>
                     <div>
                         <FieldLabel>Favorite deck</FieldLabel>
-                        <FieldInput
-                            value={profile.favorite_deck ? profile.favorite_deck.name : 'No deck selected'}
-                            readOnly
-                            style={{ opacity: 0.7, cursor: 'default' }}
-                        />
+                        <FieldSelect
+                            value={form.favorite_deck_id === '' ? '' : String(form.favorite_deck_id)}
+                            onChange={(e) => setField('favorite_deck_id', e.target.value === '' ? '' : Number(e.target.value))}
+                            disabled={isSaving || deckOptions.length === 0}
+                        >
+                            {form.favorite_deck_id === '' && <option value="">No deck selected</option>}
+                            {deckOptions.map((deck) => (
+                                <option key={deck.id} value={String(deck.id)}>{deck.name}</option>
+                            ))}
+                        </FieldSelect>
                     </div>
                     <div style={{ gridColumn: '1 / -1' }}>
                         <FieldLabel>Bio · what the cards reveal about you</FieldLabel>
-                        <FieldTextarea defaultValue="Reader of the Thoth deck. Drawn to the Major Arcana, fascinated by reversals." />
+                        <FieldTextarea
+                            value={form.bio}
+                            onChange={(e) => setField('bio', e.target.value)}
+                            placeholder="Reader of the Thoth deck. Drawn to the Major Arcana, fascinated by reversals."
+                            disabled={isSaving}
+                            maxLength={500}
+                        />
+                        <div style={{ marginTop: 6, textAlign: 'right', fontSize: 11, color: '#7c799f' }}>
+                            {form.bio.length} / 500
+                        </div>
                     </div>
                 </div>
             </MysticCard>
@@ -190,15 +303,50 @@ export function ProfileInfoTab({ profile, isLoading, onAvatarChange, fetchProfil
             <MysticCard>
                 <SectionHeader eyebrow="Practice" title="Reading preferences" />
                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 14, marginTop: 20 }}>
-                    <PrefRow icon="moon" label="Lunar phase awareness" value="On" desc="Color readings with current moon phase" />
-                    <PrefRow icon="sparkle" label="Card animations" value="Cinematic" desc="Full shuffle + reveal sequence" />
-                    <PrefRow icon="globe" label="Reading language" value="English" desc="Used for all generated interpretations" />
-                    <PrefRow icon="eye" label="Reversed cards" value="Enabled" desc="Cards may appear inverted in spreads" />
+                    <ToggleRow
+                        icon="moon"
+                        label="Lunar phase awareness"
+                        desc="Color readings with current moon phase"
+                        checked={form.lunar_phase_awareness}
+                        disabled={isSaving}
+                        onChange={(v) => setField('lunar_phase_awareness', v)}
+                    />
+                    <SelectRow
+                        icon="sparkle"
+                        label="Card animations"
+                        desc={CARD_ANIMATION_OPTIONS.find((o) => o.value === form.card_animations)?.desc ?? ''}
+                        value={form.card_animations}
+                        disabled={isSaving}
+                        options={CARD_ANIMATION_OPTIONS.map((o) => ({ value: o.value, label: o.label }))}
+                        onChange={(v) => setField('card_animations', v)}
+                    />
+                    <SelectRow
+                        icon="globe"
+                        label="Reading language"
+                        desc="Used for all generated interpretations"
+                        value={form.reading_language}
+                        disabled={isSaving}
+                        options={READING_LANGUAGE_OPTIONS.map((l) => ({ value: l, label: l }))}
+                        onChange={(v) => setField('reading_language', v)}
+                    />
+                    <ToggleRow
+                        icon="eye"
+                        label="Reversed cards"
+                        desc="Cards may appear inverted in spreads"
+                        checked={form.reversed_cards}
+                        disabled={isSaving}
+                        onChange={(v) => setField('reversed_cards', v)}
+                    />
                 </div>
-                <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 24, gap: 10 }}>
-                    <GhostButton>Discard changes</GhostButton>
-                    <MysticButton>
-                        <ProfileIcon name="check" size={14} /> Save profile
+                <div style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', marginTop: 24, gap: 10 }}>
+                    {isDirty && (
+                        <span style={{ marginRight: 'auto', color: '#f5b942', fontSize: 12 }}>
+                            You have unsaved changes
+                        </span>
+                    )}
+                    <GhostButton onClick={handleDiscard} disabled={isSaving || !isDirty}>Discard changes</GhostButton>
+                    <MysticButton onClick={handleSave} disabled={isSaving || !isDirty}>
+                        <ProfileIcon name="check" size={14} /> {isSaving ? 'Saving…' : 'Save profile'}
                     </MysticButton>
                 </div>
             </MysticCard>
@@ -206,7 +354,12 @@ export function ProfileInfoTab({ profile, isLoading, onAvatarChange, fetchProfil
     );
 }
 
-function PrefRow({ icon, label, value, desc }: { icon: Parameters<typeof ProfileIcon>[0]['name']; label: string; value: string; desc: string }) {
+function RowShell({ icon, label, desc, children }: {
+    icon: Parameters<typeof ProfileIcon>[0]['name'];
+    label: string;
+    desc: string;
+    children: React.ReactNode;
+}) {
     return (
         <div style={{
             display: 'flex', alignItems: 'center', gap: 14,
@@ -226,14 +379,72 @@ function PrefRow({ icon, label, value, desc }: { icon: Parameters<typeof Profile
                 <div style={{ fontSize: 14, fontWeight: 600, color: '#f4f1ff' }}>{label}</div>
                 <div style={{ fontSize: 12, color: '#7c799f' }}>{desc}</div>
             </div>
-            <div style={{
-                fontSize: 12, fontWeight: 600, color: '#b3b0d4',
-                padding: '6px 12px', background: '#1d2049', borderRadius: 999,
-                flexShrink: 0,
-            }}>
-                {value}
-            </div>
+            <div style={{ flexShrink: 0 }}>{children}</div>
         </div>
+    );
+}
+
+function ToggleRow({ icon, label, desc, checked, disabled, onChange }: {
+    icon: Parameters<typeof ProfileIcon>[0]['name'];
+    label: string;
+    desc: string;
+    checked: boolean;
+    disabled?: boolean;
+    onChange: (v: boolean) => void;
+}) {
+    return (
+        <RowShell icon={icon} label={label} desc={desc}>
+            <button
+                type="button"
+                role="switch"
+                aria-checked={checked}
+                aria-label={label}
+                onClick={() => !disabled && onChange(!checked)}
+                disabled={disabled}
+                style={{
+                    width: 46, height: 26, borderRadius: 999, position: 'relative',
+                    border: '1px solid', cursor: disabled ? 'not-allowed' : 'pointer',
+                    borderColor: checked ? 'rgba(168,85,247,0.6)' : '#2a2d5a',
+                    background: checked
+                        ? 'linear-gradient(180deg, #a855f7 0%, #8b5cf6 100%)'
+                        : '#1d2049',
+                    transition: 'all 160ms ease', padding: 0,
+                    opacity: disabled ? 0.6 : 1,
+                }}
+            >
+                <span style={{
+                    position: 'absolute', top: 2, left: checked ? 22 : 2,
+                    width: 20, height: 20, borderRadius: '50%',
+                    background: '#fff', transition: 'left 160ms ease',
+                    boxShadow: '0 1px 3px rgba(0,0,0,0.4)',
+                }} />
+            </button>
+        </RowShell>
+    );
+}
+
+function SelectRow({ icon, label, desc, value, options, disabled, onChange }: {
+    icon: Parameters<typeof ProfileIcon>[0]['name'];
+    label: string;
+    desc: string;
+    value: string;
+    options: { value: string; label: string }[];
+    disabled?: boolean;
+    onChange: (v: string) => void;
+}) {
+    return (
+        <RowShell icon={icon} label={label} desc={desc}>
+            <FieldSelect
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                disabled={disabled}
+                style={{ width: 'auto', minWidth: 130, padding: '8px 12px' }}
+            >
+                {options.map((o) => (
+                    <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+            </FieldSelect>
+        </RowShell>
     );
 }
 

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -19,7 +19,7 @@ type TabId = 'profile' | 'decks' | 'subscription' | 'history' | 'notifications';
 
 export default function ProfilePage() {
     const { isAuthenticated } = useAuth();
-    const { profile, fetchProfile, updateFullName } = useUserProfile();
+    const { profile, decks, fetchProfile, fetchDecks, updateProfile } = useUserProfile();
     const { isPremium } = useSubscription();
 
     const [activeTab, setActiveTab] = useState<TabId>('profile');
@@ -27,7 +27,8 @@ export default function ProfilePage() {
 
     useEffect(() => {
         fetchProfile();
-    }, [fetchProfile]);
+        fetchDecks();
+    }, [fetchProfile, fetchDecks]);
 
     if (!isAuthenticated) {
         return (
@@ -94,8 +95,9 @@ export default function ProfilePage() {
                         {activeTab === 'profile' && (
                             <ProfileInfoTab
                                 profile={profile}
+                                decks={decks}
                                 fetchProfile={fetchProfile}
-                                updateFullName={updateFullName}
+                                updateProfile={updateProfile}
                                 onAvatarChange={() => {}}
                             />
                         )}

--- a/frontend/src/hooks/useUserProfile.ts
+++ b/frontend/src/hooks/useUserProfile.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { UserProfile, Deck } from '@/types/tarot';
+import { UserProfile, Deck, ProfileUpdatePayload } from '@/types/tarot';
 import { auth } from '@/lib/api';
 import { useAuth } from '@/contexts/AuthContext';
 
@@ -84,22 +84,22 @@ export const useUserProfile = () => {
         }
     }, []);
 
-    const updateFullName = useCallback(async (fullName: string) => {
+    const updateProfile = useCallback(async (data: ProfileUpdatePayload) => {
         setIsLoading(true);
         setError(null);
 
         try {
-            // Convert empty string to null for the API
-            const fullNameValue = fullName.trim() === '' ? null : fullName.trim();
-            const updatedProfile = await auth.updateProfile({ full_name: fullNameValue });
+            const updatedProfile = await auth.updateProfile(data);
             setProfile(updatedProfile);
             return true;
         } catch (err: unknown) {
-            let errorMessage = 'Failed to update full name';
+            let errorMessage = 'Failed to update profile';
             if (typeof err === 'object' && err !== null) {
-                const errorObject = err as { response?: { data?: { error?: string } }, message?: string };
+                const errorObject = err as { response?: { data?: { error?: string; detail?: string } }, message?: string };
                 if (errorObject.response?.data?.error) {
                     errorMessage = errorObject.response.data.error;
+                } else if (errorObject.response?.data?.detail) {
+                    errorMessage = errorObject.response.data.detail;
                 } else if (errorObject.message) {
                     errorMessage = errorObject.message;
                 }
@@ -119,6 +119,6 @@ export const useUserProfile = () => {
         fetchProfile,
         fetchDecks,
         updateFavoriteDeck,
-        updateFullName,
+        updateProfile,
     };
 };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -26,6 +26,7 @@ import {
     ReminderCreate,
     JournalFilters,
     TagUsage,
+    ProfileUpdatePayload,
 } from "@/types/tarot";
 
 // Callback function to be set by AuthProvider
@@ -237,7 +238,7 @@ export const auth = {
         return response.data;
     },
 
-    updateProfile: async (data: { favorite_deck_id?: number; full_name?: string | null }) => {
+    updateProfile: async (data: ProfileUpdatePayload) => {
         const response = await api.put("/auth/me", data);
         return response.data;
     },

--- a/frontend/src/test-utils.tsx
+++ b/frontend/src/test-utils.tsx
@@ -21,6 +21,7 @@ jest.mock('@/hooks/useUserProfile', () => ({
         fetchProfile: jest.fn(),
         fetchDecks: jest.fn(),
         updateFavoriteDeck: jest.fn().mockResolvedValue(true),
+        updateProfile: jest.fn().mockResolvedValue(true),
     }),
 }));
 

--- a/frontend/src/types/tarot.ts
+++ b/frontend/src/types/tarot.ts
@@ -65,6 +65,23 @@ export interface UserProfile {
     number_of_paid_turns: number;
     last_free_turns_reset?: string;
     avatar_url?: string;
+    bio?: string | null;
+    timezone?: string | null;
+    lunar_phase_awareness?: boolean;
+    card_animations?: string;
+    reading_language?: string;
+    reversed_cards?: boolean;
+}
+
+export interface ProfileUpdatePayload {
+    favorite_deck_id?: number;
+    full_name?: string | null;
+    bio?: string | null;
+    timezone?: string | null;
+    lunar_phase_awareness?: boolean;
+    card_animations?: string;
+    reading_language?: string;
+    reversed_cards?: boolean;
 }
 
 // Shared Reading Types


### PR DESCRIPTION
## Summary
Expanded the user profile management system to allow users to edit and save additional profile information beyond just their full name. Users can now manage their bio, timezone, favorite deck, and reading preferences (lunar phase awareness, card animations, reading language, and reversed cards) through an enhanced profile settings interface.

## Key Changes

### Backend
- **Database Model**: Added six new fields to the `User` model:
  - `bio` (optional text field, max 500 chars)
  - `timezone` (optional IANA timezone string)
  - `lunar_phase_awareness` (boolean, default True)
  - `card_animations` (string: cinematic/minimal/off, default "cinematic")
  - `reading_language` (string: English/Vietnamese/Spanish/French/German, default "English")
  - `reversed_cards` (boolean, default True)

- **Schema Updates**: Extended `UserUpdate` schema with validators for all new fields:
  - Bio validation: sanitized, max 500 chars, whitespace-only treated as null
  - Timezone validation: verified against IANA timezone database
  - Card animations: restricted to predefined choices
  - Reading language: restricted to predefined choices
  - All fields support clearing by sending null or empty string

- **API Endpoint**: Updated `PUT /auth/me` to accept and persist all new profile fields
- **Response Schema**: Extended `UserResponse` to include all new fields with appropriate defaults
- **Database Migration**: Added migration to safely add new columns with sensible defaults

- **Tests**: Added comprehensive test coverage for all new profile fields including validation, persistence, and partial updates

### Frontend
- **Type Definitions**: Added `ProfileUpdatePayload` interface for type-safe profile updates
- **Profile Component**: Completely refactored `ProfileInfoTab` to:
  - Use unified form state management instead of individual field states
  - Support editing all profile fields (bio, timezone, favorite deck, reading preferences)
  - Implement dirty state tracking to show "unsaved changes" indicator
  - Add save/discard functionality with proper loading states
  - Display character count for bio field (500 char limit)

- **UI Components**: 
  - Replaced static preference display with interactive toggle and select components
  - Added `ToggleRow` component for boolean preferences with smooth animations
  - Added `SelectRow` component for dropdown preferences
  - Timezone selector with 13 common timezones
  - Card animation selector with descriptions
  - Reading language selector with 5 supported languages

- **Hook Updates**: Modified `useUserProfile` hook to:
  - Replace `updateFullName` with generic `updateProfile` method
  - Support batch updates of multiple profile fields
  - Add `fetchDecks` capability for populating favorite deck selector

- **Toast Notifications**: Added success/error feedback when saving profile changes

## Notable Implementation Details
- Form state is synced with the baseline profile via `useEffect`, allowing proper handling of async profile loads and refetches
- Dirty state is computed via `useMemo` to efficiently track changes
- Only changed fields are included in the update payload sent to the API
- Timezone validation uses Python's `zoneinfo` module for robust IANA timezone support
- All string inputs are sanitized to prevent XSS attacks
- Reading preferences have sensible defaults that apply to new users

https://claude.ai/code/session_012vS5EoK7WbqgmgASvtapfN