### PR TITLE
Refactor monitoring: extract central stack, update ArcanaAI guide

### DIFF
--- a/central-monitoring/.env.example
+++ b/central-monitoring/.env.example
@@ -1,0 +1,10 @@
+# Copy to .env and fill in. NEVER commit the real .env.
+#   cp .env.example .env
+
+# Grafana admin (first-login credentials). Use a long random password.
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=replace-with-a-long-random-password
+
+# Public identity of the Grafana UI (used for cookies, redirects, share links).
+GRAFANA_DOMAIN=grafana.nguyenvanloc.com
+GRAFANA_ROOT_URL=https://grafana.nguyenvanloc.com/

--- a/central-monitoring/.gitignore
+++ b/central-monitoring/.gitignore
@@ -1,0 +1,9 @@
+# Secrets and host-specific overrides
+.env
+*.local.yaml
+*.local.yml
+docker-compose.override.yaml
+docker-compose.override.yml
+
+# Allow the committed examples
+!docker-compose.prod.override.yaml.example

--- a/central-monitoring/README.md
+++ b/central-monitoring/README.md
@@ -1,0 +1,228 @@
+# Central Monitoring
+
+A standalone, self-hosted monitoring stack — **Prometheus + Grafana** — that
+serves **many projects** from one place. You view everything at
+`https://grafana.nguyenvanloc.com`; projects get their metrics in either by
+being **pulled** (scraped) or by **pushing** to
+`https://metrics.nguyenvanloc.com/api/v1/write`.
+
+> **This directory is a self-contained draft of a separate repository.** It
+> currently lives inside `arcana-ai/` so it can be reviewed in one place. To
+> deploy it, move it into its own git repo:
+> ```bash
+> cp -r central-monitoring /path/to/central-monitoring && cd $_
+> git init && git add . && git commit -m "Initial central monitoring stack"
+> ```
+
+---
+
+## How metrics actually flow (read this first)
+
+Three different things — don't conflate them:
+
+| Thing | URL | Who talks to it | Purpose |
+|---|---|---|---|
+| **Grafana** | `grafana.nguyenvanloc.com` | You, in a browser | View dashboards & alerts |
+| **Prometheus ingest** | `metrics.nguyenvanloc.com/api/v1/write` | A project's **agent** | Receive *pushed* metrics |
+| A project's **`/metrics`** | internal, e.g. `tarot-backend:8000/metrics` | Prometheus (*pull*) | Expose metrics |
+
+A project **never sends metrics to `grafana.nguyenvanloc.com`** — that host is
+only the human UI. Metrics land in **Prometheus** (pushed there, or pulled by
+it), and Grafana reads them back out of Prometheus to draw graphs.
+
+```
+                              You (browser)
+                                   │ https://grafana.nguyenvanloc.com
+                                   ▼
+                              ┌─────────┐        ┌───────────────┐
+                              │ Grafana │ ─────▶ │  Prometheus   │
+                              └─────────┘ query  │  TSDB + rules │
+                                                 └───────────────┘
+                                                  ▲             ▲
+                                  pull (localnet) │             │ push (remote_write)
+                                                  │             │ https://metrics.../api/v1/write
+                             ┌────────────────────┘             └──────────────────┐
+                             │                                                      │
+                   co-located project                                    remote project + agent
+              (arcana-ai: tarot-backend:8000/metrics)            (Grafana Alloy scrapes locally,
+               added via prometheus/targets/*.yml)                pushes; see agent/)
+```
+
+**Server vs agents.** Prometheus + Grafana are the central *server* — one
+deployment. `node-exporter` and `cAdvisor` only see the host they run on, so
+they belong to a per-host *agent* (see `agent/`), not the central box. If a
+project is co-located with this stack, one agent on this host covers it.
+
+---
+
+## Layout
+
+```
+central-monitoring/
+├── docker-compose.yaml                     # Prometheus + Grafana (the server)
+├── docker-compose.prod.override.yaml.example  # bind to localhost for prod
+├── .env.example                            # Grafana admin + domain
+├── prometheus/
+│   ├── prometheus.yml                      # self-scrape, file_sd, remote_write receiver
+│   ├── targets/                            # PULL: one file per co-located project
+│   │   └── arcana-ai.yml
+│   └── rules/
+│       └── shared_alerts.yml               # generic liveness alerts
+├── grafana/
+│   ├── provisioning/                       # datasource (uid=prometheus) + dashboard provider
+│   └── dashboards/
+│       └── shared-targets.json             # starter shared dashboard ($project aware)
+├── agent/                                  # PUSH: drop next to a remote project
+│   ├── docker-compose.agent.yaml           # Alloy + node-exporter + cadvisor
+│   ├── config.alloy                        # scrape local /metrics -> remote_write
+│   └── .env.example
+└── reverse-proxy/
+    └── Caddyfile.example                   # grafana vhost + authenticated metrics vhost
+```
+
+---
+
+## Quick start
+
+### 1. Create the shared network
+
+Co-located pull uses container DNS over an **external** Docker network shared
+with the monitored apps:
+
+```bash
+docker network create localnet || true
+```
+
+### 2. Configure secrets
+
+```bash
+cp .env.example .env
+# edit .env: set a long random GRAFANA_ADMIN_PASSWORD and your domain
+chmod 600 .env
+```
+
+### 3. Start the stack
+
+Local testing:
+
+```bash
+docker compose --env-file .env up -d
+```
+
+Production (binds Grafana/Prometheus to localhost; only the reverse proxy is
+public):
+
+```bash
+cp docker-compose.prod.override.yaml.example docker-compose.prod.override.yaml
+docker compose \
+  -f docker-compose.yaml \
+  -f docker-compose.prod.override.yaml \
+  --env-file .env up -d
+```
+
+### 4. Verify
+
+```bash
+docker ps --filter 'name=monitoring-' --format 'table {{.Names}}\t{{.Status}}'
+# Prometheus targets (via SSH tunnel in prod):
+#   open http://localhost:9090/targets  -> co-located targets should be UP
+```
+
+In Grafana (`Connections → Data sources → Prometheus → Save & test`) you want a
+green "Successfully queried the Prometheus API". The **Shared — Targets &
+Liveness** dashboard should already be provisioned.
+
+---
+
+## Put HTTPS in front
+
+Use the two-vhost `reverse-proxy/Caddyfile.example`:
+
+- `grafana.nguyenvanloc.com` → `127.0.0.1:3002` (the UI).
+- `metrics.nguyenvanloc.com` → `127.0.0.1:9090`, but **only** the
+  `/api/v1/write` path, behind basic auth. Everything else returns 404, so
+  nobody can query your Prometheus from the internet.
+
+```bash
+caddy hash-password --plaintext 'a-strong-shared-token'   # paste hash into the Caddyfile
+sudo cp reverse-proxy/Caddyfile.example /etc/caddy/Caddyfile   # then edit hashes/domains
+sudo systemctl reload caddy
+```
+
+DNS: point `A`/`AAAA` records for both `grafana` and `metrics` at the server.
+
+---
+
+## Connect a co-located project (PULL — simplest)
+
+The project runs on the **same Docker host** as this stack and shares
+`localnet`.
+
+1. Make sure the project's app container is on `localnet` and serves `/metrics`.
+2. Drop a target file in `prometheus/targets/<project>.yml` (copy
+   `arcana-ai.yml`):
+   ```yaml
+   - targets: ["my-app:8080"]
+     labels:
+       project: "my-app"
+       component: "backend"
+       env: "production"
+   ```
+3. Done — Prometheus picks it up within `refresh_interval` (30s); no restart.
+
+That's the whole integration. No agent, no public endpoint, no token.
+
+---
+
+## Connect a remote project (PUSH — "just call a URL")
+
+The project runs **somewhere else** and can't be scraped directly. Use the
+agent: copy `agent/` next to the project, set `.env`, and start it. It scrapes
+the project locally and pushes to `metrics.nguyenvanloc.com/api/v1/write`. Full
+steps in `agent/README.md`.
+
+This is the model behind "every project calls into the monitoring container" —
+the call goes to the **metrics** endpoint, authenticated, not to Grafana.
+
+---
+
+## Dashboards
+
+- Shared/infra dashboards live in `grafana/dashboards/` and are provisioned on
+  startup (read-only in the UI — edit the JSON, or "Save as" a copy).
+- **Per-project dashboards stay with the project** (observability-as-code).
+  Bring them here by copying their JSON into `grafana/dashboards/<project>/`
+  (subfolders become Grafana folders) or by syncing in CI.
+- Filter shared dashboards by the provisioned `$project` template variable
+  (`label_values(up, project)`).
+
+---
+
+## Security checklist
+
+- [ ] Only `grafana.*` and `metrics.*` (write path) are reachable publicly.
+- [ ] Prometheus UI (`:9090`) is bound to `127.0.0.1` / behind SSH only.
+- [ ] `metrics.*/api/v1/write` requires auth; everything else there is 404.
+- [ ] `.env` is gitignored and `chmod 600`.
+- [ ] Each pushing project has its own credential (rotate per project).
+- [ ] Remote pull (if you use it instead of push) runs over WireGuard/Tailscale,
+      never a public `/metrics`.
+
+---
+
+## Migrating ArcanaAI onto this stack
+
+ArcanaAI currently ships its own `monitoring-docker-compose.yaml` + `monitoring/`.
+To cut over:
+
+1. Deploy this central stack (above).
+2. Keep ArcanaAI co-located? Use `prometheus/targets/arcana-ai.yml` (already
+   here) and **stop** ArcanaAI's bundled monitoring compose.
+3. ArcanaAI elsewhere? Run `agent/` on its host with `PROJECT_NAME=arcana-ai`.
+4. Move ArcanaAI's dashboards/alerts (`monitoring/grafana/dashboards/*`,
+   `monitoring/prometheus/rules/tarot_alerts.yml`) into this repo (or keep them
+   in the ArcanaAI repo and sync them in).
+5. Once green here, delete the old monitoring stack from the ArcanaAI repo.
+
+See `docs/grafana-monitoring-guide.md` in the ArcanaAI repo for the
+ArcanaAI-specific metrics, PromQL, dashboards, and alerts.

