### PR TITLE
fix(frontend): wrap admin pages' useSearchParams in Suspense to unblock production build

### DIFF
--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Profile editing now uses an explicit "Edit profile" button: fields are read-only by default and unlock for editing only after clicking Edit, which then shows Save/Cancel controls. This replaces the always-editable form so it's clear how to update profile information.
 
+### Fixed
+- Frontend production builds now succeed for `/admin/cards`: the page's `useSearchParams()` usage is wrapped in a Suspense boundary to satisfy Next.js prerender requirements in Docker/CI builds.
+
 ## [0.0.15] - 2026-05-24
 
 ### Added

--- a/frontend/src/app/admin/cards/page.tsx
+++ b/frontend/src/app/admin/cards/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { Suspense, useState, useEffect, useMemo } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import AdminLayout, { AdminLoadingScreen } from "@/components/AdminLayout";
@@ -46,6 +46,14 @@ const COLUMNS: Column[] = [
 ];
 
 export default function AdminCardsPage() {
+    return (
+        <Suspense fallback={<AdminLoadingScreen label="Loading cards…" />}>
+            <AdminCardsPageContent />
+        </Suspense>
+    );
+}
+
+function AdminCardsPageContent() {
     const { user, isAuthenticated, isAuthLoading } = useAuth();
     const router = useRouter();
     const searchParams = useSearchParams();

--- a/frontend/src/app/admin/chat-sessions/page.tsx
+++ b/frontend/src/app/admin/chat-sessions/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { Suspense, useState, useEffect, useMemo } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import AdminLayout, { AdminLoadingScreen } from "@/components/AdminLayout";
@@ -34,6 +34,14 @@ const COLUMNS: Column[] = [
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
 export default function AdminChatSessionsPage() {
+    return (
+        <Suspense fallback={<AdminLoadingScreen label="Loading sessions…" />}>
+            <AdminChatSessionsPageContent />
+        </Suspense>
+    );
+}
+
+function AdminChatSessionsPageContent() {
     const { user, isAuthenticated, isAuthLoading } = useAuth();
     const router = useRouter();
     const searchParams = useSearchParams();

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { Suspense, useState, useEffect, useMemo } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import AdminLayout, { AdminLoadingScreen } from "@/components/AdminLayout";
@@ -41,6 +41,14 @@ const COLUMNS: Column[] = [
 ];
 
 export default function AdminUsersPage() {
+    return (
+        <Suspense fallback={<AdminLoadingScreen label="Loading users…" />}>
+            <AdminUsersPageContent />
+        </Suspense>
+    );
+}
+
+function AdminUsersPageContent() {
     const { user, isAuthenticated, isAuthLoading } = useAuth();
     const router = useRouter();
     const searchParams = useSearchParams();


### PR DESCRIPTION
### Motivation
- Next.js production prerender in CI/Docker failed with `useSearchParams() should be wrapped in a suspense boundary` for admin pages, causing `npm run build` to exit with an error. 
- The pages involved read router search params on the client, which must run under a `Suspense` boundary to satisfy the app-router CSR bailout requirements. 
- The repository policy requires a changelog entry for user-visible fixes, so the changelog was updated accordingly.

### Description
- Wrapped the top-level exports of `admin` pages in a `Suspense` fallback and moved the existing page logic into inner `*Content` components so `useSearchParams()` runs inside the Suspense boundary (changes in `frontend/src/app/admin/cards/page.tsx`, `frontend/src/app/admin/chat-sessions/page.tsx`, and `frontend/src/app/admin/users/page.tsx`).
- Added `Suspense` imports and `Admin*PageContent` components that contain the original logic so behaviour is unchanged at runtime while satisfying prerender requirements. 
- Updated `backend/docs/CHANGELOG.md` to document the production build/prerender fix per project changelog policy.

### Testing
- Ran `cd frontend && npm run build` and the build completes successfully without the previous prerender error. 
- The build prerendered `/admin/cards`, `/admin/chat-sessions`, and `/admin/users` as static/dynamic routes during the production build step. 
- No automated test failures were observed during the build validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12e2026f708328bb80874978251cfe)