### PR TITLE
admin: add “No sessions” filter to Users page

### DIFF
--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Chat completions can now receive a `rename_chat` tool call for brand-new sessions, allowing the model to assign a short descriptive conversation title instead of leaving every chat as "New Chat".
 - Admin Users now supports bulk user deletion with a Select mode, row-level multi-select checkboxes, page-level select-all, and a single "Delete selected" action for removing multiple users in one flow.
+- Admin Users now includes a "No sessions" filter chip so administrators can quickly find accounts that have never started a chat session.
 
 ### Changed
 - The backend now conditionally includes the `rename_chat` tool only when a session still has its default title; once a title is set by either the user or assistant, subsequent model calls omit the rename tool.

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -28,7 +28,7 @@ interface AdminUser {
 
 interface AdminDeck { id: number; name: string; }
 
-type Filter = "all" | "active" | "inactive" | "vip";
+type Filter = "all" | "active" | "inactive" | "vip" | "no_sessions";
 const PAGE_SIZE = 10;
 
 const COLUMNS: Column[] = [
@@ -101,6 +101,7 @@ function AdminUsersPageContent() {
             if (filter === "active" && !u.is_active) return false;
             if (filter === "inactive" && u.is_active) return false;
             if (filter === "vip" && !u.is_specialized_premium) return false;
+            if (filter === "no_sessions" && u.chat_sessions_count > 0) return false;
             if (!s) return true;
             return u.username.toLowerCase().includes(s)
                 || u.email.toLowerCase().includes(s)
@@ -149,9 +150,9 @@ function AdminUsersPageContent() {
                 <div className="toolbar">
                     <SearchInput value={q} onChange={setQ} placeholder="Search by name, username, email…" />
                     <div className="filter-group">
-                        {(["all", "active", "inactive", "vip"] as Filter[]).map((f) => (
+                        {(["all", "active", "inactive", "vip", "no_sessions"] as Filter[]).map((f) => (
                             <button key={f} className={`filter-chip ${filter === f ? "is-active" : ""}`} onClick={() => setFilter(f)}>
-                                {f === "all" ? "All" : f === "vip" ? "VIP" : f[0].toUpperCase() + f.slice(1)}
+                                {f === "all" ? "All" : f === "vip" ? "VIP" : f === "no_sessions" ? "No sessions" : f[0].toUpperCase() + f.slice(1)}
                             </button>
                         ))}
                     </div>


### PR DESCRIPTION
### Motivation
- Provide administrators a quick way to locate accounts that have never started a chat session so they can triage or reach out to inactive/new users.

### Description
- Add a new `no_sessions` filter to the frontend `Admin → Users` list by extending the `Filter` type and applying `if (filter === "no_sessions" && u.chat_sessions_count > 0) return false;` in the client-side filtering logic, and expose a `No sessions` filter chip in the toolbar (`frontend/src/app/admin/users/page.tsx`).
- Document the user-facing change in the changelog by adding an entry under `0.0.18` in `backend/docs/CHANGELOG.md`.

### Testing
- Ran the targeted frontend lint/type-check command `cd frontend && npm run lint -- --file src/app/admin/users/page.tsx`, which completed and reported type-check pass while the repository's existing ESLint circular-config issue surfaced separately (lint fallback path exercised).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a141448cedc8328a0752ac0976f7d7e)