--- a/central-monitoring/agent/.env.example
+++ b/central-monitoring/agent/.env.example
@@ -10,5 +10,6 @@ APP_METRICS_ADDRESS=tarot-backend:8000
 METRICS_REMOTE_WRITE_URL=https://metrics.nguyenvanloc.com/api/v1/write
 
 # Basic-auth credentials enforced by the reverse proxy on the write endpoint.
-METRICS_USERNAME=arcana-ai
-METRICS_PASSWORD=replace-with-the-token-from-the-central-stack
+# Placeholder only — replace in your real .env. This is NOT a credential.
+METRICS_USERNAME=<your-project-name>
+METRICS_PASSWORD=<paste-the-write-token-here>

--- a/central-monitoring/agent/.env.example
+++ b/central-monitoring/agent/.env.example
@@ -1,0 +1,14 @@
+# Copy to .env next to docker-compose.agent.yaml. NEVER commit the real .env.
+
+# Identifies this project in Grafana (becomes the `project` label on every metric).
+PROJECT_NAME=arcana-ai
+
+# Where the app exposes Prometheus metrics, reachable from the agent container.
+APP_METRICS_ADDRESS=tarot-backend:8000
+
+# Central ingest endpoint (the reverse proxy in front of central Prometheus).
+METRICS_REMOTE_WRITE_URL=https://metrics.nguyenvanloc.com/api/v1/write
+
+# Basic-auth credentials enforced by the reverse proxy on the write endpoint.
+METRICS_USERNAME=arcana-ai
+METRICS_PASSWORD=replace-with-the-token-from-the-central-stack

--- a/central-monitoring/agent/README.md
+++ b/central-monitoring/agent/README.md
@@ -1,0 +1,45 @@
+# Project agent (push)
+
+Use this when a project runs on a **different host** than the central
+monitoring stack, so the central Prometheus cannot scrape it directly. The
+agent (Grafana Alloy) scrapes the project locally and **pushes** to
+`https://metrics.<domain>/api/v1/write`.
+
+> If the project runs on the **same** host as the central stack, you don't need
+> this agent at all — add a pull target instead (see the top-level README,
+> "Connect a co-located project").
+
+## Use it
+
+1. Copy this whole `agent/` folder next to the project you want to monitor.
+2. `cp .env.example .env` and fill in:
+   - `PROJECT_NAME` — the label that identifies this project in Grafana.
+   - `APP_METRICS_ADDRESS` — host:port where the app serves `/metrics`.
+   - `METRICS_REMOTE_WRITE_URL` — the central ingest URL.
+   - `METRICS_USERNAME` / `METRICS_PASSWORD` — credentials the central reverse
+     proxy enforces on the write endpoint.
+3. Make sure the project's containers share the external `localnet` network so
+   Alloy can resolve `APP_METRICS_ADDRESS` by container DNS:
+   ```bash
+   docker network create localnet || true
+   ```
+4. Start the agent:
+   ```bash
+   docker compose -f docker-compose.agent.yaml --env-file .env up -d
+   ```
+
+## Verify
+
+```bash
+docker logs monitoring-agent-alloy --tail 50      # look for successful remote_write
+```
+
+In Grafana's Explore, run `up{project="<PROJECT_NAME>"}` or
+`count by (project) (scrape_samples_scraped)` — your project should appear.
+
+## What it ships
+
+- App metrics from `APP_METRICS_ADDRESS/metrics`.
+- Host metrics (node-exporter) and per-container metrics (cAdvisor) for this host.
+
+All carry the `project` label so dashboards can filter by `$project`.

--- a/central-monitoring/agent/config.alloy
+++ b/central-monitoring/agent/config.alloy
@@ -1,0 +1,48 @@
+// Grafana Alloy agent for a REMOTE project (one that this central stack cannot
+// scrape directly). It scrapes the project's own /metrics plus the local
+// node-exporter/cadvisor, then pushes everything to the central Prometheus
+// remote_write endpoint. Values come from .env (see .env.example).
+
+// 1) Scrape this project's application metrics.
+prometheus.scrape "app" {
+  targets = [
+    {
+      "__address__" = sys.env("APP_METRICS_ADDRESS"), // e.g. "tarot-backend:8000"
+      "project"     = sys.env("PROJECT_NAME"),        // e.g. "arcana-ai"
+      "component"   = "backend",
+      "env"         = "production",
+    },
+  ]
+  metrics_path    = "/metrics"
+  scrape_interval = "15s"
+  forward_to      = [prometheus.remote_write.central.receiver]
+}
+
+// 2) Scrape host + container metrics from the agent's local exporters.
+prometheus.scrape "infra" {
+  targets = [
+    {
+      "__address__" = "monitoring-agent-node-exporter:9100",
+      "project"     = sys.env("PROJECT_NAME"),
+      "component"   = "node-exporter",
+    },
+    {
+      "__address__" = "monitoring-agent-cadvisor:8080",
+      "project"     = sys.env("PROJECT_NAME"),
+      "component"   = "cadvisor",
+    },
+  ]
+  scrape_interval = "15s"
+  forward_to      = [prometheus.remote_write.central.receiver]
+}
+
+// 3) Push to the central stack. Authenticated at the reverse proxy.
+prometheus.remote_write "central" {
+  endpoint {
+    url = sys.env("METRICS_REMOTE_WRITE_URL") // https://metrics.<domain>/api/v1/write
+    basic_auth {
+      username = sys.env("METRICS_USERNAME")
+      password = sys.env("METRICS_PASSWORD")
+    }
+  }
+}

