### PR TITLE
feat(admin): add bulk-select and bulk-delete for admin users

### DIFF
--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Admin Users now supports bulk user deletion with a Select mode, row-level multi-select checkboxes, page-level select-all, and a single "Delete selected" action for removing multiple users in one flow.
+
 ## [0.0.17] - 2026-05-24
 
 ### Added

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -32,6 +32,7 @@ type Filter = "all" | "active" | "inactive" | "vip";
 const PAGE_SIZE = 10;
 
 const COLUMNS: Column[] = [
+    { label: "", width: "4%" },
     { label: "User", width: "34%" },
     { label: "Status", width: "12%" },
     { label: "Plan", width: "10%" },
@@ -67,6 +68,9 @@ function AdminUsersPageContent() {
     const [q, setQ] = useState("");
     const [filter, setFilter] = useState<Filter>("all");
     const [page, setPage] = useState(1);
+    const [selectionMode, setSelectionMode] = useState(false);
+    const [selectedUserIds, setSelectedUserIds] = useState<Set<number>>(new Set());
+    const [isBulkDeleting, setIsBulkDeleting] = useState(false);
 
     useEffect(() => {
         if (isAuthLoading) return;
@@ -107,8 +111,17 @@ function AdminUsersPageContent() {
     const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
     const currentPage = Math.min(page, totalPages);
     const pageRows = filtered.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+    const selectedCount = selectedUserIds.size;
+    const pageUserIds = pageRows.map((u) => u.id);
+    const allCurrentPageSelected = pageUserIds.length > 0 && pageUserIds.every((id) => selectedUserIds.has(id));
 
     useEffect(() => { setPage(1); }, [q, filter]);
+    useEffect(() => {
+        setSelectedUserIds((prev) => {
+            const next = new Set(Array.from(prev).filter((id) => users.some((u) => u.id === id)));
+            return next.size === prev.size ? prev : next;
+        });
+    }, [users]);
 
     if (isAuthLoading || !user) return <AdminLoadingScreen label="Loading users…" />;
     if (!user.is_admin) return null;
@@ -142,16 +155,95 @@ function AdminUsersPageContent() {
                             </button>
                         ))}
                     </div>
+                    <div style={{ display: "flex", gap: 8, marginLeft: "auto" }}>
+                        <Button
+                            variant={selectionMode ? "secondary" : "ghost"}
+                            onClick={() => {
+                                setSelectionMode((prev) => !prev);
+                                setSelectedUserIds(new Set());
+                            }}
+                        >
+                            {selectionMode ? "Cancel selection" : "Select"}
+                        </Button>
+                        {selectionMode && (
+                            <Button
+                                variant="danger"
+                                disabled={selectedCount === 0 || isBulkDeleting}
+                                onClick={async () => {
+                                    if (selectedCount === 0 || isBulkDeleting) return;
+                                    const shouldDelete = window.confirm(`Delete ${selectedCount} selected user${selectedCount > 1 ? "s" : ""}? This cannot be undone.`);
+                                    if (!shouldDelete) return;
+                                    setIsBulkDeleting(true);
+                                    try {
+                                        await Promise.all(
+                                            Array.from(selectedUserIds).map((id) => api.delete(`/admin/users/${id}`)),
+                                        );
+                                        setSelectedUserIds(new Set());
+                                        setSelectionMode(false);
+                                        await loadData();
+                                    } catch {
+                                        alert("Failed to delete one or more users.");
+                                    } finally {
+                                        setIsBulkDeleting(false);
+                                    }
+                                }}
+                            >
+                                {isBulkDeleting ? "Deleting…" : `Delete selected (${selectedCount})`}
+                            </Button>
+                        )}
+                    </div>
                 </div>
+                {selectionMode && (
+                    <div className="muted" style={{ marginTop: 8, marginBottom: 12 }}>
+                        Select users from the table, then choose “Delete selected”.
+                    </div>
+                )}
 
                 <Table
                     columns={COLUMNS}
                     rows={pageRows}
                     empty="No users match your filters."
                     renderRow={(u: AdminUser) => (
-                        <UserRow key={u.id} u={u} decks={decks} onSaved={loadData} />
+                        <UserRow
+                            key={u.id}
+                            u={u}
+                            decks={decks}
+                            onSaved={loadData}
+                            selectionMode={selectionMode}
+                            selected={selectedUserIds.has(u.id)}
+                            onToggleSelected={() => {
+                                setSelectedUserIds((prev) => {
+                                    const next = new Set(prev);
+                                    if (next.has(u.id)) next.delete(u.id);
+                                    else next.add(u.id);
+                                    return next;
+                                });
+                            }}
+                        />
                     )}
                 />
+                {selectionMode && (
+                    <div style={{ display: "flex", justifyContent: "space-between", marginTop: 10 }}>
+                        <label className="admin-check-label">
+                            <input
+                                type="checkbox"
+                                className="admin-check"
+                                checked={allCurrentPageSelected}
+                                onChange={(e) => {
+                                    const checked = e.target.checked;
+                                    setSelectedUserIds((prev) => {
+                                        const next = new Set(prev);
+                                        if (checked) pageUserIds.forEach((id) => next.add(id));
+                                        else pageUserIds.forEach((id) => next.delete(id));
+                                        return next;
+                                    });
+                                }}
+                            />
+                            <span>Select all on this page</span>
+                        </label>
+                        <span className="muted">{selectedCount} selected</span>
+                    </div>
+                )}
 
                 <div className="pagination">
                     <span className="pagination-info">
@@ -175,13 +267,38 @@ function AdminUsersPageContent() {
     );
 }
 
-function UserRow({ u, decks, onSaved }: { u: AdminUser; decks: AdminDeck[]; onSaved: () => void }) {
+function UserRow({
+    u,
+    decks,
+    onSaved,
+    selectionMode,
+    selected,
+    onToggleSelected,
+}: {
+    u: AdminUser;
+    decks: AdminDeck[];
+    onSaved: () => void;
+    selectionMode: boolean;
+    selected: boolean;
+    onToggleSelected: () => void;
+}) {
     const [open, setOpen] = useState(false);
     const [validationError, setValidationError] = useState("");
 
     return (
         <Dialog open={open} onOpenChange={(o) => { setOpen(o); if (!o) setValidationError(""); }}>
-            <tr className="is-clickable" onClick={() => setOpen(true)}>
+            <tr className={selectionMode ? "" : "is-clickable"} onClick={() => { if (!selectionMode) setOpen(true); }}>
+                <td onClick={(e) => e.stopPropagation()}>
+                    {selectionMode && (
+                        <input
+                            type="checkbox"
+                            className="admin-check"
+                            checked={selected}
+                            onChange={onToggleSelected}
+                            aria-label={`Select ${u.username}`}
+                        />
+                    )}
+                </td>
                 <td>
                     <div className="cell-user">
                         <Avatar src={u.avatar_url} username={u.username} size="sm" />


### PR DESCRIPTION
### Motivation
- Administrators need a way to remove multiple user accounts at once instead of deleting them one-by-one from the Admin Users table. 
- Prevent accidental edit-dialog opens while selecting rows by introducing an explicit selection mode with dedicated controls. 

### Description
- Add a selection column and UI state (`selectionMode`, `selectedUserIds`, `isBulkDeleting`) to `frontend/src/app/admin/users/page.tsx` and render row-level checkboxes when selection mode is active. 
- Implement page-level "Select all on this page" behavior and selected-count feedback, and add a `Delete selected` action that confirms intent and issues parallel `DELETE /admin/users/{id}` requests. 
- Disable row click-to-edit while in selection mode to avoid accidental dialog opens and refresh the user list after bulk deletes by reusing the existing `loadData()` call. 
- Update `backend/docs/CHANGELOG.md` with an `Unreleased` entry documenting the new admin bulk-delete capability. 

### Testing
- Ran TypeScript type-check with `cd frontend && npm run type-check`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13bf33d5c88328bc453a64cb686e77)