### PR TITLE
Remove keyboard shortcut display from New reading button

### DIFF
--- a/frontend/src/app/session/layout.tsx
+++ b/frontend/src/app/session/layout.tsx
@@ -148,7 +148,7 @@ function LeftRail() {
       <button className="sess-new-btn" onClick={handleNew}>
         <IconPlus />
         <span>New reading</span>
-        <span className="sess-kbd">⌘N</span>
+
       </button>
 
       <div className="sess-rail-section">


### PR DESCRIPTION
## Summary
Removed the keyboard shortcut indicator (⌘N) from the "New reading" button in the session layout.

## Changes
- Removed the `<span className="sess-kbd">⌘N</span>` element from the New reading button in the left rail navigation

## Details
This change simplifies the button UI by removing the visual keyboard shortcut hint. The keyboard shortcut functionality itself remains unchanged; only the display of the shortcut indicator has been removed.

https://claude.ai/code/session_014XkFZcABcxgutfYhtW1SCq