### PR TITLE
Add standardized timezone endpoint and wire frontend timezone dropdowns

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -39,7 +39,7 @@ from sqlalchemy.exc import IntegrityError, OperationalError, SQLAlchemyError
 
 from config import settings
 from database import Base, engine
-from routers import admin, auth, changelog, chat, health, journal, sharing, stats, streaks, subscription, support, tarot, tasks, web_push
+from routers import admin, auth, changelog, chat, health, journal, sharing, stats, streaks, subscription, support, tarot, tasks, utilities, web_push
 from utils.error_handlers import (
     TarotAPIException,
     general_exception_handler,
@@ -155,6 +155,7 @@ app.include_router(changelog.router)  # Changelog and version information
 app.include_router(streaks.router)  # Daily streaks and achievements
 app.include_router(stats.router)    # Aggregated dashboard statistics
 app.include_router(web_push.router)  # Web Push (VAPID) subscriptions and delivery
+app.include_router(utilities.router)  # Shared utility endpoints
 
 
 @app.get("/")

--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Chat completions can now receive a `rename_chat` tool call for brand-new sessions, allowing the model to assign a short descriptive conversation title instead of leaving every chat as "New Chat".
+- Added a standardized timezone catalog endpoint (`GET /utilities/timezones`) so frontend timezone dropdowns can use one backend-defined IANA list across profile and notification settings; it now returns the full runtime `zoneinfo.available_timezones()` set.
 - Admin Users now supports bulk user deletion with a Select mode, row-level multi-select checkboxes, page-level select-all, and a single "Delete selected" action for removing multiple users in one flow.
 - Admin Users now includes a "No sessions" filter chip so administrators can quickly find accounts that have never started a chat session.
 

--- a/backend/routers/utilities.py
+++ b/backend/routers/utilities.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, Request
+
+from schemas import TimezoneOption
+from utils.rate_limiter import RATE_LIMITS, limiter
+from utils.timezones import get_standard_timezones
+
+router = APIRouter(prefix="/utilities", tags=["utilities"])
+
+
+@router.get("/timezones", response_model=list[TimezoneOption])
+@limiter.limit(RATE_LIMITS["default"])
+async def get_timezone_options(request: Request):
+    """Return a standardized list of supported IANA timezones for UI dropdowns."""
+    return [TimezoneOption(value=tz, label=tz) for tz in get_standard_timezones()]

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -504,6 +504,13 @@ class UserResponse(BaseModel):
         json_encoders = {datetime: lambda v: v.isoformat()}
 
 
+class TimezoneOption(BaseModel):
+    """Timezone item returned by the timezone options endpoint."""
+
+    value: str
+    label: str
+
+
 # Password Reset Models
 class ForgotPasswordRequest(BaseModel):
     """Schema for requesting a password reset email.

--- a/backend/utils/timezones.py
+++ b/backend/utils/timezones.py
@@ -1,0 +1,8 @@
+"""Standard timezone options shared across backend and frontend."""
+
+from zoneinfo import available_timezones
+
+
+def get_standard_timezones() -> list[str]:
+    """Return a stable, sorted list of IANA timezone names for UI selection."""
+    return sorted(available_timezones())

--- a/frontend/src/app/profile/_components/NotificationsTab.tsx
+++ b/frontend/src/app/profile/_components/NotificationsTab.tsx
@@ -1,10 +1,20 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { MysticCard, SectionHeader, FieldLabel, FieldInput, FieldSelect } from './MysticCard';
 import { ProfileIcon } from './ProfileIcon';
 import { GhostButton } from './ProfileInfoTab';
 import { PushNotificationToggle } from '@/components/PushNotificationToggle';
+import { auth } from '@/lib/api';
+import { TimezoneOption } from '@/types/tarot';
+
+const TIMEZONE_FALLBACK_OPTIONS: TimezoneOption[] = [
+    { value: 'UTC', label: 'UTC' },
+    { value: 'Asia/Ho_Chi_Minh', label: 'Asia/Ho_Chi_Minh' },
+    { value: 'Asia/Singapore', label: 'Asia/Singapore' },
+    { value: 'Europe/London', label: 'Europe/London' },
+    { value: 'America/New_York', label: 'America/New_York' },
+];
 
 export function NotificationsTab() {
     const [prefs, setPrefs] = useState({
@@ -12,6 +22,21 @@ export function NotificationsTab() {
         marketing: false, security: true,
     });
     const toggle = (k: keyof typeof prefs) => setPrefs(p => ({ ...p, [k]: !p[k] }));
+    const [timezoneOptions, setTimezoneOptions] = useState<TimezoneOption[]>(TIMEZONE_FALLBACK_OPTIONS);
+
+    useEffect(() => {
+        const loadTimezones = async () => {
+            try {
+                const options = await auth.getTimezones();
+                if (Array.isArray(options) && options.length > 0) {
+                    setTimezoneOptions(options);
+                }
+            } catch {
+                setTimezoneOptions(TIMEZONE_FALLBACK_OPTIONS);
+            }
+        };
+        loadTimezones();
+    }, []);
 
     return (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
@@ -129,10 +154,9 @@ export function NotificationsTab() {
                     <div>
                         <FieldLabel>Timezone</FieldLabel>
                         <FieldSelect defaultValue="Asia/Ho_Chi_Minh">
-                            <option>Asia/Ho_Chi_Minh</option>
-                            <option>Asia/Singapore</option>
-                            <option>Europe/London</option>
-                            <option>America/New_York</option>
+                            {timezoneOptions.map((tz) => (
+                                <option key={tz.value} value={tz.value}>{tz.label}</option>
+                            ))}
                         </FieldSelect>
                     </div>
                 </div>

--- a/frontend/src/app/profile/_components/ProfileInfoTab.tsx
+++ b/frontend/src/app/profile/_components/ProfileInfoTab.tsx
@@ -4,8 +4,9 @@ import React, { useEffect, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
 import { MysticCard, SectionHeader, FieldLabel, FieldInput, FieldSelect, FieldTextarea } from './MysticCard';
 import { ProfileIcon } from './ProfileIcon';
-import { Deck, ProfileUpdatePayload, UserProfile } from '@/types/tarot';
+import { Deck, ProfileUpdatePayload, TimezoneOption, UserProfile } from '@/types/tarot';
 import { AvatarUpload } from '@/components/AvatarUpload';
+import { auth } from '@/lib/api';
 
 interface ProfileInfoTabProps {
     profile: UserProfile | null;
@@ -27,20 +28,20 @@ interface FormState {
     reversed_cards: boolean;
 }
 
-const TIMEZONE_OPTIONS: { value: string; label: string }[] = [
+const TIMEZONE_FALLBACK_OPTIONS: TimezoneOption[] = [
     { value: 'UTC', label: 'UTC' },
-    { value: 'Asia/Ho_Chi_Minh', label: 'Vietnam (UTC+7)' },
-    { value: 'Asia/Singapore', label: 'Singapore (UTC+8)' },
-    { value: 'Asia/Tokyo', label: 'Japan (UTC+9)' },
-    { value: 'Asia/Kolkata', label: 'India (UTC+5:30)' },
-    { value: 'Europe/London', label: 'London (UTC+0)' },
-    { value: 'Europe/Paris', label: 'Central Europe (UTC+1)' },
-    { value: 'America/New_York', label: 'New York (UTC−5)' },
-    { value: 'America/Chicago', label: 'Chicago (UTC−6)' },
-    { value: 'America/Denver', label: 'Denver (UTC−7)' },
-    { value: 'America/Los_Angeles', label: 'Los Angeles (UTC−8)' },
-    { value: 'Australia/Sydney', label: 'Sydney (UTC+11)' },
-    { value: 'Pacific/Auckland', label: 'Auckland (UTC+13)' },
+    { value: 'Asia/Ho_Chi_Minh', label: 'Asia/Ho_Chi_Minh' },
+    { value: 'Asia/Singapore', label: 'Asia/Singapore' },
+    { value: 'Asia/Tokyo', label: 'Asia/Tokyo' },
+    { value: 'Asia/Kolkata', label: 'Asia/Kolkata' },
+    { value: 'Europe/London', label: 'Europe/London' },
+    { value: 'Europe/Paris', label: 'Europe/Paris' },
+    { value: 'America/New_York', label: 'America/New_York' },
+    { value: 'America/Chicago', label: 'America/Chicago' },
+    { value: 'America/Denver', label: 'America/Denver' },
+    { value: 'America/Los_Angeles', label: 'America/Los_Angeles' },
+    { value: 'Australia/Sydney', label: 'Australia/Sydney' },
+    { value: 'Pacific/Auckland', label: 'Pacific/Auckland' },
 ];
 
 const CARD_ANIMATION_OPTIONS: { value: string; label: string; desc: string }[] = [
@@ -68,6 +69,7 @@ export function ProfileInfoTab({ profile, decks, isLoading, onAvatarChange, fetc
     const baseline = useMemo(() => (profile ? toForm(profile) : null), [profile]);
     const [form, setForm] = useState<FormState | null>(baseline);
     const [isSaving, setIsSaving] = useState(false);
+    const [timezoneOptions, setTimezoneOptions] = useState<TimezoneOption[]>(TIMEZONE_FALLBACK_OPTIONS);
     const [isEditing, setIsEditing] = useState(false);
 
     // Re-sync the editable form whenever the underlying profile changes
@@ -75,6 +77,20 @@ export function ProfileInfoTab({ profile, decks, isLoading, onAvatarChange, fetc
     useEffect(() => {
         setForm(baseline);
     }, [baseline]);
+
+    useEffect(() => {
+        const loadTimezones = async () => {
+            try {
+                const options = await auth.getTimezones();
+                if (Array.isArray(options) && options.length > 0) {
+                    setTimezoneOptions(options);
+                }
+            } catch {
+                setTimezoneOptions(TIMEZONE_FALLBACK_OPTIONS);
+            }
+        };
+        loadTimezones();
+    }, []);
 
     const memberSince = profile?.created_at
         ? new Date(profile.created_at).getFullYear()
@@ -277,7 +293,7 @@ export function ProfileInfoTab({ profile, decks, isLoading, onAvatarChange, fetc
                             style={locked ? { opacity: 0.7, cursor: 'default' } : undefined}
                         >
                             <option value="">Not set</option>
-                            {TIMEZONE_OPTIONS.map((tz) => (
+                            {timezoneOptions.map((tz) => (
                                 <option key={tz.value} value={tz.value}>{tz.label}</option>
                             ))}
                         </FieldSelect>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -249,6 +249,11 @@ export const auth = {
         return response.data;
     },
 
+    getTimezones: async () => {
+        const response = await api.get("/utilities/timezones");
+        return response.data;
+    },
+
     me: async () => {
         const response = await api.get("/auth/me");
         return response.data;

--- a/frontend/src/types/tarot.ts
+++ b/frontend/src/types/tarot.ts
@@ -73,6 +73,11 @@ export interface UserProfile {
     reversed_cards?: boolean;
 }
 
+export interface TimezoneOption {
+    value: string;
+    label: string;
+}
+
 export interface ProfileUpdatePayload {
     favorite_deck_id?: number;
     full_name?: string | null;


### PR DESCRIPTION
### Motivation
- Centralize the canonical list of IANA timezones on the backend so multiple UI pages can use a single authoritative source for timezone dropdowns. 
- Avoid duplicated, stale timezone lists in frontend components and provide a stable, sorted set of zone names for profile and notification settings. 
- Rate-limit the endpoint and reuse existing schemas and response shapes for consistent API behavior.

### Description
- Added a new backend router `GET /utilities/timezones` in `backend/routers/utilities.py` that returns `TimezoneOption` items and is rate-limited with the existing limiter. 
- Introduced `backend/utils/timezones.py` with `get_standard_timezones()` that returns a sorted list from `zoneinfo.available_timezones()`. 
- Added a `TimezoneOption` Pydantic model to `backend/schemas.py` and included the new `utilities` router in `backend/app.py`. 
- Updated `backend/docs/CHANGELOG.md` to document the new endpoint. 
- Frontend changes: added `auth.getTimezones()` to `frontend/src/lib/api.ts`, declared `TimezoneOption` in `frontend/src/types/tarot.ts`, and updated `ProfileInfoTab.tsx` and `NotificationsTab.tsx` to fetch and use the backend timezone list with a small fallback set when the call fails.

### Testing
- Ran backend static checks and imports (type checking and linting) and the added modules import correctly with no errors. 
- Performed a frontend typecheck/build (`tsc` / `npm run build` equivalent) and the updated components compile without type errors. 
- Manually exercised the new endpoint via the frontend fetch in a local development run and confirmed the timezone dropdowns populate; no automated test failures occurred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a141d43a5dc83289acdfc3373727ed2)