### PR TITLE
Fix blank tarot cards in session by bypassing Next.js image optimization

### DIFF
--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Home page center "Card of the day" image now renders reliably for remote deck URLs by bypassing Next image optimization for that slot and falling back gracefully if the image fails to load.
 - Admin user deletion now performs a dedicated soft delete by marking `is_deleted=true` (and deactivating the account) instead of hard-deleting the database row, preventing foreign-key conflicts when related checkout sessions exist while keeping deleted state distinct from inactive users.
 - `/session` now shows recent readings in the left rail instead of visually collapsing the session list.
+- Chat session spread cards now load card artwork with direct image rendering (instead of Next.js optimization) so Card of the Day deck URLs render reliably in-session without blank card faces.
 
 ## [0.0.17] - 2026-05-24
 

--- a/frontend/src/app/session/[id]/page.tsx
+++ b/frontend/src/app/session/[id]/page.tsx
@@ -3,7 +3,6 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useParams, useSearchParams, useRouter } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
-import Image from 'next/image';
 import { useSessionCtx } from '../context';
 import type { Message, Card } from '../context';
 
@@ -83,13 +82,13 @@ function SpreadCard({ card, position, index, revealed }: {
         {/* Front face — card image */}
         <div className="sess-card-face sess-card-front">
           {card.image_url ? (
-            <div style={{ position: 'relative', width: '100%', height: '100%', transform: isReversed ? 'rotate(180deg)' : 'none' }}>
-              <Image
+            <div style={{ width: '100%', height: '100%', transform: isReversed ? 'rotate(180deg)' : 'none' }}>
+              <img
                 src={card.image_url}
                 alt={card.name}
-                fill
-                style={{ objectFit: 'cover' }}
-                sizes="220px"
+                style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                loading="lazy"
+                decoding="async"
               />
             </div>
           ) : (


### PR DESCRIPTION
### Motivation
- Session spread cards were rendering as blank because `next/image` optimization can fail for some remote deck URLs, causing the Card of the Day / in-session images to not appear. 
- The change makes the session spread card rendering follow the more reliable direct-image pattern used elsewhere to avoid optimizer routing issues.

### Description
- Replaced `next/image` usage with a native `<img>` element in `frontend/src/app/session/[id]/page.tsx` and removed the unused `next/image` import. 
- Preserved the existing reversed-card transform and layout while adding `loading="lazy"` and `decoding="async"` for the inline image. 
- Added a user-facing entry to `backend/docs/CHANGELOG.md` documenting the fix per repository changelog requirements.

### Testing
- Ran the frontend lint script (`npm run lint -- --file src/app/session/[id]/page.tsx`); ESLint failed in this environment due to a circular-config error, but the script fell back to a type-check step which passed. 
- No additional automated tests were run as part of this change; the lint/type-check fallback is the only automated validation executed and it succeeded at the type-check step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1416a474148328aa378627e11921cd)