### PR TITLE
feat(chat): auto-title new conversations via conditional rename_chat tool

### DIFF
--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.18] - 2026-05-25
+
+### Added
+- Chat completions can now receive a `rename_chat` tool call for brand-new sessions, allowing the model to assign a short descriptive conversation title instead of leaving every chat as "New Chat".
+
+### Changed
+- The backend now conditionally includes the `rename_chat` tool only when a session still has its default title; once a title is set by either the user or assistant, subsequent model calls omit the rename tool.
+
 ## [0.0.17] - 2026-05-24
 
 ### Added

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -136,6 +136,28 @@ DRAW_CARDS_TOOL = {
 }
 
 
+
+
+RENAME_CHAT_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "rename_chat",
+        "description": (
+            "Assign a short, descriptive title to a newly created chat that still uses the default title. "
+            "Use this only once when the chat has never been named by the user or assistant."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "A concise chat title (max 100 characters)",
+                },
+            },
+            "required": ["title"],
+        },
+    },
+}
 def validate_chat_session_exists(db: Session, session_id: int, user_id: int) -> bool:
     """
     Validate that a chat session exists and belongs to the specified user.
@@ -920,13 +942,31 @@ async def create_message(
                 # generator.
 
                 # Get model response with tool calling
-                llm_response = llm.bind_tools([DRAW_CARDS_TOOL]).invoke(messages_for_llm)
+                available_tools = [DRAW_CARDS_TOOL]
+                if session.title == "New Chat":
+                    available_tools.append(RENAME_CHAT_TOOL)
+
+                llm_response = llm.bind_tools(available_tools).invoke(messages_for_llm)
 
                 # Check if the model wants to use tools
                 if llm_response.tool_calls:
                     tool_call = llm_response.tool_calls[0]
 
-                    if tool_call["name"] == "draw_cards":
+                    if tool_call["name"] == "rename_chat":
+                        new_title = (tool_call.get("args", {}).get("title") or "").strip()
+                        if new_title:
+                            session.title = new_title[:100]
+                            db.commit()
+                            db.refresh(session)
+                            yield f"data: {json.dumps({'type': 'session_renamed', 'title': session.title})}\n\n"
+
+                        llm_response = llm.bind_tools([DRAW_CARDS_TOOL]).invoke(messages_for_llm)
+                        if llm_response.tool_calls:
+                            tool_call = llm_response.tool_calls[0]
+                        else:
+                            tool_call = None
+
+                    if tool_call and tool_call["name"] == "draw_cards":
                         # Execute the tool
                         args = tool_call["args"]
                         user_question = args.get("user_question", message_request.content)

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -955,7 +955,7 @@ async def create_message(
                     if tool_call["name"] == "rename_chat":
                         new_title = (tool_call.get("args", {}).get("title") or "").strip()
                         if new_title:
-                            session.title = new_title[:100]
+                            session.title = new_title
                             db.commit()
                             db.refresh(session)
                             yield f"data: {json.dumps({'type': 'session_renamed', 'title': session.title})}\n\n"

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -143,7 +143,7 @@ RENAME_CHAT_TOOL = {
     "function": {
         "name": "rename_chat",
         "description": (
-            "Assign a short, descriptive title to a newly created chat that still uses the default title. "
+            "Assign a short, descriptive title to a newly created chat that still uses the default title. The description should not exceed 100 characters."
             "Use this only once when the chat has never been named by the user or assistant."
         ),
         "parameters": {


### PR DESCRIPTION
### Motivation
- Prevent every new conversation from staying named "New Chat" by letting the model suggest a concise short title for brand-new sessions.
- Ensure the rename behavior is non-invasive and only available for sessions that have never been named by the user or assistant.

### Description
- Added a `RENAME_CHAT_TOOL` definition in `backend/routers/chat.py` that exposes a `rename_chat` function-style tool with a single `title` parameter.
- Updated the LLM tool binding to include `rename_chat` only when `session.title == "New Chat"`, keeping already-named sessions unaffected.
- Implemented handling for `rename_chat` tool calls: the backend trims and persists the returned title, emits a `session_renamed` stream event to clients, and then continues the normal flow by re-invoking the model with only the `draw_cards` tool.
- Updated `backend/docs/CHANGELOG.md` with a new `0.0.18` entry documenting the feature and the conditional tool inclusion.

### Testing
- Compiled the modified router with `python -m py_compile backend/routers/chat.py`, which completed successfully.
- No automated unit test changes were added as part of this PR; runtime behavior is exercised via the streaming SSE path that emits a `session_renamed` event when the rename tool is used.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13ba0e0fbc8328b93e8cd6388b5ed2)