### PR TITLE
feat(admin): add password reset from admin portal

### DIFF
--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Admin Users now supports bulk user deletion with a Select mode, row-level multi-select checkboxes, page-level select-all, and a single "Delete selected" action for removing multiple users in one flow.
 - Admin Users now includes a "No sessions" filter chip so administrators can quickly find accounts that have never started a chat session.
 - Header navigation now includes a dedicated Sessions tab that links directly to `/session` for faster access to chat history.
+- Admin Users now supports direct password resets from the user edit dialog, allowing administrators to set a new password for any account without email token flow.
 
 ### Changed
 - The backend now conditionally includes the `rename_chat` tool only when a session still has its default title; once a title is set by either the user or assistant, subsequent model calls omit the rename tool.

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -24,6 +24,7 @@ from schemas import (
     AdminSpreadResponse,
     AdminSpreadUpdate,
     AdminUserResponse,
+    AdminUserPasswordResetRequest,
     AdminUserUpdate,
 )
 from utils.avatar_utils import avatar_manager
@@ -383,6 +384,23 @@ async def delete_user(user_id: int, db: Session = Depends(get_db), admin_user: U
     db.commit()
 
     return {"message": "User deleted successfully"}
+
+
+@router.post("/users/{user_id}/reset-password")
+async def reset_user_password(
+    user_id: int,
+    payload: AdminUserPasswordResetRequest,
+    db: Session = Depends(get_db),
+    admin_user: User = Depends(get_admin_user),
+):
+    """Reset a user's password from the admin portal."""
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    user.password = payload.new_password
+    db.commit()
+    return {"message": "Password reset successfully"}
 
 
 # Chat Session Management

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -937,6 +937,18 @@ class AdminUserUpdate(BaseModel):
         return _sanitize_string(v, "Full name", min_length=1, max_length=100, allow_empty=False)
 
 
+class AdminUserPasswordResetRequest(BaseModel):
+    new_password: str
+
+    @field_validator("new_password")
+    def validate_new_password(cls, v):  # noqa: N805
+        if not v or not v.strip():
+            raise ValueError("Password cannot be empty")
+        if len(v.strip()) < 8:
+            raise ValueError("Password must be at least 8 characters long")
+        return v.strip()
+
+
 class AdminChatSessionResponse(BaseModel):
     id: int
     title: str

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -349,6 +349,10 @@ function UserRow({
                                 receive_error_alerts: fd.get("receive_error_alerts") === "on",
                                 favorite_deck_id: parseInt(fd.get("favorite_deck_id") as string),
                             });
+                            const newPassword = (fd.get("new_password") as string | null)?.trim() ?? "";
+                            if (newPassword) {
+                                await api.post(`/admin/users/${u.id}/reset-password`, { new_password: newPassword });
+                            }
                             setOpen(false);
                             onSaved();
                         } catch { alert("Failed to update user."); }
@@ -366,6 +370,17 @@ function UserRow({
                             <input name={f.name} type={f.type} defaultValue={f.val} required={f.required} className="admin-input" />
                         </div>
                     ))}
+                    <div>
+                        <label className="admin-field-label">Reset password</label>
+                        <input
+                            name="new_password"
+                            type="password"
+                            minLength={8}
+                            autoComplete="new-password"
+                            placeholder="Leave blank to keep current password"
+                            className="admin-input"
+                        />
+                    </div>
                     <div className="flex flex-col gap-3">
                         {[
                             { name: "is_active", label: "Active user", checked: u.is_active },


### PR DESCRIPTION
### Motivation
- Provide administrators a supported way to set a new password for a user directly from the admin UI for faster account recovery and support workflows.
- Avoid forcing an email token flow when admins must intervene (e.g. account support or migration) while still using the existing model password hashing logic.

### Description
- Add a backend endpoint `POST /admin/users/{user_id}/reset-password` that accepts `AdminUserPasswordResetRequest` and updates the user's password via the model setter so hashing is applied (`backend/routers/admin.py`).
- Introduce `AdminUserPasswordResetRequest` schema with server-side validation (trimmed, required, minimum length 8) as `backend/schemas.py`.
- Extend the Admin Users edit dialog to include an optional `new_password` input and call the new admin endpoint after saving profile changes when a new password is provided (`frontend/src/app/admin/users/page.tsx`).
- Update the project changelog in `backend/docs/CHANGELOG.md` to document the new admin capability.

### Testing
- Ran `python -m py_compile backend/routers/admin.py backend/schemas.py` and compilation succeeded.
- Attempted frontend lint with `npm --prefix frontend run -s lint -- --file src/app/admin/users/page.tsx`, but ESLint crashed due to an environment/config serialization error unrelated to the code changes; no lint errors in the changed file were produced before the failure.
- No automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1590f6dc2c832884b6d385dc7b79a0)