--- a/central-monitoring/agent/docker-compose.agent.yaml
+++ b/central-monitoring/agent/docker-compose.agent.yaml
@@ -1,0 +1,58 @@
+name: monitoring-agent
+
+# Runs ON a remote project's host. Scrapes that host's app + infra metrics and
+# PUSHES them to the central stack. Nothing here is exposed to the internet.
+#
+# Requires the project's own containers to share the external `localnet`
+# network so Alloy can reach the app by container DNS (e.g. tarot-backend:8000).
+services:
+  alloy:
+    image: grafana/alloy:latest
+    container_name: monitoring-agent-alloy
+    command:
+      - run
+      - /etc/alloy/config.alloy
+      - --storage.path=/var/lib/alloy/data
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy:ro
+      - alloy-data:/var/lib/alloy/data
+    env_file:
+      - .env
+    restart: always
+    networks:
+      - localnet
+
+  node-exporter:
+    image: prom/node-exporter:latest
+    container_name: monitoring-agent-node-exporter
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($$|/)'
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    restart: always
+    networks:
+      - localnet
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: monitoring-agent-cadvisor
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:rw
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    restart: always
+    networks:
+      - localnet
+
+volumes:
+  alloy-data:
+
+networks:
+  localnet:
+    external: true
+    name: localnet

--- a/central-monitoring/docker-compose.prod.override.yaml.example
+++ b/central-monitoring/docker-compose.prod.override.yaml.example
@@ -1,0 +1,22 @@
+# Production override: bind everything to localhost so ONLY the reverse proxy
+# is reachable from the internet. Copy to docker-compose.prod.override.yaml
+# (kept local, gitignored) and start with:
+#
+#   docker compose \
+#     -f docker-compose.yaml \
+#     -f docker-compose.prod.override.yaml \
+#     --env-file .env up -d
+services:
+  grafana:
+    ports:
+      - "127.0.0.1:3002:3000"
+    environment:
+      - GF_SERVER_DOMAIN=${GRAFANA_DOMAIN}
+      - GF_SERVER_ROOT_URL=${GRAFANA_ROOT_URL}
+      - GF_SECURITY_COOKIE_SECURE=true
+      - GF_SECURITY_COOKIE_SAMESITE=lax
+  prometheus:
+    # Keep Prometheus private. The remote_write receiver is exposed publicly
+    # ONLY through the reverse proxy (with auth) at metrics.<domain>/api/v1/write.
+    ports:
+      - "127.0.0.1:9090:9090"

--- a/central-monitoring/docker-compose.yaml
+++ b/central-monitoring/docker-compose.yaml
@@ -1,0 +1,59 @@
+name: central-monitoring
+
+# Central monitoring "server": Prometheus (store + scrape + rules) and
+# Grafana (view UI). Per-host agents and co-located projects feed into this.
+#
+# Network: this stack joins the EXTERNAL `localnet` network so it can PULL
+# metrics from co-located projects by container DNS (e.g. tarot-backend:8000).
+# Create it once on the host:  docker network create localnet
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: monitoring-prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/targets:/etc/prometheus/targets:ro
+      - ./prometheus/rules:/etc/prometheus/rules:ro
+      - prometheus-data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=30d'
+      - '--web.enable-lifecycle'
+      # Accept pushed metrics from remote project agents (Grafana Alloy ->
+      # remote_write). This is what powers https://metrics.<domain>/api/v1/write.
+      - '--web.enable-remote-write-receiver'
+    restart: always
+    networks:
+      - localnet
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: monitoring-grafana
+    ports:
+      - "3002:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is required}
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_SERVER_DOMAIN=${GRAFANA_DOMAIN:-localhost}
+      - GF_SERVER_ROOT_URL=${GRAFANA_ROOT_URL:-http://localhost:3002/}
+      - GF_INSTALL_PLUGINS=grafana-piechart-panel
+    restart: always
+    networks:
+      - localnet
+
+volumes:
+  prometheus-data:
+  grafana-data:
+
+networks:
+  localnet:
+    external: true
+    name: localnet

--- a/central-monitoring/grafana/dashboards/shared-targets.json
+++ b/central-monitoring/grafana/dashboards/shared-targets.json
@@ -1,0 +1,72 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 0,
+  "title": "Shared — Targets & Liveness",
+  "uid": "shared-targets",
+  "tags": ["shared", "infrastructure"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "project",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "definition": "label_values(up, project)",
+        "query": { "query": "label_values(up, project)", "refId": "StandardVariableQuery" },
+        "includeAll": true,
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "current": { "selected": false, "text": "All", "value": "$__all" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Targets UP",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none" },
+      "targets": [ { "refId": "A", "expr": "count(up{project=~\"$project\"} == 1)", "datasource": { "type": "prometheus", "uid": "prometheus" } } ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Targets DOWN",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none" },
+      "targets": [ { "refId": "A", "expr": "count(up{project=~\"$project\"} == 0) or vector(0)", "datasource": { "type": "prometheus", "uid": "prometheus" } } ]
+    },
+    {
+      "id": 3,
+      "type": "table",
+      "title": "All pulled targets",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 12, "w": 12, "x": 12, "y": 0 },
+      "options": { "showHeader": true },
+      "targets": [ { "refId": "A", "expr": "up{project=~\"$project\"}", "instant": true, "format": "table", "datasource": { "type": "prometheus", "uid": "prometheus" } } ]
+    }
+  ]
+}

--- a/central-monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/central-monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+providers:
+  - name: "default"
+    orgId: 1
+    # Top-level folder shown in Grafana. Per-project dashboards can set their
+    # own folder via folder structure under /var/lib/grafana/dashboards.
+    folder: "Shared Infrastructure"
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: true

--- a/central-monitoring/grafana/provisioning/datasources/datasources.yml
+++ b/central-monitoring/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    # Internal container DNS name of the Prometheus service in this stack.
+    url: http://monitoring-prometheus:9090
+    isDefault: true
+    editable: true
+    # Keep this UID stable: dashboards reference the datasource by UID.
+    uid: prometheus
+    jsonData:
+      timeInterval: "5s"

