### PR TITLE
Add Sessions shortcut to top navigation

### DIFF
--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Chat completions can now receive a `rename_chat` tool call for brand-new sessions, allowing the model to assign a short descriptive conversation title instead of leaving every chat as "New Chat".
 - Admin Users now supports bulk user deletion with a Select mode, row-level multi-select checkboxes, page-level select-all, and a single "Delete selected" action for removing multiple users in one flow.
 - Admin Users now includes a "No sessions" filter chip so administrators can quickly find accounts that have never started a chat session.
+- Header navigation now includes a dedicated Sessions tab that links directly to `/session` for faster access to chat history.
 
 ### Changed
 - The backend now conditionally includes the `rename_chat` tool only when a session still has its default title; once a title is set by either the user or assistant, subsequent model calls omit the rename tool.

--- a/frontend/src/components/EnhancedNavigation.tsx
+++ b/frontend/src/components/EnhancedNavigation.tsx
@@ -14,6 +14,7 @@ import {
     History,
     BookOpen,
     Library,
+    MessageCircle,
     LogOut,
     Crown,
     Star,
@@ -59,6 +60,12 @@ const NAV_ITEMS = [
         href: '/library',
         Icon: Library,
         match: (p: string) => p.startsWith('/library'),
+    },
+    {
+        label: 'Sessions',
+        href: '/session',
+        Icon: MessageCircle,
+        match: (p: string) => p.startsWith('/session'),
     },
 ];
 


### PR DESCRIPTION
### Motivation
- Provide a direct Sessions shortcut in the global header so users can quickly open the chat history at `/session`, and keep the project changelog in sync with this user-facing addition per project guidelines.

### Description
- Add a `Sessions` nav item to `NAV_ITEMS` in `frontend/src/components/EnhancedNavigation.tsx` (imported `MessageCircle`, `href: '/session'`, active-route `match`).
- Append a note to `backend/docs/CHANGELOG.md` under `0.0.18` → `Added` documenting the new header navigation entry.

### Testing
- Ran `npm --prefix frontend run lint -- --file src/components/EnhancedNavigation.tsx`, which fell back to the project type-check due to an existing ESLint config issue; the type-check passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a141d89bd40832885bdb9d8c5223092)