### PR TITLE
Add staging deployment workflow, staging compose, and setup checklist

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -1,0 +1,57 @@
+name: Deploy to VPS (Staging)
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    branches: [staging]
+    types:
+      - completed
+
+env:
+  PROJECT_DIR: ${{ secrets.VPS_STAGING_PROJECT_DIR }}
+  COMPOSE_FILE: docker-compose.staging.yaml
+  IMAGE_TAG: ${{ github.event.workflow_run.head_sha }}
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: Deploy staging application
+        run: |
+          set -e
+          cd "${{ env.PROJECT_DIR }}"
+
+          git fetch origin
+          git checkout staging
+          git pull origin staging
+
+          export IMAGE_TAG="${IMAGE_TAG}"
+          echo "Deploying staging image tag: ${IMAGE_TAG}"
+
+          docker compose -f "${COMPOSE_FILE}" pull
+          docker compose -f "${COMPOSE_FILE}" up -d
+
+      - name: Run database migrations
+        run: |
+          set -e
+          cd "${{ env.PROJECT_DIR }}"
+          echo "Waiting for staging backend to be ready..."
+          sleep 30
+          docker compose -f "${COMPOSE_FILE}" exec -T backend \
+            uv run python migrate.py
+          echo "Staging database migrations completed successfully"
+
+      - name: Health check
+        run: |
+          cd "${{ env.PROJECT_DIR }}"
+          echo "Service status:"
+          docker compose -f "${COMPOSE_FILE}" ps
+          echo "Checking staging backend health endpoint..."
+          sleep 10
+          if curl -f http://localhost:8010/health; then
+            echo "Staging backend health check passed"
+          else
+            echo "Warning: Staging backend health check failed"
+          fi

--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.19] - 2026-05-25
+
+### Added
+- Added a dedicated staging deployment workflow triggered by successful CI runs on the `staging` branch, including automated image rollout, database migration, and health checks for the staging stack.
+- Added `docker-compose.staging.yaml` to run an isolated staging stack (frontend, backend, Redis, Celery worker, and Celery beat) with staging-specific container names, env files, and Traefik host rules.
+- Added `docs/STAGING_SETUP_TODO.md` with manual follow-ups that still require external access (GitHub secrets, VPS preparation, DNS/TLS, and optional hardening).
+
 ## [0.0.18] - 2026-05-25
 
 ### Added

--- a/docker-compose.staging.yaml
+++ b/docker-compose.staging.yaml
@@ -1,0 +1,93 @@
+services:
+  backend:
+    image: vanloc1808/tarot-backend:${IMAGE_TAG:-latest}
+    container_name: tarot-backend-staging
+    env_file:
+      - ./backend/.env.staging
+    volumes:
+      - ./user-avatars-staging:/avatar
+    depends_on:
+      - redis
+    restart: always
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.tarot-backend-staging.rule=Host(`staging-backend-arcanaai.nguyenvanloc.com`)"
+      - "traefik.http.routers.tarot-backend-staging.entrypoints=websecure"
+      - "traefik.http.routers.tarot-backend-staging.tls=true"
+      - "traefik.http.services.tarot-backend-staging.loadbalancer.server.port=8000"
+    ports:
+      - "8010:8000"
+    networks:
+      - localnet
+
+  frontend:
+    image: vanloc1808/tarot-frontend:${IMAGE_TAG:-latest}
+    container_name: tarot-frontend-staging
+    restart: always
+    env_file:
+      - ./frontend/.env.staging
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.tarot-frontend-staging.rule=Host(`staging-arcanaai.nguyenvanloc.com`)"
+      - "traefik.http.routers.tarot-frontend-staging.entrypoints=websecure"
+      - "traefik.http.routers.tarot-frontend-staging.tls=true"
+      - "traefik.http.services.tarot-frontend-staging.loadbalancer.server.port=3000"
+    networks:
+      - localnet
+
+  redis:
+    image: redis:7-alpine
+    container_name: tarot-redis-staging
+    volumes:
+      - redis_data_staging:/data
+    restart: always
+    command: redis-server --appendonly yes
+    networks:
+      - localnet
+
+  celery-worker:
+    image: vanloc1808/tarot-backend:${IMAGE_TAG:-latest}
+    container_name: tarot-celery-worker-staging
+    env_file:
+      - ./backend/.env.staging
+    volumes:
+      - ./user-avatars-staging:/avatar
+    depends_on:
+      - redis
+      - backend
+    restart: always
+    command: >
+      bash -c "source .venv/bin/activate &&
+               /app/wait-for-it.sh tarot-redis-staging:6379 --timeout=60 --strict -- echo 'Redis is up' &&
+               cd /app &&
+               PYTHONPATH=/app celery -A celery_app worker --loglevel=info --queues=email,notifications,celery"
+    networks:
+      - localnet
+
+  celery-beat:
+    image: vanloc1808/tarot-backend:${IMAGE_TAG:-latest}
+    container_name: tarot-celery-beat-staging
+    env_file:
+      - ./backend/.env.staging
+    volumes:
+      - ./user-avatars-staging:/avatar
+      - celery_beat_data_staging:/app/celerybeat-schedule
+    depends_on:
+      - redis
+      - backend
+    restart: always
+    command: >
+      bash -c "source .venv/bin/activate &&
+              /app/wait-for-it.sh tarot-redis-staging:6379 --timeout=60 --strict -- echo 'Redis is up' &&
+              cd /app &&
+              PYTHONPATH=/app celery -A celery_app beat --loglevel=info --schedule=/app/celerybeat-schedule"
+    networks:
+      - localnet
+
+volumes:
+  redis_data_staging:
+  celery_beat_data_staging:
+
+networks:
+  localnet:
+    external: true

