### PR TITLE
Add admin "No sessions" filter (backend + frontend) and tests

### DIFF
--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Chat completions can now receive a `rename_chat` tool call for brand-new sessions, allowing the model to assign a short descriptive conversation title instead of leaving every chat as "New Chat".
 - Admin Users now supports bulk user deletion with a Select mode, row-level multi-select checkboxes, page-level select-all, and a single "Delete selected" action for removing multiple users in one flow.
+- Admin Users now includes a "No sessions" filter that is backed by the admin users API (`no_sessions=true`), so administrators can reliably fetch only accounts that have never started a chat session.
 
 ### Changed
 - The backend now conditionally includes the `rename_chat` tool only when a session still has its default title; once a title is set by either the user or assistant, subsequent model calls omit the rename tool.

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -321,11 +321,19 @@ async def list_users(
     request: Request,
     skip: int = Query(0, ge=0),
     limit: int = Query(20, ge=1, le=100),
+    no_sessions: bool = Query(False, description="Return only users with zero chat sessions"),
     db: Session = Depends(get_db),
     admin_user: User = Depends(get_admin_user),
 ):
     """List all users with pagination"""
-    users = db.query(User).offset(skip).limit(limit).all()
+    users_query = db.query(User)
+    if no_sessions:
+        users_query = (
+            users_query.outerjoin(ChatSession, ChatSession.user_id == User.id)
+            .group_by(User.id)
+            .having(func.count(ChatSession.id) == 0)
+        )
+    users = users_query.offset(skip).limit(limit).all()
 
     return [build_admin_user_response(user, str(request.base_url).rstrip('/')) for user in users]
 

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -1,6 +1,6 @@
 import pytest
 from fastapi import status
-from models import User
+from models import ChatSession, User
 from routers.auth import create_access_token
 from database import get_db
 
@@ -53,6 +53,27 @@ def test_admin_list_users(client, admin_auth_headers):
     resp = client.get("/admin/users", headers=admin_auth_headers)
     assert resp.status_code == status.HTTP_200_OK
     assert isinstance(resp.json(), list)
+
+
+def test_admin_list_users_no_sessions_filter(client, admin_auth_headers, db_session):
+    no_sessions_user = User(username="nosessionsuser", email="nosessions@example.com", is_active=True)
+    no_sessions_user.password = "password123"
+    has_sessions_user = User(username="hassessionsuser", email="hassessions@example.com", is_active=True)
+    has_sessions_user.password = "password123"
+    db_session.add_all([no_sessions_user, has_sessions_user])
+    db_session.commit()
+    db_session.refresh(no_sessions_user)
+    db_session.refresh(has_sessions_user)
+
+    db_session.add(ChatSession(title="Started chat", user_id=has_sessions_user.id))
+    db_session.commit()
+
+    resp = client.get("/admin/users?limit=100&no_sessions=true", headers=admin_auth_headers)
+    assert resp.status_code == status.HTTP_200_OK
+    users = resp.json()
+    user_ids = {u["id"] for u in users}
+    assert no_sessions_user.id in user_ids
+    assert has_sessions_user.id not in user_ids
 
 def test_admin_get_user(client, admin_auth_headers):
     users = client.get("/admin/users", headers=admin_auth_headers).json()

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -28,7 +28,7 @@ interface AdminUser {
 
 interface AdminDeck { id: number; name: string; }
 
-type Filter = "all" | "active" | "inactive" | "vip";
+type Filter = "all" | "active" | "inactive" | "vip" | "no_sessions";
 const PAGE_SIZE = 10;
 
 const COLUMNS: Column[] = [
@@ -76,14 +76,15 @@ function AdminUsersPageContent() {
         if (isAuthLoading) return;
         if (!isAuthenticated) { router.push("/login"); return; }
         if (!user?.is_admin) { router.push("/"); return; }
-        loadData();
-    }, [isAuthenticated, user, router, isAuthLoading]);
+        loadData(filter);
+    }, [isAuthenticated, user, router, isAuthLoading, filter]);
 
-    const loadData = async () => {
+    const loadData = async (activeFilter: Filter) => {
         try {
             setLoading(true);
+            const usersParams = activeFilter === "no_sessions" ? { limit: 100, no_sessions: true } : { limit: 100 };
             const [usersRes, decksRes] = await Promise.all([
-                api.get("/admin/users?limit=100"),
+                api.get("/admin/users", { params: usersParams }),
                 api.get("/admin/decks?limit=100"),
             ]);
             setUsers(usersRes.data);
@@ -149,9 +150,9 @@ function AdminUsersPageContent() {
                 <div className="toolbar">
                     <SearchInput value={q} onChange={setQ} placeholder="Search by name, username, email…" />
                     <div className="filter-group">
-                        {(["all", "active", "inactive", "vip"] as Filter[]).map((f) => (
+                        {(["all", "active", "inactive", "vip", "no_sessions"] as Filter[]).map((f) => (
                             <button key={f} className={`filter-chip ${filter === f ? "is-active" : ""}`} onClick={() => setFilter(f)}>
-                                {f === "all" ? "All" : f === "vip" ? "VIP" : f[0].toUpperCase() + f.slice(1)}
+                                {f === "all" ? "All" : f === "vip" ? "VIP" : f === "no_sessions" ? "No sessions" : f[0].toUpperCase() + f.slice(1)}
                             </button>
                         ))}
                     </div>
@@ -180,7 +181,7 @@ function AdminUsersPageContent() {
                                         );
                                         setSelectedUserIds(new Set());
                                         setSelectionMode(false);
-                                        await loadData();
+                                        await loadData(filter);
                                     } catch {
                                         alert("Failed to delete one or more users.");
                                     } finally {
@@ -208,7 +209,7 @@ function AdminUsersPageContent() {
                             key={u.id}
                             u={u}
                             decks={decks}
-                            onSaved={loadData}
+                            onSaved={() => loadData(filter)}
                             selectionMode={selectionMode}
                             selected={selectedUserIds.has(u.id)}
                             onToggleSelected={() => {


### PR DESCRIPTION
### Motivation
- Provide administrators a reliable way to fetch accounts that have never started a chat session via the admin UI and API.
- Surface the filter in the admin users page so staff can quickly identify users with zero chat sessions.

### Description
- Add a `no_sessions` query parameter to the admin users endpoint and implement filtering by performing an `outerjoin` to `ChatSession` and a `HAVING count(ChatSession.id) == 0` clause in `routers/admin.py` to return only users with zero sessions.
- Update the admin users frontend (`frontend/src/app/admin/users/page.tsx`) to add a `no_sessions` filter option, send `no_sessions=true` when the filter is active, and thread the active filter into data reloads and callbacks like `onSaved` and bulk-delete refreshes.
- Add a backend test `test_admin_list_users_no_sessions_filter` in `backend/tests/test_admin.py` that creates users with and without sessions and asserts the API returns only the users with no sessions.
- Update `backend/docs/CHANGELOG.md` with an entry describing the new "No sessions" filter.

### Testing
- Ran the backend tests with `pytest`, including the new `test_admin_list_users_no_sessions_filter`, and the test suite passed.
- Exercised the admin users frontend flow in development by toggling the `No sessions` filter which triggers `GET /admin/users?no_sessions=true` and verified the UI updates accordingly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a141448cedc8328a0752ac0976f7d7e)