### PR TITLE
fix: prevent homepage Quick Actions overlap in sidebar

### DIFF
--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Admin user deletion now performs a dedicated soft delete by marking `is_deleted=true` (and deactivating the account) instead of hard-deleting the database row, preventing foreign-key conflicts when related checkout sessions exist while keeping deleted state distinct from inactive users.
 - `/session` now shows recent readings in the left rail instead of visually collapsing the session list.
 - Chat session spread cards now load card artwork with direct image rendering (instead of Next.js optimization) so Card of the Day deck URLs render reliably in-session without blank card faces.
+- Homepage Quick Actions links now stack cleanly without visual overlap on narrow layouts, while still allowing each action label to stay on a single line.
 
 ## [0.0.17] - 2026-05-24
 

--- a/frontend/src/components/MysticalSidebar.tsx
+++ b/frontend/src/components/MysticalSidebar.tsx
@@ -159,24 +159,24 @@ export function MysticalSidebar({ className = '' }: MysticalSidebarProps) {
                         <FiZap className="w-4 h-4 text-purple-400" />
                         Quick Actions
                     </h3>
-                    <div className="space-y-2">
+                    <div className="grid gap-2">
                         <Link
                             href="/reading"
-                            className="flex items-center gap-3 p-2 rounded-lg hover:bg-purple-900/40 transition-colors text-sm text-gray-300 hover:text-purple-300"
+                            className="flex w-full items-center gap-3 p-2 rounded-lg hover:bg-purple-900/40 transition-colors text-sm leading-5 text-gray-300 hover:text-purple-300"
                         >
                             <FiSun className="w-4 h-4" />
                             New Reading
                         </Link>
                         <Link
                             href="/journal"
-                            className="flex items-center gap-3 p-2 rounded-lg hover:bg-purple-900/40 transition-colors text-sm text-gray-300 hover:text-purple-300"
+                            className="flex w-full items-center gap-3 p-2 rounded-lg hover:bg-purple-900/40 transition-colors text-sm leading-5 text-gray-300 hover:text-purple-300"
                         >
                             <FiBookOpen className="w-4 h-4" />
                             Journal
                         </Link>
                         <Link
                             href="/profile"
-                            className="flex items-center gap-3 p-2 rounded-lg hover:bg-purple-900/40 transition-colors text-sm text-gray-300 hover:text-purple-300"
+                            className="flex w-full items-center gap-3 p-2 rounded-lg hover:bg-purple-900/40 transition-colors text-sm leading-5 text-gray-300 hover:text-purple-300"
                         >
                             <FiUser className="w-4 h-4" />
                             Profile
@@ -193,7 +193,7 @@ export function MysticalSidebar({ className = '' }: MysticalSidebarProps) {
                             <FiHeart className="w-4 h-4 text-red-400" />
                             Your Journey
                         </h3>
-                        <div className="space-y-2">
+                        <div className="grid gap-2">
                             <div className="flex justify-between items-center">
                                 <span className="text-xs text-gray-400">Member since</span>
                                 <span className="text-xs text-purple-300">


### PR DESCRIPTION
### Motivation
- Prevent the Quick Actions links in the homepage sidebar from visually overlapping on narrow layouts so each action remains on its own row and labels stay readable.

### Description
- Update `frontend/src/components/MysticalSidebar.tsx` to replace the vertical spacing container from `space-y-2` to `grid gap-2` and add `w-full` and `leading-5` to the Quick Action `Link` classes for `href="/reading"`, `href="/journal"`, and `href="/profile"`; also normalize the User Stats block to `grid gap-2` for consistent spacing, and add a changelog entry in `backend/docs/CHANGELOG.md` documenting the fix.

### Testing
- No automated tests were run for this visual/layout-only change; the modification was validated by inspecting the updated `MysticalSidebar.tsx` and committing the changelog update successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1418066ca083288904b05b759e86ec)