### PR TITLE
Render pre-reading assistant messages in session detail and update changelog

### DIFF
--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the unused "Save" action from the chat session reading header, leaving only the "New spread" button in that action row.
 
 ### Fixed
+- Session detail pages now always render assistant replies that do not include drawn cards, instead of hiding the conversation until a card-bearing assistant message appears.
 - Home page center "Card of the day" image now renders reliably for remote deck URLs by bypassing Next image optimization for that slot and falling back gracefully if the image fails to load.
 - Admin user deletion now performs a dedicated soft delete by marking `is_deleted=true` (and deactivating the account) instead of hard-deleting the database row, preventing foreign-key conflicts when related checkout sessions exist while keeping deleted state distinct from inactive users.
 - `/session` now shows recent readings in the left rail instead of visually collapsing the session list.

--- a/frontend/src/app/session/[id]/page.tsx
+++ b/frontend/src/app/session/[id]/page.tsx
@@ -510,6 +510,13 @@ function SessionDetailInner() {
     [messages, readingMsgIdx]
   );
 
+  const preReadingMsgs = useMemo(() => {
+    if (readingMsgIdx < 0) {
+      return messages;
+    }
+    return messages.slice(0, readingMsgIdx);
+  }, [messages, readingMsgIdx]);
+
   const continuationMsgs = useMemo(() => {
     if (readingMsgIdx < 0) return [];
     return messages.slice(readingMsgIdx + 1);
@@ -572,6 +579,11 @@ function SessionDetailInner() {
           {!hasContent && !loading && !isDrawingCards && (
             <NewSessionComposer sessionId={sessionId} />
           )}
+
+          {/* ── Messages before first card reading (plain chat fallback) ── */}
+          {preReadingMsgs.map((msg) => (
+            <ChatMessage key={msg.id} message={msg} />
+          ))}
 
           {/* ── Question header ── */}
           {questionMsg && (


### PR DESCRIPTION
### Motivation
- Fix a UX bug where assistant replies that don't include drawn cards were hidden on session detail pages until a card-bearing assistant message appeared.
- Ensure the change is recorded in the project's changelog for the 0.0.18 release.

### Description
- Add a `preReadingMsgs` `useMemo` in `frontend/src/app/session/[id]/page.tsx` to capture all messages before the first assistant message that contains cards.
- Render `preReadingMsgs` with `<ChatMessage />` so plain chat exchanges appear even when no card reading is present.
- Update `backend/docs/CHANGELOG.md` under `0.0.18` -> `Fixed` to document that session detail pages now always render assistant replies that do not include drawn cards.

### Testing
- Ran frontend type-checking and build (`yarn tsc` / `yarn build`) which completed successfully.
- Executed frontend unit tests (`yarn test`) and they passed.
- Ran linting (`yarn lint`) with no new issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a142a7d9f94832889e66347e6150505)