--- a/docs/STAGING_SETUP_TODO.md
+++ b/docs/STAGING_SETUP_TODO.md
@@ -1,0 +1,37 @@
+# Staging Setup - Manual Follow-ups
+
+These are the actions that still require manual access outside this repository.
+
+## GitHub repository settings
+
+- Add `VPS_STAGING_PROJECT_DIR` in **GitHub → Settings → Secrets and variables → Actions**.
+  - Value should point to the staging checkout path on the self-hosted runner, e.g. `/opt/arcana-ai-staging`.
+- Confirm the self-hosted runner used by this repo can:
+  - access Docker daemon,
+  - pull images from Docker Hub,
+  - read the staging project directory.
+
+## VPS / host setup
+
+- Create or update staging checkout on the server:
+  - `git clone` the repo to the path used in `VPS_STAGING_PROJECT_DIR` (if not present),
+  - ensure `staging` branch exists and is tracked.
+- Create environment files:
+  - `backend/.env.staging`
+  - `frontend/.env.staging`
+- Ensure `localnet` Docker network exists:
+  - `docker network create localnet` (only once if absent).
+- Verify Traefik is attached to `localnet` and can route staging hosts.
+
+## DNS / TLS
+
+- Add DNS records for:
+  - `staging-arcanaai.nguyenvanloc.com`
+  - `staging-backend-arcanaai.nguyenvanloc.com`
+- Point both records to the VPS public IP (or LB in front of it).
+- Verify TLS certificates are issued for both staging domains.
+
+## Optional hardening
+
+- Protect staging with basic auth or IP allowlist at Traefik level.
+- Add separate staging database / storage credentials (avoid sharing production secrets).


### PR DESCRIPTION
### Motivation
- Provide a dedicated staging deployment path so changes can be validated on an isolated environment before promoting to production. 
- Keep staging isolated from production to avoid name/port/secret collisions and to let Traefik route staging hosts separately. 
- Capture manual follow-ups (secrets, VPS setup, DNS/TLS) that cannot be completed from inside the repo. 

### Description
- Add a GitHub Actions workflow `/.github/workflows/deploy-staging.yaml` that triggers after successful `CI` runs on the `staging` branch and performs image pull/compose up, runs migrations, and performs a health check. 
- Add `docker-compose.staging.yaml` with isolated service/container names, staging-specific env files, Traefik host rules, staging Redis/Celery volumes, and a mapped backend health port `8010`. 
- Add `docs/STAGING_SETUP_TODO.md` listing manual follow-ups required outside the repository such as creating the `VPS_STAGING_PROJECT_DIR` secret, provisioning `backend/.env.staging` and `frontend/.env.staging` on the VPS, creating the `localnet` Docker network, and adding DNS/TLS records. 
- Update `backend/docs/CHANGELOG.md` with a new `0.0.19` entry describing the staging deployment support. 

### Testing
- Verified repository state with `git status --short` and successfully created the commit for the change. 
- Performed a basic Python sanity check with `python -m py_compile backend/config.py` which completed successfully. 
- Inspected the new files with `nl`/`sed` and other file listing commands to confirm the workflow, compose file, checklist, and changelog were written as expected. 
- No CI-run or end-to-end deployment tests were executed in this change; DNS, GitHub secret creation, and VPS-side setup are listed in `docs/STAGING_SETUP_TODO.md` and must be completed manually.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13c36215988328a3334214555fb3b6)