--- a/central-monitoring/prometheus/prometheus.yml
+++ b/central-monitoring/prometheus/prometheus.yml
@@ -1,0 +1,40 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    monitor: central
+
+rule_files:
+  - "/etc/prometheus/rules/*.yml"
+
+# Wire up an Alertmanager here later if you want routed notifications.
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: []
+
+scrape_configs:
+  # Prometheus self-monitoring
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  # ----------------------------------------------------------------------
+  # PULL: co-located projects on the same Docker host / localnet network.
+  # Add a project by dropping a file in prometheus/targets/<project>.yml.
+  # Prometheus reloads target files automatically (no restart needed).
+  # Each target file sets its own project/component/env labels, and may set
+  # __metrics_path__ / __scheme__ per target if it differs from the default.
+  # ----------------------------------------------------------------------
+  - job_name: "projects"
+    file_sd_configs:
+      - files:
+          - "/etc/prometheus/targets/*.yml"
+        refresh_interval: 30s
+
+  # ----------------------------------------------------------------------
+  # PUSH: remote projects send metrics to /api/v1/write (enabled via the
+  # --web.enable-remote-write-receiver flag in docker-compose.yaml). Pushed
+  # series carry whatever labels the project's Alloy agent attaches
+  # (project, component, env, instance), so they need no scrape_config here.
+  # ----------------------------------------------------------------------

--- a/central-monitoring/prometheus/rules/shared_alerts.yml
+++ b/central-monitoring/prometheus/rules/shared_alerts.yml
@@ -1,0 +1,30 @@
+groups:
+  - name: shared-infrastructure
+    rules:
+      # Fires for any PULLED target that stops responding. Pushed (remote_write)
+      # projects don't produce `up`; give them a heartbeat-style alert instead,
+      # e.g. absent(up{project="..."}) or alert on stale pushed series.
+      - alert: TargetDown
+        expr: up == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Target down: {{ $labels.job }} / {{ $labels.instance }}"
+          description: >
+            Prometheus has failed to scrape {{ $labels.instance }}
+            (project={{ $labels.project }}, component={{ $labels.component }})
+            for more than 2 minutes.
+
+      - alert: PushedProjectStale
+        # No fresh samples pushed for a project in 5 minutes. Adjust the
+        # selector to a metric your agents always send.
+        expr: |
+          count by (project) (
+            count_over_time(scrape_samples_scraped[5m])
+          ) == 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "No metrics from project {{ $labels.project }} in 5m"

--- a/central-monitoring/prometheus/targets/arcana-ai.yml
+++ b/central-monitoring/prometheus/targets/arcana-ai.yml
@@ -1,0 +1,19 @@
+# PULL target for ArcanaAI when it runs on the same Docker host as this stack.
+# Prometheus reaches tarot-backend:8000/metrics over the shared localnet network.
+# file_sd format: a list of target groups, each with targets + labels.
+- targets:
+    - "tarot-backend:8000"
+  labels:
+    project: "arcana-ai"
+    component: "backend"
+    env: "production"
+
+# Frontend metrics route (only resolves once Next.js exposes /api/metrics).
+# Uncomment when ready — note the per-target metrics path override.
+# - targets:
+#     - "tarot-frontend:3000"
+#   labels:
+#     project: "arcana-ai"
+#     component: "frontend"
+#     env: "production"
+#     __metrics_path__: "/api/metrics"

--- a/central-monitoring/reverse-proxy/Caddyfile.example
+++ b/central-monitoring/reverse-proxy/Caddyfile.example
@@ -1,0 +1,26 @@
+# Two public hostnames, two very different purposes. Caddy gets Let's Encrypt
+# certs automatically. Copy to /etc/caddy/Caddyfile and reload.
+
+# 1) Grafana — the human-facing dashboard UI. This is the ONLY thing people open.
+grafana.nguyenvanloc.com {
+  reverse_proxy 127.0.0.1:3002
+}
+
+# 2) Metrics ingest — project agents PUSH here via remote_write. Nothing human
+#    opens this. Lock the write path behind basic auth.
+#    Generate a hash:  caddy hash-password --plaintext 'a-strong-shared-token'
+#    (Caddy < 2.8 uses the `basicauth` directive instead of `basic_auth`.)
+metrics.nguyenvanloc.com {
+  @write path /api/v1/write
+  handle @write {
+    basic_auth {
+      arcana-ai $2a$14$REPLACE_WITH_BCRYPT_HASH
+    }
+    reverse_proxy 127.0.0.1:9090
+  }
+
+  # Refuse everything else — no querying Prometheus from the public internet.
+  handle {
+    respond "Not found" 404
+  }
+}

--- a/docs/grafana-monitoring-guide.md
+++ b/docs/grafana-monitoring-guide.md
@@ -1,23 +1,27 @@
-# Personal Grafana Monitoring Guide for grafana.nguyenvanloc.com
+# ArcanaAI Monitoring Guide (central Grafana at grafana.nguyenvanloc.com)
 
-A hands-on guide for building a **personal, central Grafana site** at
-`grafana.nguyenvanloc.com` and using it to monitor multiple projects,
-including ArcanaAI.
+A hands-on guide for monitoring ArcanaAI through a **central, standalone
+monitoring stack** — one Prometheus + Grafana that also serves your other
+projects.
 
 The intended end state is:
 
-- One private Grafana UI at `https://grafana.nguyenvanloc.com`.
-- One Prometheus instance that scrapes ArcanaAI now and can scrape more
-  projects later.
-- Project labels on every scrape target so dashboards can filter by
+- One private Grafana UI at `https://grafana.nguyenvanloc.com` for **all**
+  projects.
+- One Prometheus instance that ingests ArcanaAI now and more projects later.
+- A `project` label on every series so dashboards filter by
   `project="arcana-ai"`, `project="another-project"`, etc.
-- Grafana and Prometheus data persisted on disk so a container restart
-  does not wipe dashboards or metrics.
+- Grafana and Prometheus data persisted on disk so a restart does not wipe
+  dashboards or metrics.
 
-> Heads up: this repo already ships the **ArcanaAI monitoring config**
-> (`monitoring-docker-compose.yaml` + `monitoring/`). This guide adapts
-> that config into a personal monitoring stack instead of treating
-> Grafana as a one-off local dashboard for only this repository.
+> **Architecture note (changed).** The monitoring stack no longer lives in
+> this repository. It is its own repo — see the `central-monitoring/` draft at
+> the root of this repo, meant to be extracted into a standalone
+> `central-monitoring` repository. This guide covers (a) the ArcanaAI side —
+> exposing metrics and connecting to that central stack — and (b) the
+> ArcanaAI-specific PromQL, dashboards, and alerts you build once connected.
+> Operating the stack itself (compose, reverse proxy, network, secrets) lives
+> in the central repo's `README.md`.
 
 ---
 
