### PR TITLE
feat: gate profile editing behind an explicit Edit button

### DIFF
--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.16] - 2026-05-24
+
+### Changed
+- Profile editing now uses an explicit "Edit profile" button: fields are read-only by default and unlock for editing only after clicking Edit, which then shows Save/Cancel controls. This replaces the always-editable form so it's clear how to update profile information.
+
 ## [0.0.15] - 2026-05-24
 
 ### Added

--- a/frontend/src/app/profile/_components/ProfileIcon.tsx
+++ b/frontend/src/app/profile/_components/ProfileIcon.tsx
@@ -6,7 +6,7 @@ type IconName =
     | 'user' | 'cards' | 'crown' | 'history' | 'bell'
     | 'upload' | 'trash' | 'check' | 'sparkle' | 'moon'
     | 'bolt' | 'plus' | 'refresh' | 'lock' | 'external'
-    | 'dot' | 'globe' | 'eye' | 'chart' | 'card';
+    | 'dot' | 'globe' | 'eye' | 'chart' | 'card' | 'pencil';
 
 export function ProfileIcon({ name, size = 16, stroke = 1.8 }: { name: IconName; size?: number; stroke?: number }) {
     const common = {
@@ -36,6 +36,7 @@ export function ProfileIcon({ name, size = 16, stroke = 1.8 }: { name: IconName;
         case 'eye':     return <svg {...common}><path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12z"/><circle cx="12" cy="12" r="3"/></svg>;
         case 'chart':   return <svg {...common}><line x1="3" y1="20" x2="21" y2="20"/><line x1="6" y1="20" x2="6" y2="12"/><line x1="11" y1="20" x2="11" y2="8"/><line x1="16" y1="20" x2="16" y2="14"/><line x1="21" y1="20" x2="21" y2="4"/></svg>;
         case 'card':    return <svg {...common}><rect x="2" y="6" width="20" height="13" rx="2"/><line x1="2" y1="11" x2="22" y2="11"/></svg>;
+        case 'pencil':  return <svg {...common}><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z"/></svg>;
         default: return null;
     }
 }

--- a/frontend/src/app/profile/_components/ProfileInfoTab.tsx
+++ b/frontend/src/app/profile/_components/ProfileInfoTab.tsx
@@ -68,6 +68,7 @@ export function ProfileInfoTab({ profile, decks, isLoading, onAvatarChange, fetc
     const baseline = useMemo(() => (profile ? toForm(profile) : null), [profile]);
     const [form, setForm] = useState<FormState | null>(baseline);
     const [isSaving, setIsSaving] = useState(false);
+    const [isEditing, setIsEditing] = useState(false);
 
     // Re-sync the editable form whenever the underlying profile changes
     // (initial load, refetch, or after a successful save).
@@ -131,6 +132,7 @@ export function ProfileInfoTab({ profile, decks, isLoading, onAvatarChange, fetc
             const ok = await updateProfile(payload);
             if (ok) {
                 toast.success('Profile updated');
+                setIsEditing(false);
             } else {
                 toast.error('Could not save your profile. Please try again.');
             }
@@ -139,9 +141,12 @@ export function ProfileInfoTab({ profile, decks, isLoading, onAvatarChange, fetc
         }
     };
 
-    const handleDiscard = () => {
+    const handleCancel = () => {
         setForm(baseline);
+        setIsEditing(false);
     };
+
+    const locked = !isEditing || isSaving;
 
     if (isLoading || !profile || !form) {
         return (
@@ -237,7 +242,15 @@ export function ProfileInfoTab({ profile, decks, isLoading, onAvatarChange, fetc
 
             {/* Account details form */}
             <MysticCard>
-                <SectionHeader eyebrow="Personal" title="Account details" />
+                <SectionHeader
+                    eyebrow="Personal"
+                    title="Account details"
+                    action={!isEditing ? (
+                        <MysticButton onClick={() => setIsEditing(true)}>
+                            <ProfileIcon name="pencil" size={14} /> Edit profile
+                        </MysticButton>
+                    ) : undefined}
+                />
                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20, marginTop: 20 }}>
                     <div>
                         <FieldLabel>Username</FieldLabel>
@@ -252,9 +265,10 @@ export function ProfileInfoTab({ profile, decks, isLoading, onAvatarChange, fetc
                         <FieldInput
                             value={form.full_name}
                             onChange={(e) => setField('full_name', e.target.value)}
-                            placeholder="Enter your full name"
-                            disabled={isSaving}
+                            placeholder={isEditing ? 'Enter your full name' : 'Not set'}
+                            readOnly={locked}
                             maxLength={100}
+                            style={locked ? { opacity: 0.7, cursor: 'default' } : undefined}
                         />
                     </div>
                     <div>
@@ -262,7 +276,8 @@ export function ProfileInfoTab({ profile, decks, isLoading, onAvatarChange, fetc
                         <FieldSelect
                             value={form.timezone}
                             onChange={(e) => setField('timezone', e.target.value)}
-                            disabled={isSaving}
+                            disabled={locked}
+                            style={locked ? { opacity: 0.7, cursor: 'default' } : undefined}
                         >
                             <option value="">Not set</option>
                             {TIMEZONE_OPTIONS.map((tz) => (
@@ -275,7 +290,8 @@ export function ProfileInfoTab({ profile, decks, isLoading, onAvatarChange, fetc
                         <FieldSelect
                             value={form.favorite_deck_id === '' ? '' : String(form.favorite_deck_id)}
                             onChange={(e) => setField('favorite_deck_id', e.target.value === '' ? '' : Number(e.target.value))}
-                            disabled={isSaving || deckOptions.length === 0}
+                            disabled={locked || deckOptions.length === 0}
+                            style={locked ? { opacity: 0.7, cursor: 'default' } : undefined}
                         >
                             {form.favorite_deck_id === '' && <option value="">No deck selected</option>}
                             {deckOptions.map((deck) => (
@@ -288,13 +304,16 @@ export function ProfileInfoTab({ profile, decks, isLoading, onAvatarChange, fetc
                         <FieldTextarea
                             value={form.bio}
                             onChange={(e) => setField('bio', e.target.value)}
-                            placeholder="Reader of the Thoth deck. Drawn to the Major Arcana, fascinated by reversals."
-                            disabled={isSaving}
+                            placeholder={isEditing ? 'Reader of the Thoth deck. Drawn to the Major Arcana, fascinated by reversals.' : 'No bio yet'}
+                            readOnly={locked}
                             maxLength={500}
+                            style={locked ? { opacity: 0.7, cursor: 'default' } : undefined}
                         />
-                        <div style={{ marginTop: 6, textAlign: 'right', fontSize: 11, color: '#7c799f' }}>
-                            {form.bio.length} / 500
-                        </div>
+                        {isEditing && (
+                            <div style={{ marginTop: 6, textAlign: 'right', fontSize: 11, color: '#7c799f' }}>
+                                {form.bio.length} / 500
+                            </div>
+                        )}
                     </div>
                 </div>
             </MysticCard>
@@ -308,7 +327,7 @@ export function ProfileInfoTab({ profile, decks, isLoading, onAvatarChange, fetc
                         label="Lunar phase awareness"
                         desc="Color readings with current moon phase"
                         checked={form.lunar_phase_awareness}
-                        disabled={isSaving}
+                        disabled={locked}
                         onChange={(v) => setField('lunar_phase_awareness', v)}
                     />
                     <SelectRow
@@ -316,7 +335,7 @@ export function ProfileInfoTab({ profile, decks, isLoading, onAvatarChange, fetc
                         label="Card animations"
                         desc={CARD_ANIMATION_OPTIONS.find((o) => o.value === form.card_animations)?.desc ?? ''}
                         value={form.card_animations}
-                        disabled={isSaving}
+                        disabled={locked}
                         options={CARD_ANIMATION_OPTIONS.map((o) => ({ value: o.value, label: o.label }))}
                         onChange={(v) => setField('card_animations', v)}
                     />
@@ -325,7 +344,7 @@ export function ProfileInfoTab({ profile, decks, isLoading, onAvatarChange, fetc
                         label="Reading language"
                         desc="Used for all generated interpretations"
                         value={form.reading_language}
-                        disabled={isSaving}
+                        disabled={locked}
                         options={READING_LANGUAGE_OPTIONS.map((l) => ({ value: l, label: l }))}
                         onChange={(v) => setField('reading_language', v)}
                     />
@@ -334,21 +353,23 @@ export function ProfileInfoTab({ profile, decks, isLoading, onAvatarChange, fetc
                         label="Reversed cards"
                         desc="Cards may appear inverted in spreads"
                         checked={form.reversed_cards}
-                        disabled={isSaving}
+                        disabled={locked}
                         onChange={(v) => setField('reversed_cards', v)}
                     />
                 </div>
-                <div style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', marginTop: 24, gap: 10 }}>
-                    {isDirty && (
-                        <span style={{ marginRight: 'auto', color: '#f5b942', fontSize: 12 }}>
-                            You have unsaved changes
-                        </span>
-                    )}
-                    <GhostButton onClick={handleDiscard} disabled={isSaving || !isDirty}>Discard changes</GhostButton>
-                    <MysticButton onClick={handleSave} disabled={isSaving || !isDirty}>
-                        <ProfileIcon name="check" size={14} /> {isSaving ? 'Saving…' : 'Save profile'}
-                    </MysticButton>
-                </div>
+                {isEditing && (
+                    <div style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', marginTop: 24, gap: 10 }}>
+                        {isDirty && (
+                            <span style={{ marginRight: 'auto', color: '#f5b942', fontSize: 12 }}>
+                                You have unsaved changes
+                            </span>
+                        )}
+                        <GhostButton onClick={handleCancel} disabled={isSaving}>Cancel</GhostButton>
+                        <MysticButton onClick={handleSave} disabled={isSaving || !isDirty}>
+                            <ProfileIcon name="check" size={14} /> {isSaving ? 'Saving…' : 'Save profile'}
+                        </MysticButton>
+                    </div>
+                )}
             </MysticCard>
         </div>
     );


### PR DESCRIPTION
Profile fields are now read-only until the user clicks "Edit profile", which unlocks the inputs and shows Save/Cancel. Makes it clear how to update info instead of the always-editable form.

https://claude.ai/code/session_012vS5EoK7WbqgmgASvtapfN