### PR TITLE
Add Scalar API reference documentation at /scalar

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -376,7 +376,7 @@ The backend includes a comprehensive GitHub Actions workflow:
 
 ## 📚 Documentation
 
-- **API Documentation**: Available at `/docs` when running the server
+- **API Documentation** (local environment only): Swagger UI at `/docs`, ReDoc at `/redoc`, and a [Scalar](https://scalar.com/) API reference at `/scalar`
 - **Migration Guide**: See `migrations/` directory
 - **Configuration**: See `config.py` and `.env.example`
 - **Testing**: See `tests/` directory

--- a/backend/app.py
+++ b/backend/app.py
@@ -32,6 +32,8 @@ Version: 1.0.0
 from fastapi import FastAPI, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse
+from scalar_fastapi import get_scalar_api_reference
 from slowapi.errors import RateLimitExceeded
 from sqlalchemy.exc import IntegrityError, OperationalError, SQLAlchemyError
 
@@ -70,7 +72,13 @@ from utils.rate_limiter import limiter, rate_limit_exceeded_handler
 # This ensures all tables are created before the application starts
 Base.metadata.create_all(bind=engine)
 
-# Initialize FastAPI application with metadata
+# Initialize FastAPI application with metadata.
+#
+# Interactive documentation is exposed through three UIs that all read from the
+# same generated OpenAPI schema: the built-in Swagger UI ("/docs"), ReDoc
+# ("/redoc"), and Scalar ("/scalar", registered below). All of them — along with
+# the raw schema — are only enabled in the local environment so internal API
+# details are not published in production.
 # https://stackoverflow.com/questions/73677919/how-to-disable-swagger-ui-documentation-in-fastapi-for-production-server
 app = FastAPI(
     title="ArcanaAI API",
@@ -81,6 +89,22 @@ app = FastAPI(
     redoc_url="/redoc" if settings.FASTAPI_ENV == "local" else None,
     openapi_url="/openapi.json" if settings.FASTAPI_ENV == "local" else None,
 )
+
+
+# Serve an additional interactive API reference with Scalar (https://scalar.com/)
+# at "/scalar", alongside the built-in Swagger UI and ReDoc. Registered only in the
+# local environment to mirror the OpenAPI schema gating above and keep the docs
+# private in production.
+if settings.FASTAPI_ENV == "local":
+
+    @app.get("/scalar", include_in_schema=False)
+    async def scalar_docs() -> HTMLResponse:
+        """Render the Scalar API reference from the generated OpenAPI schema."""
+        return get_scalar_api_reference(
+            openapi_url=app.openapi_url or "/openapi.json",
+            title=app.title,
+        )
+
 
 # Configure rate limiting
 # Add the limiter to the app state and register exception handler
@@ -162,7 +186,7 @@ app.include_router(journal.router)  # Advanced tarot journal and personal growth
 app.include_router(support.router)  # Support ticket system with file uploads
 app.include_router(changelog.router)  # Changelog and version information
 app.include_router(streaks.router)  # Daily streaks and achievements
-app.include_router(stats.router)    # Aggregated dashboard statistics
+app.include_router(stats.router)  # Aggregated dashboard statistics
 app.include_router(web_push.router)  # Web Push (VAPID) subscriptions and delivery
 app.include_router(utilities.router)  # Shared utility endpoints
 
@@ -173,20 +197,22 @@ async def root():
     API Root Endpoint
 
     Welcome endpoint that provides basic information about the ArcanaAI API
-    and links to interactive documentation.
+    and links to the interactive documentation.
 
     Returns:
         dict: API welcome information
             - message (str): Welcome message
             - docs_url (str): URL to Swagger UI documentation
             - redoc_url (str): URL to ReDoc documentation
+            - scalar_url (str): URL to Scalar API reference
 
     Example Response:
         ```json
         {
             "message": "Welcome to the ArcanaAI API",
             "docs_url": "/docs",
-            "redoc_url": "/redoc"
+            "redoc_url": "/redoc",
+            "scalar_url": "/scalar"
         }
         ```
 
@@ -197,4 +223,5 @@ async def root():
         "message": "Welcome to the ArcanaAI API",
         "docs_url": "/docs",
         "redoc_url": "/redoc",
+        "scalar_url": "/scalar",
     }

--- a/backend/docs/CHANGELOG.md
+++ b/backend/docs/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.20] - 2026-06-22
+
+### Added
+- Added a [Scalar](https://scalar.com/) API reference at `/scalar`, served alongside the existing Swagger UI (`/docs`) and ReDoc (`/redoc`). All three read from the same OpenAPI schema (`/openapi.json`) and remain available only in the local environment. The API root response (`GET /`) now includes a `scalar_url` field.
+
 ## [0.0.19] - 2026-06-20
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -90,6 +90,7 @@ dependencies = [
     "yarl>=1.24.2",
     "pytest-asyncio>=1.4.0",
     "web3>=7.12.0",
+    "scalar-fastapi>=1.8.2",
 ]
 
 [tool.ruff]

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -13,6 +13,7 @@ def test_read_root(client):
     assert data["message"] == "Welcome to the ArcanaAI API"
     assert data["docs_url"] == "/docs"
     assert data["redoc_url"] == "/redoc"
+    assert data["scalar_url"] == "/scalar"
 
 
 def test_health_check(client):
@@ -25,7 +26,7 @@ def test_health_check(client):
 
 
 def test_docs_available(client):
-    """Test that API documentation is accessible"""
+    """Test that the Swagger UI documentation is accessible"""
     response = client.get("/docs")
     assert response.status_code == status.HTTP_200_OK
 
@@ -34,6 +35,18 @@ def test_redoc_available(client):
     """Test that ReDoc documentation is accessible"""
     response = client.get("/redoc")
     assert response.status_code == status.HTTP_200_OK
+
+
+def test_scalar_available(client):
+    """Test that the Scalar API reference is served at /scalar"""
+    response = client.get("/scalar")
+    assert response.status_code == status.HTTP_200_OK
+    assert "text/html" in response.headers["content-type"]
+    body = response.text.lower()
+    # Scalar renders an HTML shell that loads the Scalar reference bundle and
+    # points it at the generated OpenAPI schema.
+    assert "@scalar/api-reference" in body
+    assert "/openapi.json" in body
 
 
 def test_openapi_schema_available(client):

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -310,6 +310,7 @@ dependencies = [
     { name = "requests-toolbelt" },
     { name = "rsa" },
     { name = "ruff" },
+    { name = "scalar-fastapi" },
     { name = "six" },
     { name = "slowapi" },
     { name = "sniffio" },
@@ -395,6 +396,7 @@ requires-dist = [
     { name = "requests-toolbelt", specifier = ">=1.0.0" },
     { name = "rsa", specifier = ">=4.9.1" },
     { name = "ruff", specifier = ">=0.15.17" },
+    { name = "scalar-fastapi", specifier = ">=1.8.2" },
     { name = "six", specifier = ">=1.17.0" },
     { name = "slowapi", specifier = ">=0.1.10" },
     { name = "sniffio", specifier = ">=1.3.1" },
@@ -3429,6 +3431,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
+]
+
+[[package]]
+name = "scalar-fastapi"
+version = "1.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/81/c0c70776a3d7d371ee06d38d26a8d361c97439d46f79acb6d67cf6c760ad/scalar_fastapi-1.8.2.tar.gz", hash = "sha256:0de09b8c63f78c1052792faa200d740b2ccaeeb88ac54e7ea633ac4edc6fde82", size = 8371, upload-time = "2026-04-09T22:41:24.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/b1/b9a482620479b2801a4dfa5c4c10b4cc280097e894114e0298f21a0fca55/scalar_fastapi-1.8.2-py3-none-any.whl", hash = "sha256:d96e2c8b3676491eaebb4ec8d9f4de77adb2374d86f87d321546fa6f084e8cb8", size = 7677, upload-time = "2026-04-09T22:41:23.209Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Added [Scalar](https://scalar.com/) as an additional interactive API reference alongside the existing Swagger UI and ReDoc documentation. The Scalar reference is served at `/scalar` and reads from the same OpenAPI schema, maintaining consistency across all three documentation interfaces.

## Key Changes
- **New dependency**: Added `scalar-fastapi>=1.8.2` to project dependencies
- **New endpoint**: Registered `/scalar` route that serves the Scalar API reference (local environment only)
- **Updated root response**: Added `scalar_url` field to the API root endpoint (`GET /`) response
- **Enhanced documentation**: Updated docstrings and README to reflect the three available documentation options
- **Test coverage**: Added `test_scalar_available()` to verify the Scalar endpoint is accessible and properly configured
- **Minor formatting**: Fixed trailing whitespace in router registration comments

## Implementation Details
- The Scalar endpoint is conditionally registered only when `FASTAPI_ENV == "local"`, mirroring the existing behavior for Swagger UI and ReDoc
- The endpoint is excluded from the OpenAPI schema (`include_in_schema=False`) to keep it internal
- All three documentation interfaces (`/docs`, `/redoc`, `/scalar`) are gated behind the local environment check to prevent exposing API details in production
- Updated CHANGELOG with version 0.0.20 entry documenting the new feature

https://claude.ai/code/session_017eRCKDppzHaSC4GYskw1Nq