@@ -26,7 +30,7 @@ The intended end state is:
 1. [What you're monitoring](#1-what-youre-monitoring)
 2. [Personal monitoring architecture](#2-personal-monitoring-architecture)
 3. [Grafana concepts in 5 minutes](#3-grafana-concepts-in-5-minutes)
-4. [Setup Grafana from scratch for grafana.nguyenvanloc.com](#4-setup-grafana-from-scratch-for-grafananguyenvanloccom)
+4. [Connect ArcanaAI to the central monitoring stack](#4-connect-arcanaai-to-the-central-monitoring-stack)
 5. [PromQL primer with this project's metrics](#5-promql-primer-with-this-projects-metrics)
 6. [Dashboards to build](#6-dashboards-to-build)
    - [6.1 Golden signals (API health)](#61-dashboard-1--golden-signals-api-health)
@@ -43,8 +47,9 @@ The intended end state is:
 
 ## 1. What you're monitoring
 
-This Grafana site is **not just for ArcanaAI**. Treat it as your personal
-observability home:
+The central Grafana site is **shared across projects**, not just ArcanaAI —
+treat it as your personal observability home. This guide focuses on the
+ArcanaAI slice of it:
 
 | Scope | Examples | How it appears in Grafana |
 |---|---|---|
@@ -72,60 +77,64 @@ The ArcanaAI backend already exposes Prometheus metrics at
 
 ---
 
-## 2. Personal monitoring architecture
+## 2. Architecture: ArcanaAI as a client of the central stack
 
-Use a central monitoring stack and add projects to it over time:
+The monitoring stack (Prometheus + Grafana) is **its own deployment**, in its
+own repository (`central-monitoring`). ArcanaAI is just one of several projects
+that feed metrics into it.
 
 ```text
-Internet
-  │
-  │ https://grafana.nguyenvanloc.com
-  ▼
-Caddy / Nginx reverse proxy with TLS
-  │
-  ▼
-Grafana container (private UI, port 3002 on localhost only)
-  │
-  ▼
-Prometheus container (not public, port 9090 on localhost only)
-  │
-  ├── ArcanaAI backend: tarot-backend:8000/metrics
-  ├── ArcanaAI frontend: tarot-frontend:3000/api/metrics (optional)
-  ├── cAdvisor: container metrics
-  ├── node-exporter: host metrics
-  └── Future projects: add more scrape jobs
+                              You (browser)
+                                   │ https://grafana.nguyenvanloc.com
+                                   ▼
+                              ┌─────────┐        ┌───────────────┐
+                              │ Grafana │ ─────▶ │  Prometheus   │
+                              └─────────┘ query  │  TSDB + rules │
+                                                 └───────────────┘
+                                                  ▲             ▲
+                                  pull (localnet) │             │ push (remote_write)
+                                                  │             │ https://metrics.../api/v1/write
+                             ┌────────────────────┘             └──────────────────┐
+                             │                                                      │
+                   ArcanaAI co-located                                  ArcanaAI on another host
+              (tarot-backend:8000/metrics, scraped)             (Alloy agent scrapes locally, pushes)
 ```
 
-### What this repository already provides
+### Three URLs, three jobs — don't conflate them
 
-Defined in `monitoring-docker-compose.yaml`:
+| Thing | URL | Who talks to it |
+|---|---|---|
+| **Grafana** (view UI) | `grafana.nguyenvanloc.com` | You, in a browser |
+| **Prometheus ingest** (push) | `metrics.nguyenvanloc.com/api/v1/write` | ArcanaAI's **agent** |
+| ArcanaAI **`/metrics`** | `tarot-backend:8000/metrics` (internal) | Prometheus, when it pulls |
 
-| Service | Current container | Current port mapping | Purpose |
-|---|---|---|---|
-| Prometheus | `tarot-prometheus` | `9090:9090` | Scrapes metrics, stores 30d, evaluates alert rules |
-| Grafana | `tarot-grafana` | `3002:3000` | Dashboards & alerts UI |
-| cAdvisor | `tarot-cadvisor` | `8090:8080` | Per-container CPU/mem/net metrics |
-| node-exporter | `tarot-node-exporter` | `9200:9100` | Host metrics (disk, load, network) |
+ArcanaAI **never** sends metrics to `grafana.nguyenvanloc.com` — that host is
+only the viewer. Metrics land in **Prometheus** (pushed there, or pulled by it),
+and Grafana reads them back out to draw graphs.
 
-Prometheus scrape targets (`monitoring/prometheus/prometheus.yml`):
+### Two ways ArcanaAI connects
 
-- `tarot-backend:8000/metrics` (every 10s)
-- `tarot-frontend:3000/api/metrics` (every 30s) — only if you add a
-  metrics route in Next.js
-- `tarot-node-exporter:9100`
-- `tarot-cadvisor:8080`
+| Mode | When | What ArcanaAI does |
+|---|---|---|
+| **Pull** | ArcanaAI is on the **same Docker host** as the stack | Expose `/metrics`, share `localnet`. The central repo adds `prometheus/targets/arcana-ai.yml`. No agent, no public endpoint. |
+| **Push** | ArcanaAI runs on a **different host** | Run the central repo's `agent/` next to ArcanaAI. It scrapes `tarot-backend:8000/metrics` locally and pushes to the ingest URL with a token. |
 
-Grafana is auto-provisioned via
-`monitoring/grafana/provisioning/`:
+The ArcanaAI backend already exposes Prometheus metrics at `GET /metrics`
+(see `backend/utils/metrics.py` and `backend/app.py:79`), so the ArcanaAI side
+of either mode is wiring, not code.
 
-- `datasources/datasources.yml` adds the Prometheus data source
-  (UID `prometheus`) — **use this UID in every panel query**.
-- `dashboards/dashboards.yml` loads any JSON dropped into
-  `monitoring/grafana/dashboards/`.
+### Select on labels, not on `job`
 
-There are 3 starter dashboard JSONs already, plus prebuilt alert rules
-in `monitoring/prometheus/rules/tarot_alerts.yml`. Treat those as
-ArcanaAI references, not as the entire personal Grafana site.
+Under the central stack the pull job is shared (`projects`, via file-based
+discovery) and pushed series come from the agent — so **don't select by
+`job="tarot-backend"`**. Every ArcanaAI series instead carries:
+
+- `project="arcana-ai"`
+- `component="backend"` (or `frontend`, `node-exporter`, `cadvisor`, …)
+- `env="production"`
+
+Use those in queries and as Grafana `$project` / `$component` variables. That is
+also what lets one dashboard switch between ArcanaAI and future projects.
 
 ### Recommended conventions for multiple projects
 
@@ -133,30 +142,11 @@ Use these conventions from day one so adding projects later is easy:
 
 | Convention | Recommendation |
 |---|---|
-| Prometheus job names | `<project>-<component>`, e.g. `arcana-ai-backend`, `blog-api`, `trading-bot-worker` |
-| Static labels | Add `project`, `component`, and `env` labels to every scrape job |
-| Grafana folders | One folder per project (`ArcanaAI`, `Personal Blog`, etc.) plus one `Shared Infrastructure` folder |
-| Dashboard variables | Add a top-level `$project` variable to shared dashboards |
-| Public exposure | Publish only Grafana through HTTPS; keep Prometheus, cAdvisor, and node-exporter private |
-| Secrets | Keep admin passwords, SMTP credentials, OAuth secrets, and webhook URLs in `.env`, never in git |
-
-For ArcanaAI, prefer this scrape naming when you are ready to update
-`monitoring/prometheus/prometheus.yml`:
-
-```yaml
-- job_name: "arcana-ai-backend"
-  static_configs:
-    - targets: ["tarot-backend:8000"]
-      labels:
-        project: "arcana-ai"
-        component: "backend"
-        env: "production"
-  metrics_path: "/metrics"
-  scrape_interval: 10s
-```
-
-That single `project` label lets one Grafana dashboard switch between
-projects later.
+| Target labels | Always set `project`, `component`, `env` — both pull target files and the agent config do this. |
+| Grafana folders | One folder per project (`ArcanaAI`, `Personal Blog`, …) plus one `Shared Infrastructure` folder. |
+| Dashboard variables | A top-level `$project` variable on shared dashboards. |
+| Public exposure | Only Grafana (view) and the authenticated `/api/v1/write` (ingest) are public; keep the Prometheus UI, cAdvisor, and node-exporter private. |
+| Secrets | Keep admin passwords, push tokens, SMTP credentials, and webhook URLs in `.env`, never in git. |
 
 ---
 
@@ -186,81 +176,14 @@ Rule of thumb for panel choice:
 
 ---
 
-## 4. Setup Grafana from scratch for grafana.nguyenvanloc.com
+## 4. Connect ArcanaAI to the central monitoring stack
 
-You're starting from zero. These steps assume a fresh VPS or server that
-will host your personal monitoring stack and expose only Grafana at
-`https://grafana.nguyenvanloc.com`.
+> Operating the stack itself — DNS, the shared `localnet` network, `.env`,
+> Grafana admin, the reverse proxy with the `grafana` and `metrics` vhosts, and
+> starting the containers — lives in the **central repo's `README.md`**. Stand
+> that up first. This section is only the ArcanaAI side.
 
-> If you are only testing locally, replace `grafana.nguyenvanloc.com`
-> with `localhost:3002` and skip the DNS / HTTPS reverse-proxy steps.
-
-### 4.1 Prerequisites
-
-- A server/VPS with Docker Engine ≥ 20.10 and Docker Compose v2
-  (`docker compose ...`, not `docker-compose ...`).
-- SSH access to the server.
-- DNS access for `nguyenvanloc.com`.
-- Ports `80` and `443` open to the internet for HTTPS.
-- Monitoring ports kept private or firewall-restricted:
-  - `3002` Grafana container port on the host.
-  - `9090` Prometheus.
-  - `8090` cAdvisor.
-  - `9200` node-exporter.
-- This repository checked out on the server.
-- The ArcanaAI backend `.env` file at `backend/.env` exists and is
-  populated if this same server is also running ArcanaAI.
-
-Check listening ports before starting:
-
-```bash
-ss -tlnp | grep -E ':(80|443|3002|9090|8090|9200) '
-```
-
-### 4.2 Point DNS at the monitoring server
-
-Create a DNS record:
-
-| Type | Name | Value |
-|---|---|---|
-| `A` | `grafana` | Your server IPv4 address |
-| `AAAA` | `grafana` | Your server IPv6 address, if you use IPv6 |
-
-Verify DNS from your machine:
-
-```bash
-dig +short grafana.nguyenvanloc.com
-```
-
-Do not continue with HTTPS setup until this returns your server IP.
-
-### 4.3 Create the shared Docker network
-
-All compose files in this repo attach to an **external** network called
-`localnet`. Prometheus uses container DNS over that network to reach
-ArcanaAI (`tarot-backend:8000`), so create it before starting either the
-app or monitoring stack:
-
-```bash
-docker network create localnet || true
-```
-
-Verify:
-
-```bash
-docker network ls | grep localnet
-```
-
-### 4.4 Start ArcanaAI if this server will monitor the local app
-
-If ArcanaAI runs on the same Docker host as Prometheus, start it first:
-
-```bash
-# From the repo root
-docker compose -f docker-compose.yaml up -d
-```
-
-Verify the backend exposes metrics:
+### 4.1 Confirm ArcanaAI exposes metrics
 
 ```bash
 docker exec tarot-backend curl -s http://localhost:8000/metrics | grep -E '^tarot_' | head
@@ -269,247 +192,66 @@ docker exec tarot-backend curl -s http://localhost:8000/metrics | grep -E '^taro
 You should see lines like `tarot_active_users 0.0`. If you see nothing:
 
 - `docker logs tarot-backend --tail 100` — look for import errors.
-- Confirm `setup_metrics(app)` is called in the backend app startup.
+- Confirm `setup_metrics(app)` runs at backend startup.
 
-If ArcanaAI runs on another host, skip this step and add a remote scrape
-job in [4.8](#48-add-arcanaai-and-future-projects-as-prometheus-targets).
+### 4.2 Pick pull or push
 
-### 4.5 Create the monitoring environment file
+**Pull — ArcanaAI shares the stack's Docker host (simplest).**
 
-Grafana refuses to start without `GRAFANA_ADMIN_PASSWORD`. Put secrets
-in a local `.env` file and never commit it:
+1. Make sure `tarot-backend` is on the external `localnet` network (it already
+   is in `docker-compose.yaml`) and the central stack joins `localnet` too.
+2. In the central repo, add `prometheus/targets/arcana-ai.yml`:
+   ```yaml
+   - targets: ["tarot-backend:8000"]
+     labels:
+       project: "arcana-ai"
+       component: "backend"
+       env: "production"
+   ```
+   (The `central-monitoring/` draft already ships this file.) Prometheus reloads
+   target files automatically — no restart needed.
 
-```bash
-# Repo root
-cat > .env <<'EOF'
-GRAFANA_ADMIN_USER=admin
-GRAFANA_ADMIN_PASSWORD=replace-with-a-long-random-password
-GRAFANA_DOMAIN=grafana.nguyenvanloc.com
-GRAFANA_ROOT_URL=https://grafana.nguyenvanloc.com/
-EOF
-chmod 600 .env
-```
+**Push — ArcanaAI runs on a different host.**
 
-Verify the file is ignored by git:
+1. Copy the central repo's `agent/` folder onto ArcanaAI's host.
+2. `cp agent/.env.example agent/.env` and set `PROJECT_NAME=arcana-ai`,
+   `APP_METRICS_ADDRESS=tarot-backend:8000`, the `METRICS_REMOTE_WRITE_URL`, and
+   the basic-auth token from the central stack.
+3. Start it:
+   ```bash
+   docker compose -f agent/docker-compose.agent.yaml --env-file agent/.env up -d
+   ```
 
-```bash
-git check-ignore -v .env
-```
+Either way, ArcanaAI's series arrive labelled `project="arcana-ai"`.
 
-If that command prints nothing, add `.env` to `.gitignore` before you
-continue.
+### 4.3 Verify the connection
 
-### 4.6 Add a production override for the personal domain
-
-The checked-in compose file is local-friendly. For your personal site,
-add a local override file that binds Grafana and Prometheus to localhost
-only and tells Grafana its real public URL:
-
-```bash
-cat > monitoring-docker-compose.prod.override.yaml <<'EOF'
-services:
-  grafana:
-    ports:
-      - "127.0.0.1:3002:3000"
-    environment:
-      - GF_SERVER_DOMAIN=${GRAFANA_DOMAIN}
-      - GF_SERVER_ROOT_URL=${GRAFANA_ROOT_URL}
-      - GF_SERVER_SERVE_FROM_SUB_PATH=false
-      - GF_SECURITY_COOKIE_SECURE=true
-      - GF_SECURITY_COOKIE_SAMESITE=lax
-  prometheus:
-    ports:
-      - "127.0.0.1:9090:9090"
-  cadvisor:
-    ports:
-      - "127.0.0.1:8090:8080"
-  node-exporter:
-    ports:
-      - "127.0.0.1:9200:9100"
-EOF
-```
-
-This file can stay uncommitted if it is specific to your server. The key
-security point is that **only the reverse proxy should be reachable from
-the public internet**.
-
-### 4.7 Label ArcanaAI targets for multi-project dashboards
-
-Update `monitoring/prometheus/prometheus.yml` so ArcanaAI targets carry
-stable labels. Example for the backend:
-
-```yaml
-  - job_name: "arcana-ai-backend"
-    static_configs:
-      - targets: ["tarot-backend:8000"]
-        labels:
-          project: "arcana-ai"
-          component: "backend"
-          env: "production"
-    metrics_path: "/metrics"
-    scrape_interval: 10s
-```
-
-You can do the same for the frontend, node-exporter, and cAdvisor jobs.
-For cAdvisor, the `project` label means "this exporter belongs to the
-host that runs ArcanaAI"; individual container names still come from the
-`name` label in cAdvisor metrics.
-
-After editing, validate the Prometheus config before restarting:
-
-```bash
-docker run --rm -v "$PWD/monitoring/prometheus:/etc/prometheus" prom/prometheus:latest promtool check config /etc/prometheus/prometheus.yml
-```
-
-### 4.8 Add ArcanaAI and future projects as Prometheus targets
-
-For each new project, add another scrape job with a unique `project`
-label. Examples:
-
-```yaml
-  - job_name: "personal-blog-api"
-    static_configs:
-      - targets: ["blog-api:8080"]
-        labels:
-          project: "personal-blog"
-          component: "api"
-          env: "production"
-    metrics_path: "/metrics"
-
-  - job_name: "remote-worker"
-    static_configs:
-      - targets: ["10.0.0.25:9105"]
-        labels:
-          project: "automation"
-          component: "worker"
-          env: "production"
-```
-
-For remote servers, prefer a private network such as WireGuard/Tailscale
-between Prometheus and the target. Do **not** expose `/metrics` publicly
-without authentication or network restrictions.
-
-### 4.9 Start the monitoring stack
-
-Start Grafana, Prometheus, cAdvisor, and node-exporter with your
-production override:
-
-```bash
-docker compose \
-  -f monitoring-docker-compose.yaml \
-  -f monitoring-docker-compose.prod.override.yaml \
-  --env-file .env \
-  up -d
-```
-
-Confirm all four monitoring containers came up:
-
-```bash
-docker ps --filter 'name=tarot-' --format 'table {{.Names}}\t{{.Status}}'
-```
-
-Expect to see `tarot-prometheus`, `tarot-grafana`, `tarot-cadvisor`, and
-`tarot-node-exporter` all `Up`.
-
-If Grafana keeps restarting:
-
-```bash
-docker logs tarot-grafana --tail 50
-```
-
-The most common error is a missing `GRAFANA_ADMIN_PASSWORD`; re-check
-[4.5](#45-create-the-monitoring-environment-file).
-
-### 4.10 Put HTTPS in front of Grafana
-
-Use a reverse proxy to terminate TLS and forward only Grafana traffic to
-`127.0.0.1:3002`. Caddy is the simplest option because it manages
-Let's Encrypt certificates automatically.
-
-Install Caddy, then create `/etc/caddy/Caddyfile`:
-
-```caddyfile
-grafana.nguyenvanloc.com {
-  reverse_proxy 127.0.0.1:3002
-}
-```
-
-Reload Caddy:
-
-```bash
-sudo caddy fmt --overwrite /etc/caddy/Caddyfile
-sudo systemctl reload caddy
-```
-
-Verify from your laptop/browser:
-
-```bash
-curl -I https://grafana.nguyenvanloc.com/login
-```
-
-You should get an HTTP response from Grafana, not a connection timeout.
-
-### 4.11 Verify Prometheus scraping
-
-Open Prometheus through an SSH tunnel instead of exposing it publicly:
+Reach Prometheus through an SSH tunnel (it stays private):
 
 ```bash
 ssh -L 9090:127.0.0.1:9090 your-user@your-server
+# open http://localhost:9090/targets  — for pull, the arcana-ai target is UP
 ```
 
-Then open <http://localhost:9090/targets>. You want every required job
-`UP`:
+Or in Grafana → Explore:
 
-| Job | Endpoint | Expected |
-|---|---|---|
-| `prometheus` | `localhost:9090/metrics` | UP |
-| `arcana-ai-backend` or `tarot-backend` | `tarot-backend:8000/metrics` | UP |
-| `arcana-ai-frontend` or `tarot-frontend` | `tarot-frontend:3000/api/metrics` | DOWN until you add a Next.js metrics route. OK to ignore for now. |
-| `node-exporter` | `tarot-node-exporter:9100/metrics` | UP |
-| `cadvisor` | `tarot-cadvisor:8080/metrics` | UP |
+```promql
+up{project="arcana-ai"}                     # pull: 1 = healthy
+count by (project) (scrape_samples_scraped) # push: arcana-ai should appear
+```
 
-Troubleshooting a DOWN backend target:
+Troubleshooting a DOWN pull target:
 
-1. *Connection refused* — backend container is not on `localnet`. Check
-   with `docker inspect tarot-backend -f '{{json .NetworkSettings.Networks}}'`.
-2. *No such host* — DNS lookup failed; Prometheus is on a different
-   Docker network than the backend.
-3. *Connection timeout* — backend is up but slow to respond. Curl from
-   inside the Prometheus container:
-   ```bash
-   docker exec tarot-prometheus wget -qO- http://tarot-backend:8000/metrics | head
-   ```
+1. *Connection refused / no such host* — `tarot-backend` is not on `localnet`
+   with Prometheus. Check
+   `docker inspect tarot-backend -f '{{json .NetworkSettings.Networks}}'`.
+2. *Timeout* — backend is slow; curl from inside Prometheus:
+   `docker exec monitoring-prometheus wget -qO- http://tarot-backend:8000/metrics | head`.
 
-Run a smoke-test query in Prometheus: open <http://localhost:9090/graph>,
-run `up`, and confirm you get one row per target.
+### 4.4 Generate a little traffic
 
-### 4.12 First Grafana login
-
-Open <https://grafana.nguyenvanloc.com>:
-
-- User: `admin`
-- Password: whatever you set in `.env`
-
-Then:
-
-1. **Change the admin password** at first prompt.
-2. Go to `Connections → Data sources`. There should already be a
-   Prometheus data source named "Prometheus" provisioned from
-   `monitoring/grafana/provisioning/datasources/datasources.yml`.
-   Click it, scroll to bottom, click **Save & test**. You want a green
-   "Successfully queried the Prometheus API.".
-3. Go to `Dashboards`. You'll see the provisioned ArcanaAI starter
-   dashboards. Open `tarot-overview` — if panels render data, your
-   pipeline works: ArcanaAI → Prometheus → Grafana → HTTPS domain.
-4. Create folders:
-   - `ArcanaAI`
-   - `Shared Infrastructure`
-   - One folder for each future project.
-
-### 4.13 Generate traffic so dashboards have data
-
-Brand-new Prometheus = empty time series database. Counters need a few
-data points before `rate()` returns anything. Generate a little traffic:
+A brand-new Prometheus has an empty TSDB; counters need a few samples before
+`rate()` returns anything:
 
 ```bash
 for i in $(seq 1 200); do
@@ -518,55 +260,21 @@ for i in $(seq 1 200); do
 done
 ```
 
-Wait ~30s, then refresh Grafana. Panels driven by
-`rate(http_requests_total[...])` should now have data.
-
-### 4.14 Stopping / cleaning up
-
-```bash
-# Stop monitoring only, keep data
-docker compose \
-  -f monitoring-docker-compose.yaml \
-  -f monitoring-docker-compose.prod.override.yaml \
-  down
-
-# Stop AND wipe Prometheus + Grafana data (starting over)
-docker compose \
-  -f monitoring-docker-compose.yaml \
-  -f monitoring-docker-compose.prod.override.yaml \
-  down -v
-```
-
-The `-v` flag deletes the named volumes `prometheus-data` and
-`grafana-data`. Do not run that in production unless you mean it.
-
-### 4.15 Setup recap
-
-You should now have:
-
-- DNS for `grafana.nguyenvanloc.com` pointing at your monitoring server.
-- HTTPS reverse proxy forwarding `grafana.nguyenvanloc.com` to Grafana.
-- `localnet` Docker network created.
-- Monitoring stack up: `tarot-prometheus`, `tarot-grafana`,
-  `tarot-cadvisor`, `tarot-node-exporter`.
-- ArcanaAI scraped by Prometheus with a `project="arcana-ai"` label.
-- Prometheus, cAdvisor, and node-exporter reachable only locally or over
-  SSH/private networking.
-- Grafana reachable at <https://grafana.nguyenvanloc.com> with the
-  Prometheus data source connected.
-- A path for adding more projects: add a scrape job, add labels, build a
-  folder/dashboard, then alert on it.
-
-If all of that is true, you're ready for the rest of this guide.
+Wait ~30s, refresh Grafana, and the ArcanaAI dashboards (Section 6) should have
+data. From here on, the rest of this guide — PromQL, dashboards, alerts — is the
+same regardless of pull vs push, because it all keys off the `project` and
+`component` labels.
 
 ---
 
 ## 5. PromQL primer with this project's metrics
 
-Three function patterns cover ~90% of dashboards. The examples below keep the
-current repo job name (`tarot-backend`) so they work with the checked-in config;
-if you renamed the job to `arcana-ai-backend` in Section 4, replace the job
-selector or filter by `project="arcana-ai"` instead.
+Three function patterns cover ~90% of dashboards. The example queries below are
+written with `job="tarot-backend"`, but under the **central stack** ArcanaAI is
+scraped by the shared `projects` job (or pushed via the agent), so its series
+carry `project="arcana-ai"` and `component="backend"` instead. **Swap
+`job="tarot-backend"` → `project="arcana-ai"`** in every query below (add
+`component="backend"` to disambiguate if needed).
 
 ```promql
 # Per-second rate of a counter over the last 5 minutes
@@ -824,9 +532,9 @@ built-in — don't redefine them.
 
 There are two ways to do alerts and they coexist:
 
-- **Prometheus alert rules** — defined as YAML in
-  `monitoring/prometheus/rules/`. Already populated
-  (`tarot_alerts.yml`). Use these for stable, codified production
+- **Prometheus alert rules** — defined as YAML in the central repo's
+  `prometheus/rules/`. ArcanaAI's rules (`tarot_alerts.yml`) move there
+  alongside the shared ones. Use these for stable, codified production
   alerts.
 - **Grafana-managed alerts** — defined in the Grafana UI under
   `Alerting → Alert rules`. Use these while learning and for alerts
@@ -874,7 +582,7 @@ you'll add nested policies that route on labels like
 | Memory pressure | `container_memory_usage_bytes{name="tarot-backend"} / container_spec_memory_limit_bytes{name="tarot-backend"} > 0.85` | 5m | warning |
 | Low disk | `node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"} < 0.1` | 5m | critical |
 
-These mirror `monitoring/prometheus/rules/tarot_alerts.yml` — compare
+These mirror the central repo's `prometheus/rules/tarot_alerts.yml` — compare
 your rules to that YAML once you're done to see how they translate.
 
 ---
@@ -948,10 +656,10 @@ These need a few lines of backend code first. Listed in order of value.
 - **`clamp_min(x, 1e-9)` in denominators** — protects against
   divide-by-zero when there's no traffic.
 - **Save dashboards as JSON to git.** Once you're happy with a
-  dashboard, `Dashboard settings → JSON Model → Copy`, paste into
-  `monitoring/grafana/dashboards/<name>.json`, commit. Provisioning
-  will load it on the next Grafana restart. This is the workflow that
-  makes dashboards reproducible.
+  dashboard, `Dashboard settings → JSON Model → Copy`, paste into the
+  central repo's `grafana/dashboards/arcana-ai/<name>.json`, commit.
+  Provisioning will load it on the next Grafana restart. This is the
+  workflow that makes dashboards reproducible.
 - **One dashboard per audience, not per metric.** Resist the urge to
   build "the dashboard with everything". You'll never open it.
 - **Time range matters.** A `rate(...[5m])` panel viewed over a 24h
@@ -965,9 +673,10 @@ These need a few lines of backend code first. Listed in order of value.
 
 ## Suggested learning order
 
-1. Follow [Section 4](#4-setup-grafana-from-scratch-for-grafananguyenvanloccom) end-to-end. Confirm all
-   targets are `UP` in Prometheus and the provisioned dashboards show
-   data.
+1. Stand up the central stack (its repo's `README.md`), then follow
+   [Section 4](#4-connect-arcanaai-to-the-central-monitoring-stack) to connect
+   ArcanaAI. Confirm its target is `UP` in Prometheus and the provisioned
+   dashboards show data.
 2. In Grafana `Explore`, run the queries from [section 5](#5-promql-primer-with-this-projects-metrics)
    one by one. Don't continue until each returns data.
 3. Build **Dashboard 1 (Golden signals)** from scratch. Don't copy the


### PR DESCRIPTION
## Summary

This PR decouples the monitoring infrastructure from the ArcanaAI repository by extracting it into a standalone `central-monitoring/` stack that can serve multiple projects. The guide is updated to reflect this new architecture where ArcanaAI is a *client* of a shared monitoring system rather than the owner of it.

## Key Changes

- **New `central-monitoring/` directory**: A self-contained, production-ready monitoring stack (Prometheus + Grafana) with:
  - Docker Compose setup for the central server (Prometheus + Grafana)
  - Agent setup for remote projects (Grafana Alloy + node-exporter + cAdvisor)
  - Prometheus configuration with file-based service discovery for co-located projects and remote_write receiver for pushed metrics
  - Grafana provisioning (datasources, dashboards, folders)
  - Reverse proxy examples (Caddyfile) for HTTPS + authentication
  - Comprehensive README documenting deployment, security, and multi-project integration

- **Updated `docs/grafana-monitoring-guide.md`**:
  - Renamed from "Personal Grafana Monitoring Guide" to "ArcanaAI Monitoring Guide"
  - Refocused scope: guide now covers only the ArcanaAI side (exposing metrics, connecting to the central stack, building ArcanaAI-specific dashboards/alerts)
  - Removed all operational steps for standing up the stack (DNS, reverse proxy, container startup, etc.) — those now live in `central-monitoring/README.md`
  - Clarified the three-URL architecture: Grafana (view), Prometheus ingest (push), and app `/metrics` (pull)
  - Introduced two connection modes: **pull** (co-located, simplest) and **push** (remote, via agent)
  - Emphasized label-based filtering (`project`, `component`, `env`) over job names for multi-project dashboards
  - Simplified section 4 from a full setup guide to a quick connection checklist

- **Architecture note**: The monitoring stack is now positioned as its own repository (currently drafted in `central-monitoring/` for review) that ArcanaAI and other projects feed into, rather than a bundled component of ArcanaAI.

## Notable Implementation Details

- **Pull vs. Push**: Co-located projects (same Docker host) use file-based service discovery in `prometheus/targets/*.yml` with no agent overhead. Remote projects run the agent (Alloy) to scrape locally and push to `https://metrics.<domain>/api/v1/write` with basic auth.
- **Shared labels**: All series carry `project`, `component`, and `env` labels so dashboards can filter by `$project` variable and work across multiple projects without modification.
- **Security**: Only Grafana UI and the authenticated `/api/v1/write` endpoint are public; Prometheus UI, cAdvisor, and node-exporter remain private (localhost or SSH tunnel).
- **Persistence**: Both Prometheus and Grafana data are persisted in Docker volumes so restarts don't lose dashboards or metrics.

https://claude.ai/code/session_01A1UHqTJsXyjhrU7UEfqkQg