### PR TITLE
Make admin topbar search actionable and route/prefill admin pages

### DIFF
--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The profile "Account details" and "Reading preferences" sections are now a single editable form with Save/Discard controls and an unsaved-changes indicator, instead of static placeholder fields.
 
+### Fixed
+- Admin portal top-bar search is now actionable: clicking the search icon or pressing Enter runs an admin search, routes to Users/Cards/Chat Sessions, and pre-fills each destination page's local search filter with the query.
+
 ## [0.0.14] - 2026-05-24
 
 

--- a/frontend/src/app/admin/admin.css
+++ b/frontend/src/app/admin/admin.css
@@ -344,6 +344,14 @@
   color: var(--text-1);
 }
 .admin-shell .search-input input::placeholder { color: var(--text-3); }
+.admin-shell .search-input-btn {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  display: grid;
+  place-items: center;
+}
 
 .admin-shell .topbar-icon-btn {
   position: relative;

--- a/frontend/src/app/admin/cards/page.tsx
+++ b/frontend/src/app/admin/cards/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import AdminLayout, { AdminLoadingScreen } from "@/components/AdminLayout";
 import { PageHeader, StatCard, SearchInput, Icon, Table, type Column } from "@/components/admin/AdminUI";
@@ -48,6 +48,7 @@ const COLUMNS: Column[] = [
 export default function AdminCardsPage() {
     const { user, isAuthenticated, isAuthLoading } = useAuth();
     const router = useRouter();
+    const searchParams = useSearchParams();
     const [cards, setCards] = useState<AdminCard[]>([]);
     const [decks, setDecks] = useState<AdminDeck[]>([]);
     const [loading, setLoading] = useState(true);
@@ -97,6 +98,11 @@ export default function AdminCardsPage() {
             return c.name.toLowerCase().includes(s) || (c.suit ?? "").toLowerCase().includes(s);
         });
     }, [cards, q, deckFilter, decks]);
+
+    useEffect(() => {
+        const query = searchParams.get("q");
+        if (query) setQ(query);
+    }, [searchParams]);
 
     if (isAuthLoading || !user) return <AdminLoadingScreen label="Loading cards…" />;
     if (!user.is_admin) return null;

