### PR TITLE
Adapt Grafana guide for personal grafana.nguyenvanloc.com

### DIFF
--- a/docs/grafana-monitoring-guide.md
+++ b/docs/grafana-monitoring-guide.md
@@ -1,24 +1,32 @@
-# Grafana Monitoring Guide for ArcanaAI
+# Personal Grafana Monitoring Guide for grafana.nguyenvanloc.com
 
-A hands-on guide for building Grafana dashboards and alerts on top of the
-metrics this project already exposes. Written so you can implement it
-yourself and actually learn Grafana along the way.
+A hands-on guide for building a **personal, central Grafana site** at
+`grafana.nguyenvanloc.com` and using it to monitor multiple projects,
+including ArcanaAI.
 
-> Heads up: this repo already ships the **config** for a monitoring
-> stack (`monitoring-docker-compose.yaml` + `monitoring/`), but nothing
-> is running yet. [Section 4](#4-setup-from-scratch) walks you through
-> bringing it up from zero. The rest of the guide explains what's in
-> the bundled config and how to build dashboards and alerts on top of
-> it.
+The intended end state is:
+
+- One private Grafana UI at `https://grafana.nguyenvanloc.com`.
+- One Prometheus instance that scrapes ArcanaAI now and can scrape more
+  projects later.
+- Project labels on every scrape target so dashboards can filter by
+  `project="arcana-ai"`, `project="another-project"`, etc.
+- Grafana and Prometheus data persisted on disk so a container restart
+  does not wipe dashboards or metrics.
+
+> Heads up: this repo already ships the **ArcanaAI monitoring config**
+> (`monitoring-docker-compose.yaml` + `monitoring/`). This guide adapts
+> that config into a personal monitoring stack instead of treating
+> Grafana as a one-off local dashboard for only this repository.
 
 ---
 
 ## Table of contents
 
 1. [What you're monitoring](#1-what-youre-monitoring)
-2. [The stack that's already wired up](#2-the-stack-thats-already-wired-up)
+2. [Personal monitoring architecture](#2-personal-monitoring-architecture)
 3. [Grafana concepts in 5 minutes](#3-grafana-concepts-in-5-minutes)
-4. [Setup from scratch](#4-setup-from-scratch)
+4. [Setup Grafana from scratch for grafana.nguyenvanloc.com](#4-setup-grafana-from-scratch-for-grafananguyenvanloccom)
 5. [PromQL primer with this project's metrics](#5-promql-primer-with-this-projects-metrics)
 6. [Dashboards to build](#6-dashboards-to-build)
    - [6.1 Golden signals (API health)](#61-dashboard-1--golden-signals-api-health)
@@ -35,8 +43,18 @@ yourself and actually learn Grafana along the way.
 
 ## 1. What you're monitoring
 
+This Grafana site is **not just for ArcanaAI**. Treat it as your personal
+observability home:
+
+| Scope | Examples | How it appears in Grafana |
+|---|---|---|
+| ArcanaAI app metrics | FastAPI requests, tarot readings, OpenAI tokens, DB query metrics | Prometheus metrics with `project="arcana-ai"` |
+| ArcanaAI infrastructure | Docker container CPU/memory/network, host disk/load | cAdvisor + node-exporter, filtered to `tarot-*` containers |
+| Future projects | Any other API, worker, frontend, bot, cron service, or VPS app | Add another Prometheus scrape job with a different `project` label |
+| Shared host health | Disk, CPU, memory, network, Docker daemon symptoms | One host dashboard, optionally filtered by `host` |
+
 ArcanaAI is a FastAPI + Next.js tarot reading service. The pieces worth
-watching:
+watching for this project are:
 
 | Layer | Stack |
 |---|---|
@@ -49,21 +67,45 @@ watching:
 | Payments | Lemon Squeezy + Ethereum/MetaMask |
 | Storage | Cloudflare R2 |
 
-The backend already exposes Prometheus metrics at `GET /metrics`
-(see `backend/utils/metrics.py` and `backend/app.py:79`).
+The ArcanaAI backend already exposes Prometheus metrics at
+`GET /metrics` (see `backend/utils/metrics.py` and `backend/app.py:79`).
 
 ---
 
-## 2. The stack that's already wired up
+## 2. Personal monitoring architecture
+
+Use a central monitoring stack and add projects to it over time:
+
+```text
+Internet
+  │
+  │ https://grafana.nguyenvanloc.com
+  ▼
+Caddy / Nginx reverse proxy with TLS
+  │
+  ▼
+Grafana container (private UI, port 3002 on localhost only)
+  │
+  ▼
+Prometheus container (not public, port 9090 on localhost only)
+  │
+  ├── ArcanaAI backend: tarot-backend:8000/metrics
+  ├── ArcanaAI frontend: tarot-frontend:3000/api/metrics (optional)
+  ├── cAdvisor: container metrics
+  ├── node-exporter: host metrics
+  └── Future projects: add more scrape jobs
+```
+
+### What this repository already provides
 
 Defined in `monitoring-docker-compose.yaml`:
 
-| Service | Port | Purpose |
-|---|---|---|
-| `tarot-prometheus` | 9090 | Scrapes metrics, stores 30d, evaluates alert rules |
-| `tarot-grafana` | 3002 → 3000 | Dashboards & alerts UI |
-| `tarot-cadvisor` | 8090 | Per-container CPU/mem/net metrics |
-| `tarot-node-exporter` | 9200 → 9100 | Host metrics (disk, load, network) |
+| Service | Current container | Current port mapping | Purpose |
+|---|---|---|---|
+| Prometheus | `tarot-prometheus` | `9090:9090` | Scrapes metrics, stores 30d, evaluates alert rules |
+| Grafana | `tarot-grafana` | `3002:3000` | Dashboards & alerts UI |
+| cAdvisor | `tarot-cadvisor` | `8090:8080` | Per-container CPU/mem/net metrics |
+| node-exporter | `tarot-node-exporter` | `9200:9100` | Host metrics (disk, load, network) |
 
 Prometheus scrape targets (`monitoring/prometheus/prometheus.yml`):
 
@@ -83,8 +125,38 @@ Grafana is auto-provisioned via
 
 There are 3 starter dashboard JSONs already, plus prebuilt alert rules
 in `monitoring/prometheus/rules/tarot_alerts.yml`. Treat those as
-reference, not as a finished product — you'll learn more by rebuilding
-them in the UI.
+ArcanaAI references, not as the entire personal Grafana site.
+
+### Recommended conventions for multiple projects
+
+Use these conventions from day one so adding projects later is easy:
+
+| Convention | Recommendation |
+|---|---|
+| Prometheus job names | `<project>-<component>`, e.g. `arcana-ai-backend`, `blog-api`, `trading-bot-worker` |
+| Static labels | Add `project`, `component`, and `env` labels to every scrape job |
+| Grafana folders | One folder per project (`ArcanaAI`, `Personal Blog`, etc.) plus one `Shared Infrastructure` folder |
+| Dashboard variables | Add a top-level `$project` variable to shared dashboards |
+| Public exposure | Publish only Grafana through HTTPS; keep Prometheus, cAdvisor, and node-exporter private |
+| Secrets | Keep admin passwords, SMTP credentials, OAuth secrets, and webhook URLs in `.env`, never in git |
+
+For ArcanaAI, prefer this scrape naming when you are ready to update
+`monitoring/prometheus/prometheus.yml`:
+
+```yaml
+- job_name: "arcana-ai-backend"
+  static_configs:
+    - targets: ["tarot-backend:8000"]
+      labels:
+        project: "arcana-ai"
+        component: "backend"
+        env: "production"
+  metrics_path: "/metrics"
+  scrape_interval: 10s
+```
+
+That single `project` label lets one Grafana dashboard switch between
+projects later.
 
 ---
 
@@ -96,7 +168,7 @@ them in the UI.
 | **Dashboard** | A page of panels. |
 | **Panel** | One visualization (time series, stat, table, heatmap…). |
 | **Query** | A PromQL expression the panel runs. A panel can have several (A, B, C…). |
-| **Variable** | A dropdown at the top of a dashboard that templatizes queries (e.g. `$instance`). |
+| **Variable** | A dropdown at the top of a dashboard that templatizes queries (e.g. `$project`, `$instance`). |
 | **Transformation** | Post-query reshaping (rename, join, filter rows) before the panel renders. |
 | **Annotation** | A marker on the time axis (deploys, incidents). |
 | **Alert rule** | A query that fires when a condition holds for a duration. |
@@ -114,41 +186,64 @@ Rule of thumb for panel choice:
 
 ---
 
-## 4. Setup from scratch
+## 4. Setup Grafana from scratch for grafana.nguyenvanloc.com
 
-You're starting from zero — neither the app nor the monitoring stack is
-running. Do these steps in order. Each step has a verification at the
-end; don't skip them.
+You're starting from zero. These steps assume a fresh VPS or server that
+will host your personal monitoring stack and expose only Grafana at
+`https://grafana.nguyenvanloc.com`.
+
+> If you are only testing locally, replace `grafana.nguyenvanloc.com`
+> with `localhost:3002` and skip the DNS / HTTPS reverse-proxy steps.
 
 ### 4.1 Prerequisites
 
-- Docker Engine ≥ 20.10 and Docker Compose v2 (`docker compose ...`,
-  not `docker-compose ...`).
-- Ports free on the host: `8000` (backend), `3000` (frontend, optional),
-  `9090` (Prometheus), `3002` (Grafana), `8090` (cAdvisor),
-  `9200` (node-exporter). Check with:
+- A server/VPS with Docker Engine ≥ 20.10 and Docker Compose v2
+  (`docker compose ...`, not `docker-compose ...`).
+- SSH access to the server.
+- DNS access for `nguyenvanloc.com`.
+- Ports `80` and `443` open to the internet for HTTPS.
+- Monitoring ports kept private or firewall-restricted:
+  - `3002` Grafana container port on the host.
+  - `9090` Prometheus.
+  - `8090` cAdvisor.
+  - `9200` node-exporter.
+- This repository checked out on the server.
+- The ArcanaAI backend `.env` file at `backend/.env` exists and is
+  populated if this same server is also running ArcanaAI.
 
-  ```bash
-  ss -tlnp | grep -E ':(8000|3000|9090|3002|8090|9200) '
-  ```
-
-- The backend's `.env` file at `backend/.env` exists and is populated
-  (copy from whatever template the project provides). The monitoring
-  stack doesn't read it, but the backend won't start without it.
-
-### 4.2 Create the shared Docker network
-
-All compose files (`docker-compose.yaml`, `redis-docker-compose.yaml`,
-`monitoring-docker-compose.yaml`) attach to an **external** network
-called `localnet`. Prometheus uses container DNS over that network to
-reach `tarot-backend:8000`, so this must exist before anything starts:
+Check listening ports before starting:
 
 ```bash
-docker network create localnet
+ss -tlnp | grep -E ':(80|443|3002|9090|8090|9200) '
 ```
 
-If it already exists you'll get `Error response from daemon: network
-with name localnet already exists` — that's fine, ignore it.
+### 4.2 Point DNS at the monitoring server
+
+Create a DNS record:
+
+| Type | Name | Value |
+|---|---|---|
+| `A` | `grafana` | Your server IPv4 address |
+| `AAAA` | `grafana` | Your server IPv6 address, if you use IPv6 |
+
+Verify DNS from your machine:
+
+```bash
+dig +short grafana.nguyenvanloc.com
+```
+
+Do not continue with HTTPS setup until this returns your server IP.
+
+### 4.3 Create the shared Docker network
+
+All compose files in this repo attach to an **external** network called
+`localnet`. Prometheus uses container DNS over that network to reach
+ArcanaAI (`tarot-backend:8000`), so create it before starting either the
+app or monitoring stack:
+
+```bash
+docker network create localnet || true
+```
 
 Verify:
 
@@ -156,70 +251,164 @@ Verify:
 docker network ls | grep localnet
 ```
 
-### 4.3 Start the application stack
+### 4.4 Start ArcanaAI if this server will monitor the local app
 
-The monitoring stack scrapes `tarot-backend:8000/metrics`, so the app
-has to be up first.
+If ArcanaAI runs on the same Docker host as Prometheus, start it first:
 
 ```bash
 # From the repo root
 docker compose -f docker-compose.yaml up -d
 ```
 
-This brings up `tarot-backend`, `tarot-frontend`, `tarot-redis`,
-`tarot-celery-worker`, `tarot-celery-beat`. Wait ~20s for the backend
-healthcheck to settle, then verify metrics are being exposed:
+Verify the backend exposes metrics:
 
 ```bash
-docker exec tarot-prometheus echo ok 2>/dev/null  # will fail — expected, prom isn't up yet
 docker exec tarot-backend curl -s http://localhost:8000/metrics | grep -E '^tarot_' | head
 ```
 
 You should see lines like `tarot_active_users 0.0`. If you see nothing:
 
 - `docker logs tarot-backend --tail 100` — look for import errors.
-- Confirm `setup_metrics(app)` is actually called
-  (`backend/app.py:79`).
+- Confirm `setup_metrics(app)` is called in the backend app startup.
 
-### 4.4 Configure the monitoring stack
+If ArcanaAI runs on another host, skip this step and add a remote scrape
+job in [4.8](#48-add-arcanaai-and-future-projects-as-prometheus-targets).
 
-Grafana refuses to start without `GRAFANA_ADMIN_PASSWORD`. Don't export
-this only in your current shell — put it in a `.env` file next to
-`monitoring-docker-compose.yaml` so it survives reboots:
+### 4.5 Create the monitoring environment file
+
+Grafana refuses to start without `GRAFANA_ADMIN_PASSWORD`. Put secrets
+in a local `.env` file and never commit it:
 
 ```bash
 # Repo root
 cat > .env <<'EOF'
 GRAFANA_ADMIN_USER=admin
-GRAFANA_ADMIN_PASSWORD=replace-with-a-real-password
+GRAFANA_ADMIN_PASSWORD=replace-with-a-long-random-password
+GRAFANA_DOMAIN=grafana.nguyenvanloc.com
+GRAFANA_ROOT_URL=https://grafana.nguyenvanloc.com/
 EOF
 chmod 600 .env
 ```
 
-Make sure `.env` is gitignored (the repo's `.gitignore` already
-excludes it, but double-check before committing anything):
+Verify the file is ignored by git:
 
 ```bash
-git check-ignore -v .env   # should print a matching rule
+git check-ignore -v .env
 ```
 
-### 4.5 Start the monitoring stack
+If that command prints nothing, add `.env` to `.gitignore` before you
+continue.
+
+### 4.6 Add a production override for the personal domain
+
+The checked-in compose file is local-friendly. For your personal site,
+add a local override file that binds Grafana and Prometheus to localhost
+only and tells Grafana its real public URL:
 
 ```bash
-docker compose -f monitoring-docker-compose.yaml --env-file .env up -d
+cat > monitoring-docker-compose.prod.override.yaml <<'EOF'
+services:
+  grafana:
+    ports:
+      - "127.0.0.1:3002:3000"
+    environment:
+      - GF_SERVER_DOMAIN=${GRAFANA_DOMAIN}
+      - GF_SERVER_ROOT_URL=${GRAFANA_ROOT_URL}
+      - GF_SERVER_SERVE_FROM_SUB_PATH=false
+      - GF_SECURITY_COOKIE_SECURE=true
+      - GF_SECURITY_COOKIE_SAMESITE=lax
+  prometheus:
+    ports:
+      - "127.0.0.1:9090:9090"
+  cadvisor:
+    ports:
+      - "127.0.0.1:8090:8080"
+  node-exporter:
+    ports:
+      - "127.0.0.1:9200:9100"
+EOF
 ```
 
-`--env-file .env` makes Compose read your password file (it's not
-loaded automatically when the file lives in the repo root but the
-compose file is referenced explicitly).
+This file can stay uncommitted if it is specific to your server. The key
+security point is that **only the reverse proxy should be reachable from
+the public internet**.
 
-Confirm all four containers came up:
+### 4.7 Label ArcanaAI targets for multi-project dashboards
+
+Update `monitoring/prometheus/prometheus.yml` so ArcanaAI targets carry
+stable labels. Example for the backend:
+
+```yaml
+  - job_name: "arcana-ai-backend"
+    static_configs:
+      - targets: ["tarot-backend:8000"]
+        labels:
+          project: "arcana-ai"
+          component: "backend"
+          env: "production"
+    metrics_path: "/metrics"
+    scrape_interval: 10s
+```
+
+You can do the same for the frontend, node-exporter, and cAdvisor jobs.
+For cAdvisor, the `project` label means "this exporter belongs to the
+host that runs ArcanaAI"; individual container names still come from the
+`name` label in cAdvisor metrics.
+
+After editing, validate the Prometheus config before restarting:
+
+```bash
+docker run --rm -v "$PWD/monitoring/prometheus:/etc/prometheus" prom/prometheus:latest promtool check config /etc/prometheus/prometheus.yml
+```
+
+### 4.8 Add ArcanaAI and future projects as Prometheus targets
+
+For each new project, add another scrape job with a unique `project`
+label. Examples:
+
+```yaml
+  - job_name: "personal-blog-api"
+    static_configs:
+      - targets: ["blog-api:8080"]
+        labels:
+          project: "personal-blog"
+          component: "api"
+          env: "production"
+    metrics_path: "/metrics"
+
+  - job_name: "remote-worker"
+    static_configs:
+      - targets: ["10.0.0.25:9105"]
+        labels:
+          project: "automation"
+          component: "worker"
+          env: "production"
+```
+
+For remote servers, prefer a private network such as WireGuard/Tailscale
+between Prometheus and the target. Do **not** expose `/metrics` publicly
+without authentication or network restrictions.
+
+### 4.9 Start the monitoring stack
+
+Start Grafana, Prometheus, cAdvisor, and node-exporter with your
+production override:
+
+```bash
+docker compose \
+  -f monitoring-docker-compose.yaml \
+  -f monitoring-docker-compose.prod.override.yaml \
+  --env-file .env \
+  up -d
+```
+
+Confirm all four monitoring containers came up:
 
 ```bash
 docker ps --filter 'name=tarot-' --format 'table {{.Names}}\t{{.Status}}'
 ```
 
-Expect to see `tarot-prometheus`, `tarot-grafana`, `tarot-cadvisor`,
+Expect to see `tarot-prometheus`, `tarot-grafana`, `tarot-cadvisor`, and
 `tarot-node-exporter` all `Up`.
 
 If Grafana keeps restarting:
@@ -228,64 +417,99 @@ If Grafana keeps restarting:
 docker logs tarot-grafana --tail 50
 ```
 
-The most common error is `GF_SECURITY_ADMIN_PASSWORD is required` —
-re-check step 4.4.
+The most common error is a missing `GRAFANA_ADMIN_PASSWORD`; re-check
+[4.5](#45-create-the-monitoring-environment-file).
 
-### 4.6 Verify Prometheus scraping
+### 4.10 Put HTTPS in front of Grafana
 
-Open <http://localhost:9090/targets>. You want every job `UP`:
+Use a reverse proxy to terminate TLS and forward only Grafana traffic to
+`127.0.0.1:3002`. Caddy is the simplest option because it manages
+Let's Encrypt certificates automatically.
+
+Install Caddy, then create `/etc/caddy/Caddyfile`:
+
+```caddyfile
+grafana.nguyenvanloc.com {
+  reverse_proxy 127.0.0.1:3002
+}
+```
+
+Reload Caddy:
+
+```bash
+sudo caddy fmt --overwrite /etc/caddy/Caddyfile
+sudo systemctl reload caddy
+```
+
+Verify from your laptop/browser:
+
+```bash
+curl -I https://grafana.nguyenvanloc.com/login
+```
+
+You should get an HTTP response from Grafana, not a connection timeout.
+
+### 4.11 Verify Prometheus scraping
+
+Open Prometheus through an SSH tunnel instead of exposing it publicly:
+
+```bash
+ssh -L 9090:127.0.0.1:9090 your-user@your-server
+```
+
+Then open <http://localhost:9090/targets>. You want every required job
+`UP`:
 
 | Job | Endpoint | Expected |
 |---|---|---|
 | `prometheus` | `localhost:9090/metrics` | UP |
-| `tarot-backend` | `tarot-backend:8000/metrics` | UP |
-| `tarot-frontend` | `tarot-frontend:3000/api/metrics` | DOWN until you add a Next.js metrics route (see §9). OK to ignore for now. |
+| `arcana-ai-backend` or `tarot-backend` | `tarot-backend:8000/metrics` | UP |
+| `arcana-ai-frontend` or `tarot-frontend` | `tarot-frontend:3000/api/metrics` | DOWN until you add a Next.js metrics route. OK to ignore for now. |
 | `node-exporter` | `tarot-node-exporter:9100/metrics` | UP |
 | `cadvisor` | `tarot-cadvisor:8080/metrics` | UP |
 
-**Troubleshooting a DOWN backend target:**
+Troubleshooting a DOWN backend target:
 
-1. *Connection refused* — backend container isn't on `localnet`. Check
+1. *Connection refused* — backend container is not on `localnet`. Check
    with `docker inspect tarot-backend -f '{{json .NetworkSettings.Networks}}'`.
 2. *No such host* — DNS lookup failed; Prometheus is on a different
-   network than the backend.
+   Docker network than the backend.
 3. *Connection timeout* — backend is up but slow to respond. Curl from
-   inside the prom container to confirm:
+   inside the Prometheus container:
    ```bash
    docker exec tarot-prometheus wget -qO- http://tarot-backend:8000/metrics | head
    ```
 
-Run a smoke-test query in Prometheus itself — open
-<http://localhost:9090/graph>, run `up` and confirm you get one row per
-target.
+Run a smoke-test query in Prometheus: open <http://localhost:9090/graph>,
+run `up`, and confirm you get one row per target.
 
-### 4.7 First Grafana login
+### 4.12 First Grafana login
 
-Open <http://localhost:3002>:
+Open <https://grafana.nguyenvanloc.com>:
 
 - User: `admin`
 - Password: whatever you set in `.env`
 
 Then:
 
-1. **Change the admin password** at first prompt (or `Profile →
-   Change password`). Even on localhost.
+1. **Change the admin password** at first prompt.
 2. Go to `Connections → Data sources`. There should already be a
-   Prometheus data source named "Prometheus" (provisioned from
-   `monitoring/grafana/provisioning/datasources/datasources.yml`).
+   Prometheus data source named "Prometheus" provisioned from
+   `monitoring/grafana/provisioning/datasources/datasources.yml`.
    Click it, scroll to bottom, click **Save & test**. You want a green
    "Successfully queried the Prometheus API.".
-3. Go to `Dashboards`. You'll see three provisioned dashboards:
-   `tarot-overview`, `tarot_dashboard`, `infrastructure`. Open
-   `tarot-overview` — if panels render data, your full pipeline
-   (app → Prometheus → Grafana) works. If they show "No data",
-   generate some traffic (hit the backend a few times) and refresh.
+3. Go to `Dashboards`. You'll see the provisioned ArcanaAI starter
+   dashboards. Open `tarot-overview` — if panels render data, your
+   pipeline works: ArcanaAI → Prometheus → Grafana → HTTPS domain.
+4. Create folders:
+   - `ArcanaAI`
+   - `Shared Infrastructure`
+   - One folder for each future project.
 
-### 4.8 Generate some traffic so the dashboards have something to show
+### 4.13 Generate traffic so dashboards have data
 
 Brand-new Prometheus = empty time series database. Counters need a few
-data points before `rate()` returns anything. Hammer the backend
-briefly:
+data points before `rate()` returns anything. Generate a little traffic:
 
 ```bash
 for i in $(seq 1 200); do
@@ -297,49 +521,41 @@ done
 Wait ~30s, then refresh Grafana. Panels driven by
 `rate(http_requests_total[...])` should now have data.
 
-### 4.9 Stopping / cleaning up
+### 4.14 Stopping / cleaning up
 
 ```bash
 # Stop monitoring only, keep data
-docker compose -f monitoring-docker-compose.yaml down
+docker compose \
+  -f monitoring-docker-compose.yaml \
+  -f monitoring-docker-compose.prod.override.yaml \
+  down
 
-# Stop AND wipe Prometheus + Grafana data (e.g. starting over)
-docker compose -f monitoring-docker-compose.yaml down -v
+# Stop AND wipe Prometheus + Grafana data (starting over)
+docker compose \
+  -f monitoring-docker-compose.yaml \
+  -f monitoring-docker-compose.prod.override.yaml \
+  down -v
 ```
 
 The `-v` flag deletes the named volumes `prometheus-data` and
-`grafana-data`. Don't run that in production unless you mean it.
+`grafana-data`. Do not run that in production unless you mean it.
 
-### 4.10 Dev mode: running the backend on the host, not in Docker
-
-If you're iterating on the backend with `uvicorn` directly on your host
-machine, Prometheus inside Docker can't reach `localhost:8000`. Two
-fixes:
-
-- **Linux**: add `extra_hosts: ["host.docker.internal:host-gateway"]` to
-  the `prometheus` service in `monitoring-docker-compose.yaml`, then
-  change the scrape target to `host.docker.internal:8000`.
-- **macOS/Windows Docker Desktop**: `host.docker.internal` already
-  resolves; just change the target.
-
-Don't commit that change — it's a local dev tweak. Easier: just run
-the backend in Docker too.
-
----
-
-### Setup recap
+### 4.15 Setup recap
 
 You should now have:
 
+- DNS for `grafana.nguyenvanloc.com` pointing at your monitoring server.
+- HTTPS reverse proxy forwarding `grafana.nguyenvanloc.com` to Grafana.
 - `localnet` Docker network created.
-- App stack up: `tarot-backend`, `tarot-redis`, workers, frontend.
 - Monitoring stack up: `tarot-prometheus`, `tarot-grafana`,
   `tarot-cadvisor`, `tarot-node-exporter`.
-- All Prometheus targets `UP` (frontend may be `DOWN`; that's expected
-  until you instrument it).
-- Grafana reachable at <http://localhost:3002> with the Prometheus
-  data source connected.
-- Three provisioned dashboards visible and showing data.
+- ArcanaAI scraped by Prometheus with a `project="arcana-ai"` label.
+- Prometheus, cAdvisor, and node-exporter reachable only locally or over
+  SSH/private networking.
+- Grafana reachable at <https://grafana.nguyenvanloc.com> with the
+  Prometheus data source connected.
+- A path for adding more projects: add a scrape job, add labels, build a
+  folder/dashboard, then alert on it.
 
 If all of that is true, you're ready for the rest of this guide.
 
@@ -347,7 +563,10 @@ If all of that is true, you're ready for the rest of this guide.
 
 ## 5. PromQL primer with this project's metrics
 
-Three function patterns cover ~90% of dashboards:
+Three function patterns cover ~90% of dashboards. The examples below keep the
+current repo job name (`tarot-backend`) so they work with the checked-in config;
+if you renamed the job to `arcana-ai-backend` in Section 4, replace the job
+selector or filter by `project="arcana-ai"` instead.
 
 ```promql
 # Per-second rate of a counter over the last 5 minutes
@@ -573,19 +792,26 @@ Use cAdvisor + node-exporter.
 Variables are how dashboards stop being hard-coded. Add them via
 `Dashboard settings → Variables → New variable`.
 
-Three to add to most dashboards:
+Four to add to most dashboards:
 
-1. **`instance`** — Type: *Query*, Datasource: Prometheus,
-   Query: `label_values(up{job="tarot-backend"}, instance)`.
-   Used to filter when you scale to many backend pods.
+1. **`project`** — Type: *Query*, Datasource: Prometheus,
+   Query: `label_values(up, project)`. Multi-value: ✓, Include "All": ✓.
+   Use this on shared dashboards so one Grafana site can switch between
+   ArcanaAI and future projects.
 
-2. **`endpoint`** — Type: *Query*,
-   Query: `label_values(tarot_requests_total, endpoint)`.
+2. **`instance`** — Type: *Query*, Datasource: Prometheus,
+   Query: `label_values(up{project=~"$project"}, instance)`.
+   Used to filter when you scale to many backend pods or scrape multiple
+   servers.
+
+3. **`endpoint`** — Type: *Query*,
+   Query: `label_values(tarot_requests_total{project=~"$project"}, endpoint)`.
    Multi-value: ✓, Include "All": ✓. Then use
-   `tarot_requests_total{endpoint=~"$endpoint"}` in queries.
+   `tarot_requests_total{project=~"$project",endpoint=~"$endpoint"}` in
+   queries.
 
-3. **`reading_type`** — Type: *Query*,
-   Query: `label_values(tarot_readings_total, reading_type)`.
+4. **`reading_type`** — Type: *Query*,
+   Query: `label_values(tarot_readings_total{project=~"$project"}, reading_type)`.
 
 When using multi-value variables, always use `=~` (regex match) not `=`.
 
@@ -739,7 +965,7 @@ These need a few lines of backend code first. Listed in order of value.
 
 ## Suggested learning order
 
-1. Follow [Section 4](#4-setup-from-scratch) end-to-end. Confirm all
+1. Follow [Section 4](#4-setup-grafana-from-scratch-for-grafananguyenvanloccom) end-to-end. Confirm all
    targets are `UP` in Prometheus and the provisioned dashboards show
    data.
 2. In Grafana `Explore`, run the queries from [section 5](#5-promql-primer-with-this-projects-metrics)
@@ -747,7 +973,7 @@ These need a few lines of backend code first. Listed in order of value.
 3. Build **Dashboard 1 (Golden signals)** from scratch. Don't copy the
    JSON — type each query. This is where 80% of Grafana learning
    happens.
-4. Build **Dashboard 2 (Business KPIs)**. Add the 3 variables from
+4. Build **Dashboard 2 (Business KPIs)**. Add the 4 variables from
    [section 7](#7-variables-template-variables).
 5. Set up one alert end-to-end with a webhook.site contact point.
 6. Compare your work to the bundled JSON dashboards and to


### PR DESCRIPTION
### Motivation
- Convert the repository's ArcanaAI-focused Grafana guide into a personal, central Grafana setup targeted at `grafana.nguyenvanloc.com` so one private Grafana instance can monitor multiple projects including ArcanaAI.
- Provide a secure, repeatable from-scratch workflow for production usage (DNS, TLS reverse proxy, local-only monitoring ports, and persistent data) rather than only a local dev walkthrough.

### Description
- Rewrote `docs/grafana-monitoring-guide.md` to target a personal deployment at `https://grafana.nguyenvanloc.com`, added an architecture overview, and clarified the intended end state for multi-project monitoring.
- Added step-by-step production-oriented setup instructions including DNS verification (`dig`), a suggested production compose override `monitoring-docker-compose.prod.override.yaml`, and Caddy reverse-proxy instructions for TLS (`/etc/caddy/Caddyfile`).
- Updated Prometheus guidance to recommend labeled scrape jobs (`project`, `component`, `env`) with an example `arcana-ai-backend` scrape config and added instructions to validate the Prometheus config with `promtool`.
- Updated Grafana guidance to include a top-level `$project` dashboard variable and adjusted variable queries and PromQL notes to explain using either the checked-in `tarot-backend` job name or a `project="arcana-ai"` filter.

### Testing
- Ran a Python smoke check that asserts the modified doc contains `## 4. Setup Grafana from scratch for grafana.nguyenvanloccom`, the `https://grafana.nguyenvanloc.com` domain, `project="arcana-ai"` guidance, and the `monitoring-docker-compose.prod.override.yaml` reference and the script reported success.
- Verified the updated `docs/grafana-monitoring-guide.md` is syntactically intact by printing and spot-checking key sections such as the production override, DNS/Caddy steps, Prometheus labeling, and variables examples.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22f427de44832896261f0ea19666a2)