### PR TITLE
docs: require RLS on newly created Postgres tables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,13 @@
 # Agent Instructions
 
+## Database security baseline
+
+For all newly created Postgres tables, enable Row Level Security (RLS) by default in the same migration that creates the table.
+
+- Always include `ALTER TABLE <schema>.<table> ENABLE ROW LEVEL SECURITY;` immediately after table creation.
+- Do not leave newly created public tables with RLS disabled.
+- Add or update policies in the same change when table access is required.
+
 ## Changelog
 
 When making user-facing changes, update `backend/docs/CHANGELOG.md` as part of the same change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# Claude Instructions
+
+## Database security baseline
+
+For all newly created Postgres tables, enable Row Level Security (RLS) by default in the same migration that creates the table.
+
+- Always include `ALTER TABLE <schema>.<table> ENABLE ROW LEVEL SECURITY;` immediately after table creation.
+- Do not leave newly created public tables with RLS disabled.
+- Add or update policies in the same change when table access is required.


### PR DESCRIPTION
### Motivation

- Enforce a database security baseline so newly created Postgres tables are not left publicly accessible without Row Level Security (RLS), addressing security advisor findings and preventing future regressions.

### Description

- Add a `Database security baseline` section to `AGENTS.md` that requires `ALTER TABLE <schema>.<table> ENABLE ROW LEVEL SECURITY;` to be included in the same migration that creates a table and requires adding/updating policies in the same change.
- Add `CLAUDE.md` with matching instructions so the same RLS-default rule is applied for Claude-agent workflows.
- No application code changes are included in this PR; these are documentation/instruction updates only.

### Testing

- Verified the updated files and their contents with `nl -ba AGENTS.md` and `nl -ba CLAUDE.md`, confirming the new RLS guidance is present and formatted as intended.
- PR metadata was created via the repository's PR tooling to open this change for review (tooling succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1656e4ee988328852c9be2fcc417d3)