### PR TITLE
fix(home): show center Card of the Day image reliably

### DIFF
--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Profile reading-preference toggles now render as compact switches instead of oversized circular controls.
 - Profile notification toggles now render as compact switches instead of oversized circular controls.
 - Profile history now shows infinity for free and paid turn counts when the user has unlimited access.
+- Home page center "Card of the day" image now renders reliably for remote deck URLs by bypassing Next image optimization for that slot and falling back gracefully if the image fails to load.
 
 ## [0.0.16] - 2026-05-24
 

--- a/frontend/src/components/ArcanaHome.tsx
+++ b/frontend/src/components/ArcanaHome.tsx
@@ -389,6 +389,7 @@ function Hero({ name, ready, lastReading, readingCount }: {
 function CardOfDay({ card, onRead, onJournal }: {
   card: DailyCard | null; onRead: () => void; onJournal: () => void;
 }) {
+  const [imageError, setImageError] = useState(false);
   const roman = card ? MAJOR_ROMAN[card.name] : undefined;
   return (
     <section className="ah-card ah-cod">
@@ -398,8 +399,18 @@ function CardOfDay({ card, onRead, onJournal }: {
       </div>
 
       <div className="ah-cod-frame" aria-label={card ? `${card.name} card` : 'Card of the day'}>
-        {card?.image_url
-          ? <Image src={card.image_url} alt={card.name} fill sizes="240px" style={{ objectFit: 'cover' }} />
+        {card?.image_url && !imageError
+          ? (
+            <Image
+              src={card.image_url}
+              alt={card.name}
+              fill
+              sizes="240px"
+              style={{ objectFit: 'cover' }}
+              unoptimized
+              onError={() => setImageError(true)}
+            />
+          )
           : <div className="ah-cod-art"><IconStar size={48} /></div>}
       </div>
 


### PR DESCRIPTION
### Motivation
- The center "Card of the day" slot could show a broken image for some remote deck URLs because it used Next.js' image optimizer while the sidebar displayed the same URL unoptimized, so the center needed to load remote images the same way and degrade gracefully on failure.

### Description
- Added a local `imageError` state and updated the center card's `next/image` usage to include `unoptimized` and an `onError` fallback so remote URLs bypass Next's optimizer and the placeholder art is shown when load fails, and updated `backend/docs/CHANGELOG.md` with a user-facing fix note (changes in `frontend/src/components/ArcanaHome.tsx` and `backend/docs/CHANGELOG.md`).

### Testing
- Performed automated repository file-diff and content inspections to verify the change was applied and the changelog entry was added, and those checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13bfbdd718832889a2a6426b6d5c0b)