### PR TITLE
Remove Save action from session reading header

### DIFF
--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The backend now conditionally includes the `rename_chat` tool only when a session still has its default title; once a title is set by either the user or assistant, subsequent model calls omit the rename tool.
 - Enhance the homepage UI & chat session UI.
+- Removed the unused "Save" action from the chat session reading header, leaving only the "New spread" button in that action row.
 
 ### Fixed
 - Home page center "Card of the day" image now renders reliably for remote deck URLs by bypassing Next image optimization for that slot and falling back gracefully if the image fails to load.

--- a/frontend/src/app/session/[id]/page.tsx
+++ b/frontend/src/app/session/[id]/page.tsx
@@ -12,11 +12,6 @@ const IconSparkle = ({ size = 12 }: { size?: number }) => (
     <path d="M8 1l1.4 5.6L15 8l-5.6 1.4L8 15l-1.4-5.6L1 8l5.6-1.4z" />
   </svg>
 );
-const IconBookmark = () => (
-  <svg width={14} height={14} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round">
-    <path d="M4 2.5h8v11l-4-2.5-4 2.5z" />
-  </svg>
-);
 const IconShuffle = () => (
   <svg width={14} height={14} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round">
     <path d="M2 4h2.5l7 8H14M2 12h2.5l2.2-2.5M9.4 6.5L11.5 4H14" />
@@ -555,10 +550,6 @@ function SessionDetailInner() {
           )}
         </div>
         <div className="sess-top-right">
-          <button className="sess-ghost-btn">
-            <IconBookmark />
-            Save
-          </button>
           {hasReading && (
             <button className="sess-primary-btn sess-primary-btn-sm"
               onClick={() => sendMessage(sessionId, 'Draw a new spread for me.')}


### PR DESCRIPTION
### Motivation
- Simplify the session reading header by removing an unused "Save" bookmark action so the top-right action area only shows the primary `New spread` control, and record the user-facing change in the changelog.

### Description
- Removed the `Save` button and its `IconBookmark` component from `frontend/src/app/session/[id]/page.tsx`, leaving the existing `New spread` button and behavior intact.
- Added a short entry to `backend/docs/CHANGELOG.md` under `0.0.18` documenting the removal of the Save action.

### Testing
- No automated tests were run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1419544cf483288f4d01b910778c2f)