### PR TITLE
Add user soft-delete (is_deleted) and make admin deletion a soft delete

### DIFF
--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Home page center "Card of the day" image now renders reliably for remote deck URLs by bypassing Next image optimization for that slot and falling back gracefully if the image fails to load.
+- Admin user deletion now performs a dedicated soft delete by marking `is_deleted=true` (and deactivating the account) instead of hard-deleting the database row, preventing foreign-key conflicts when related checkout sessions exist while keeping deleted state distinct from inactive users.
 
 ## [0.0.17] - 2026-05-24
 

--- a/backend/migrations/versions/20260525_040000_c9d0e1f2a3b4_add_is_deleted_to_users.py
+++ b/backend/migrations/versions/20260525_040000_c9d0e1f2a3b4_add_is_deleted_to_users.py
@@ -19,7 +19,6 @@ depends_on = None
 def upgrade() -> None:
     op.add_column('users', sa.Column('is_deleted', sa.Boolean(), nullable=False, server_default=sa.false()))
     op.create_index(op.f('ix_users_is_deleted'), 'users', ['is_deleted'], unique=False)
-    op.alter_column('users', 'is_deleted', server_default=None)
 
 
 def downgrade() -> None:

--- a/backend/migrations/versions/20260525_040000_c9d0e1f2a3b4_add_is_deleted_to_users.py
+++ b/backend/migrations/versions/20260525_040000_c9d0e1f2a3b4_add_is_deleted_to_users.py
@@ -19,6 +19,9 @@ depends_on = None
 def upgrade() -> None:
     op.add_column('users', sa.Column('is_deleted', sa.Boolean(), nullable=False, server_default=sa.false()))
     op.create_index(op.f('ix_users_is_deleted'), 'users', ['is_deleted'], unique=False)
+    bind = op.get_bind()
+    if bind.dialect.name != "sqlite":
+        op.alter_column('users', 'is_deleted', server_default=None)
 
 
 def downgrade() -> None:

--- a/backend/migrations/versions/20260525_040000_c9d0e1f2a3b4_add_is_deleted_to_users.py
+++ b/backend/migrations/versions/20260525_040000_c9d0e1f2a3b4_add_is_deleted_to_users.py
@@ -1,0 +1,27 @@
+"""add is_deleted to users
+
+Revision ID: c9d0e1f2a3b4
+Revises: b7c8d9e0f1a2
+Create Date: 2026-05-25 04:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c9d0e1f2a3b4'
+down_revision = 'b7c8d9e0f1a2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('is_deleted', sa.Boolean(), nullable=False, server_default=sa.false()))
+    op.create_index(op.f('ix_users_is_deleted'), 'users', ['is_deleted'], unique=False)
+    op.alter_column('users', 'is_deleted', server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_users_is_deleted'), table_name='users')
+    op.drop_column('users', 'is_deleted')

--- a/backend/models.py
+++ b/backend/models.py
@@ -24,6 +24,7 @@ class User(Base):
         full_name (str): Optional full name of the user.
         created_at (datetime): Timestamp of user creation.
         is_active (bool): Whether the user is active.
+        is_deleted (bool): Whether the user is soft-deleted.
         is_admin (bool): Whether the user has admin privileges.
         favorite_deck_id (int): Foreign key to the user's favorite deck.
         bio (str): Optional short biography shown on the user's profile.
@@ -50,6 +51,7 @@ class User(Base):
     full_name = Column(String, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     is_active = Column(Boolean, default=True)
+    is_deleted = Column(Boolean, default=False, nullable=False, index=True)
     is_admin = Column(Boolean, default=False)
     favorite_deck_id = Column(Integer, ForeignKey("decks.id"), default=1, index=True)
 

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -44,6 +44,7 @@ def build_admin_user_response(user: User, base_url: str = "") -> AdminUserRespon
         full_name=user.full_name,
         created_at=user.created_at,
         is_active=user.is_active,
+        is_deleted=user.is_deleted or False,
         is_admin=user.is_admin or False,
         is_specialized_premium=user.is_specialized_premium or False,
         receive_error_alerts=user.receive_error_alerts or False,
@@ -364,12 +365,13 @@ async def update_user(
 
 @router.delete("/users/{user_id}")
 async def delete_user(user_id: int, db: Session = Depends(get_db), admin_user: User = Depends(get_admin_user)):
-    """Delete a user"""
+    """Soft-delete a user by deactivating the account."""
     user = db.query(User).filter(User.id == user_id).first()
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
 
-    db.delete(user)
+    user.is_deleted = True
+    user.is_active = False
     db.commit()
 
     return {"message": "User deleted successfully"}

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -479,6 +479,7 @@ class UserResponse(BaseModel):
     full_name: str | None = None
     created_at: datetime
     is_active: bool
+    is_deleted: bool = False
     is_admin: bool = False
     is_specialized_premium: bool = False
     favorite_deck_id: int | None = None
@@ -872,6 +873,7 @@ class AdminUserResponse(BaseModel):
     full_name: str | None = None
     created_at: datetime
     is_active: bool
+    is_deleted: bool = False
     is_admin: bool = False
     is_specialized_premium: bool = False
     receive_error_alerts: bool = False
@@ -899,6 +901,7 @@ class AdminUserUpdate(BaseModel):
     email: str | None = None
     full_name: str | None = None
     is_active: bool | None = None
+    is_deleted: bool | None = None
     is_specialized_premium: bool | None = None
     receive_error_alerts: bool | None = None
     favorite_deck_id: int | None = None

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -75,11 +75,12 @@ def test_admin_update_user(client, admin_auth_headers):
 
 def test_admin_delete_user_soft_deletes(client, admin_auth_headers, test_user, db_session):
     """Test admin user delete endpoint soft-deletes the user instead of hard delete."""
-    response = client.delete(f"/admin/users/{test_user.id}", headers=admin_auth_headers)
+    user_id = test_user.id
+    response = client.delete(f"/admin/users/{user_id}", headers=admin_auth_headers)
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["message"] == "User deleted successfully"
 
-    updated_user = db_session.query(User).filter(User.id == test_user.id).first()
+    updated_user = db_session.query(User).filter(User.id == user_id).first()
     assert updated_user is not None
     assert updated_user.is_active is False
     assert updated_user.is_deleted is True

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -73,6 +73,17 @@ def test_admin_update_user(client, admin_auth_headers):
         )
         assert resp.status_code in (status.HTTP_200_OK, status.HTTP_422_UNPROCESSABLE_ENTITY)
 
+def test_admin_delete_user_soft_deletes(client, admin_auth_headers, test_user, db_session):
+    """Test admin user delete endpoint soft-deletes the user instead of hard delete."""
+    response = client.delete(f"/admin/users/{test_user.id}", headers=admin_auth_headers)
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["message"] == "User deleted successfully"
+
+    updated_user = db_session.query(User).filter(User.id == test_user.id).first()
+    assert updated_user is not None
+    assert updated_user.is_active is False
+    assert updated_user.is_deleted is True
+
 # --- Cards CRUD ---
 def test_admin_list_cards(client, admin_auth_headers):
     resp = client.get("/admin/cards", headers=admin_auth_headers)


### PR DESCRIPTION
### Motivation
- Prevent hard-deleting user rows which can break foreign-key relations (e.g. checkout sessions) by introducing a soft-delete state separate from `is_active`.
- Surface the deleted state in admin APIs and allow admins to mark users as deleted without removing DB rows.
- Ensure the schema and API surface reflect the new soft-delete behavior and are covered by tests.

### Description
- Add an Alembic migration `20260525_040000_c9d0e1f2a3b4_add_is_deleted_to_users.py` that adds an `is_deleted` boolean column with an index and default `false` to the `users` table.
- Add `is_deleted` to the `User` model in `backend/models.py` and set it as a non-nullable boolean with a default of `False` and an index.
- Update admin API response and input schemas in `backend/schemas.py` to include `is_deleted` on `UserResponse`, `AdminUserResponse`, and `AdminUserUpdate`.
- Change the admin delete endpoint in `backend/routers/admin.py` to perform a soft delete by setting `user.is_deleted = True` and `user.is_active = False` instead of deleting the row, and include `is_deleted` in the built admin response.
- Update the changelog `backend/docs/CHANGELOG.md` to document the new soft-delete behavior.
- Add an automated test `test_admin_delete_user_soft_deletes` in `backend/tests/test_admin.py` that asserts the delete endpoint marks the record as `is_deleted=True` and `is_active=False` without removing it.

### Testing
- Ran backend unit tests with `pytest backend/tests -q` and the test suite passed; the new test `test_admin_delete_user_soft_deletes` succeeded.
- Existing admin-related tests (`test_admin_list_users`, `test_admin_get_user`, `test_admin_update_user`) were executed and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13c52f74f88328a73d343045fa754d)