--- a/frontend/src/app/admin/chat-sessions/page.tsx
+++ b/frontend/src/app/admin/chat-sessions/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import AdminLayout, { AdminLoadingScreen } from "@/components/AdminLayout";
-import { PageHeader, StatCard, Icon, Table, type Column } from "@/components/admin/AdminUI";
+import { PageHeader, StatCard, SearchInput, Icon, Table, type Column } from "@/components/admin/AdminUI";
 import api from "@/lib/api";
 
 interface AdminChatSession {
@@ -36,11 +36,13 @@ const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 export default function AdminChatSessionsPage() {
     const { user, isAuthenticated, isAuthLoading } = useAuth();
     const router = useRouter();
+    const searchParams = useSearchParams();
     const [sessions, setSessions] = useState<AdminChatSession[]>([]);
     const [stats, setStats] = useState<DashboardStats>({});
     const [sortField, setSortField] = useState<SortField>("created_at");
     const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
     const [loading, setLoading] = useState(true);
+    const [q, setQ] = useState("");
 
     useEffect(() => {
         if (isAuthLoading) return;
@@ -97,6 +99,20 @@ export default function AdminChatSessionsPage() {
             capped: sessions.length >= 100 && totalSessions > sessions.length,
         };
     }, [sessions, stats]);
+
+    useEffect(() => {
+        const query = searchParams.get("q");
+        if (query) setQ(query);
+    }, [searchParams]);
+
+    const filteredSessions = useMemo(() => {
+        const search = q.trim().toLowerCase();
+        if (!search) return sessions;
+        return sessions.filter((s) =>
+            (s.title ?? "").toLowerCase().includes(search) ||
+            (s.username ?? "").toLowerCase().includes(search),
+        );
+    }, [sessions, q]);
 
     if (isAuthLoading || !user) return <AdminLoadingScreen label="Loading sessions…" />;
     if (!user.is_admin) return null;
@@ -186,10 +202,13 @@ export default function AdminChatSessionsPage() {
                         </div>
                     </div>
                 </div>
+                <div className="toolbar">
+                    <SearchInput value={q} onChange={setQ} placeholder="Search sessions by title or username…" />
+                </div>
 
                 <Table
                     columns={COLUMNS}
-                    rows={sessions}
+                    rows={filteredSessions}
                     empty="No chat sessions found."
                     renderRow={(s: AdminChatSession) => (
                         <tr key={s.id}>

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import AdminLayout, { AdminLoadingScreen } from "@/components/AdminLayout";
 import { PageHeader, StatCard, Pill, Button, SearchInput, Icon, Table, type Column } from "@/components/admin/AdminUI";
@@ -43,6 +43,7 @@ const COLUMNS: Column[] = [
 export default function AdminUsersPage() {
     const { user, isAuthenticated, isAuthLoading } = useAuth();
     const router = useRouter();
+    const searchParams = useSearchParams();
     const [users, setUsers] = useState<AdminUser[]>([]);
     const [decks, setDecks] = useState<AdminDeck[]>([]);
     const [loading, setLoading] = useState(true);
@@ -91,6 +92,11 @@ export default function AdminUsersPage() {
     const pageRows = filtered.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
 
     useEffect(() => { setPage(1); }, [q, filter]);
+
+    useEffect(() => {
+        const query = searchParams.get("q");
+        if (query) setQ(query);
+    }, [searchParams]);
 
     if (isAuthLoading || !user) return <AdminLoadingScreen label="Loading users…" />;
     if (!user.is_admin) return null;

--- a/frontend/src/components/AdminLayout.tsx
+++ b/frontend/src/components/AdminLayout.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import Link from "next/link";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import "@/app/admin/admin.css";
 import api, { tarot } from "@/lib/api";
 import { Icon, SearchInput, type IconName } from "@/components/admin/AdminUI";
@@ -199,10 +200,12 @@ interface AdminLayoutProps {
 }
 
 export default function AdminLayout({ children, activePath, breadcrumb, username = "Admin" }: AdminLayoutProps) {
+    const router = useRouter();
     const theme = useAdminTheme();
     const [sidebarOpen, setSidebarOpen] = useState(false);
     const [counts, setCounts] = useState<SidebarCounts>({});
     const [search, setSearch] = useState("");
+    const [searching, setSearching] = useState(false);
     const dailyCard = useDailyCard();
     const initial = username[0]?.toUpperCase() ?? "A";
 
@@ -213,6 +216,31 @@ export default function AdminLayout({ children, activePath, breadcrumb, username
             .catch(() => { /* counts are best-effort */ });
         return () => { cancelled = true; };
     }, []);
+
+    const runGlobalSearch = useCallback(async () => {
+        const q = search.trim();
+        if (!q || searching) return;
+        setSearching(true);
+        try {
+            const [users, cards, sessions] = await Promise.all([
+                api.post("/admin/search", { query: q, model_type: "users", limit: 1, offset: 0 }),
+                api.post("/admin/search", { query: q, model_type: "cards", limit: 1, offset: 0 }),
+                api.post("/admin/search", { query: q, model_type: "chat_sessions", limit: 1, offset: 0 }),
+            ]);
+
+            const user = users.data?.[0];
+            const card = cards.data?.[0];
+            const session = sessions.data?.[0];
+            const encoded = encodeURIComponent(q);
+            if (user?.id) router.push(`/admin/users?q=${encoded}`);
+            else if (card?.id) router.push(`/admin/cards?q=${encoded}`);
+            else if (session?.id) router.push(`/admin/chat-sessions?q=${encoded}`);
+        } catch (error) {
+            console.error("Admin global search failed:", error);
+        } finally {
+            setSearching(false);
+        }
+    }, [router, search, searching]);
 
     return (
         <div
@@ -285,7 +313,12 @@ export default function AdminLayout({ children, activePath, breadcrumb, username
                             </div>
                         </div>
                         <div className="topbar-right">
-                            <SearchInput value={search} onChange={setSearch} placeholder="Search users, cards, sessions…" />
+                            <SearchInput
+                                value={search}
+                                onChange={setSearch}
+                                onSubmit={runGlobalSearch}
+                                placeholder="Search users, cards, sessions…"
+                            />
                             <button className="topbar-icon-btn" aria-label="Notifications">
                                 <Icon name="bell" size={16} />
                             </button>

--- a/frontend/src/components/admin/AdminUI.tsx
+++ b/frontend/src/components/admin/AdminUI.tsx
@@ -139,12 +139,25 @@ export const Button = ({ variant = "secondary", size = "md", icon, children, ...
 );
 
 /* ─── Search input ──────────────────────────────────────────────────────── */
-export const SearchInput = ({ value, onChange, placeholder = "Search…" }: {
-    value: string; onChange: (v: string) => void; placeholder?: string;
+export const SearchInput = ({ value, onChange, placeholder = "Search…", onSubmit }: {
+    value: string;
+    onChange: (v: string) => void;
+    placeholder?: string;
+    onSubmit?: () => void;
 }) => (
     <div className="search-input">
-        <Icon name="search" size={15} />
-        <input type="text" value={value} onChange={(e) => onChange(e.target.value)} placeholder={placeholder} />
+        <button type="button" className="search-input-btn" onClick={onSubmit} aria-label="Run search">
+            <Icon name="search" size={15} />
+        </button>
+        <input
+            type="text"
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            onKeyDown={(e) => {
+                if (e.key === "Enter") onSubmit?.();
+            }}
+            placeholder={placeholder}
+        />
     </div>
 );
 


### PR DESCRIPTION
### Motivation
- Enable the admin top-bar search to actually perform searches and take admins directly to the most relevant management page instead of being cosmetic. 
- Pre-fill per-page local search filters from a global query so results are immediately visible on destination pages. 
- Improve admin UX for finding Users/Cards/Chat Sessions quickly and fix a missing changelog entry.

### Description
- Made the global admin search actionable by adding `runGlobalSearch` to `AdminLayout`, which queries `/admin/search` for `users`, `cards`, and `chat_sessions` and routes to the first matching page with `?q=...` using `router.push`.
- Extended the `SearchInput` component in `components/admin/AdminUI.tsx` to accept an `onSubmit` callback, added Enter-key handling, and replaced the decorative search icon with a clickable button; added supporting CSS `.search-input-btn` in `admin.css`.
- Wired up `useSearchParams` on `frontend` admin pages (`/admin/users`, `/admin/cards`, `/admin/chat-sessions`) so they read the `q` query param and populate their local `q` search state on mount, and updated `chat-sessions` to show an inline `SearchInput` and client-side filtering using that `q` state.
- Updated `backend/docs/CHANGELOG.md` to add a `Fixed` entry describing the admin portal top-bar search behavior.

### Testing
- Performed a local TypeScript typecheck and development build of the frontend, and the build completed successfully.
- Manually exercised the admin top-bar search in the dev environment to verify clicking the search button or pressing Enter runs the search and routes to `'/admin/users?q=...'`, `'/admin/cards?q=...'`, or `'/admin/chat-sessions?q=...'` and that destination pages pre-fill and apply the query; these smoke checks passed.
- No new automated unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12dd45bb108328ba56c5c5829421df)