### PR TITLE
feat: restore ArcanaAI metrics instrumentation

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -63,6 +63,7 @@ from utils.error_handlers import (
     tarot_exception_handler,
     validation_exception_handler,
 )
+from utils.metrics import setup_metrics
 from utils.middleware import RequestLoggingMiddleware
 from utils.rate_limiter import limiter, rate_limit_exceeded_handler
 
@@ -90,6 +91,8 @@ app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
 # Add custom middleware
 # Request logging middleware must be added before CORS middleware
 app.add_middleware(RequestLoggingMiddleware)
+
+setup_metrics(app, env=settings.FASTAPI_ENV)
 
 
 @app.middleware("http")
@@ -162,7 +165,7 @@ app.include_router(journal.router)  # Advanced tarot journal and personal growth
 app.include_router(support.router)  # Support ticket system with file uploads
 app.include_router(changelog.router)  # Changelog and version information
 app.include_router(streaks.router)  # Daily streaks and achievements
-app.include_router(stats.router)    # Aggregated dashboard statistics
+app.include_router(stats.router)  # Aggregated dashboard statistics
 app.include_router(web_push.router)  # Web Push (VAPID) subscriptions and delivery
 app.include_router(utilities.router)  # Shared utility endpoints
 

--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -1,10 +1,15 @@
 import os
 import sys
+import time
 from pathlib import Path
 
 from celery import Celery
 from celery.schedules import crontab
+from celery.signals import task_failure, task_postrun, task_prerun, task_retry
 from dotenv import load_dotenv
+
+from config import settings
+from utils.metrics import record_celery_failure, record_celery_task
 
 # Load environment variables
 load_dotenv()
@@ -59,5 +64,62 @@ celery_app.conf.update(
         },
     },
 )
+
+
+def _queue_name(task=None, request=None) -> str:
+    task_request = getattr(task, "request", None) or request
+    delivery_info = getattr(task_request, "delivery_info", {}) or {}
+    return delivery_info.get("routing_key") or delivery_info.get("exchange") or "unknown"
+
+
+def _task_name(sender) -> str:
+    return getattr(sender, "name", "unknown")
+
+
+@task_prerun.connect
+def track_task_start(sender=None, task_id=None, task=None, **kwargs):
+    if task is not None:
+        task.request._arcana_task_start_time = time.perf_counter()
+    record_celery_task(
+        env=settings.FASTAPI_ENV,
+        queue=_queue_name(task),
+        task_name=_task_name(sender),
+        status="started",
+    )
+
+
+@task_postrun.connect
+def track_task_done(sender=None, task_id=None, task=None, state=None, **kwargs):
+    started = getattr(getattr(task, "request", None), "_arcana_task_start_time", None)
+    duration = time.perf_counter() - started if started else None
+    task_status = "success" if state == "SUCCESS" else str(state or "unknown").lower()
+    record_celery_task(
+        env=settings.FASTAPI_ENV,
+        queue=_queue_name(task),
+        task_name=_task_name(sender),
+        status=task_status,
+        duration=duration,
+    )
+
+
+@task_failure.connect
+def track_task_failure(sender=None, task_id=None, exception=None, task=None, **kwargs):
+    record_celery_failure(
+        env=settings.FASTAPI_ENV,
+        queue=_queue_name(task or sender),
+        task_name=_task_name(sender),
+        error_type=type(exception).__name__ if exception else "unknown",
+    )
+
+
+@task_retry.connect
+def track_task_retry(sender=None, request=None, reason=None, **kwargs):
+    record_celery_task(
+        env=settings.FASTAPI_ENV,
+        queue=_queue_name(request=request),
+        task_name=_task_name(sender),
+        status="retry",
+    )
+
 
 # Explicitly import tasks to ensure they're registered

--- a/backend/config.py
+++ b/backend/config.py
@@ -37,6 +37,8 @@ class Settings(BaseSettings):
         OPENAI_MODEL (str): OpenAI model name.
         OPENAI_TEMPERATURE (float): OpenAI model temperature.
         OPENAI_MAX_TOKENS (int): Max tokens for OpenAI responses.
+        OPENAI_INPUT_COST_USD_PER_1M_TOKENS (float): Optional input token price for cost metrics.
+        OPENAI_OUTPUT_COST_USD_PER_1M_TOKENS (float): Optional output token price for cost metrics.
         MAIL_USERNAME (str): Email username.
         MAIL_PASSWORD (str): Email password.
         MAIL_FROM (str): Email sender address.
@@ -115,6 +117,8 @@ class Settings(BaseSettings):
     OPENAI_MODEL: str = os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
     OPENAI_TEMPERATURE: float = float(os.getenv("OPENAI_TEMPERATURE", "0.7"))
     OPENAI_MAX_TOKENS: int = int(os.getenv("OPENAI_MAX_TOKENS", "800"))
+    OPENAI_INPUT_COST_USD_PER_1M_TOKENS: float = float(os.getenv("OPENAI_INPUT_COST_USD_PER_1M_TOKENS", "0"))
+    OPENAI_OUTPUT_COST_USD_PER_1M_TOKENS: float = float(os.getenv("OPENAI_OUTPUT_COST_USD_PER_1M_TOKENS", "0"))
 
     # Web Push (VAPID) Settings — leave blank to disable web push
     WEBPUSH_PUBLIC_KEY: str = os.getenv("WEBPUSH_PUBLIC_KEY", "")

--- a/backend/create_checkout_sessions_table.py
+++ b/backend/create_checkout_sessions_table.py
@@ -7,9 +7,10 @@ from pathlib import Path
 # Add backend to path
 sys.path.append(str(Path(__file__).parent))
 
-from database import engine, Base
-from models import CheckoutSession
 import logging
+
+from database import engine
+from models import CheckoutSession
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/backend/database.py
+++ b/backend/database.py
@@ -46,6 +46,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from config import settings
 from utils.error_handlers import logger
+from utils.metrics import record_db_query
 
 # Load environment variables
 load_dotenv(Path(".env"))
@@ -89,15 +90,21 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 
 
+def _db_operation(statement: str | None) -> str:
+    """Return a bounded SQL operation label."""
+    operation = (statement or "").strip().split(maxsplit=1)[0].lower()
+    return operation if operation in {"select", "insert", "update", "delete"} else "other"
+
+
 # Add SQL query logging
 @event.listens_for(engine, "before_cursor_execute")
 def before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
-    conn.info.setdefault("query_start_time", []).append(time.time())
+    conn.info.setdefault("query_start_time", []).append(time.perf_counter())
 
 
 @event.listens_for(engine, "after_cursor_execute")
 def after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
-    total = time.time() - conn.info["query_start_time"].pop(-1)
+    total = time.perf_counter() - conn.info["query_start_time"].pop(-1)
     logger.logger.debug(
         "Database query executed",
         extra={
@@ -105,6 +112,27 @@ def after_cursor_execute(conn, cursor, statement, parameters, context, executema
             "parameters": str(parameters),
             "execution_time_ms": round(total * 1000, 2),
         },
+    )
+    record_db_query(
+        env=settings.FASTAPI_ENV,
+        operation=_db_operation(statement),
+        table="unknown",
+        status="success",
+        duration=total,
+    )
+
+
+@event.listens_for(engine, "handle_error")
+def handle_db_error(exception_context):
+    starts = exception_context.connection.info.get("query_start_time", []) if exception_context.connection else []
+    started = starts.pop(-1) if starts else None
+    total = time.perf_counter() - started if started else 0.0
+    record_db_query(
+        env=settings.FASTAPI_ENV,
+        operation=_db_operation(exception_context.statement),
+        table="unknown",
+        status="error",
+        duration=total,
     )
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -3,7 +3,20 @@ import uuid
 from datetime import UTC
 
 import bcrypt
-from sqlalchemy import JSON, Boolean, CheckConstraint, Column, Date, DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    CheckConstraint,
+    Column,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -90,6 +90,7 @@ dependencies = [
     "yarl>=1.24.2",
     "pytest-asyncio>=1.4.0",
     "web3>=7.12.0",
+    "prometheus-client>=0.25.0",
 ]
 
 [tool.ruff]

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,13 +1,13 @@
 from datetime import datetime, timedelta
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.security import HTTPBearer
 from sqlalchemy import asc, desc, func, or_
 from sqlalchemy.orm import Session
 
 from database import get_db
 from models import Card, ChatSession, Deck, Message, SharedReading, Spread, User
-from routers.auth import get_admin_user, get_current_user
+from routers.auth import get_admin_user
 from schemas import (
     AdminCardCreate,
     AdminCardResponse,
@@ -23,8 +23,8 @@ from schemas import (
     AdminSpreadCreate,
     AdminSpreadResponse,
     AdminSpreadUpdate,
-    AdminUserResponse,
     AdminUserPasswordResetRequest,
+    AdminUserResponse,
     AdminUserUpdate,
 )
 from utils.avatar_utils import avatar_manager

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -35,6 +35,7 @@ from utils.error_handlers import (
     ValidationError,
     logger,
 )
+from utils.metrics import record_auth_attempt
 from utils.rate_limiter import RATE_LIMITS, limiter
 
 router = APIRouter(prefix="/auth", tags=["authentication"])
@@ -305,6 +306,11 @@ def register(request: Request, user: UserCreate, db: Session = Depends(get_db)):
         # Check if username exists
         db_user = db.query(User).filter(User.username == user.username).first()
         if db_user:
+            record_auth_attempt(
+                settings.FASTAPI_ENV,
+                action="register",
+                status="validation_error",
+            )
             raise ValidationError(
                 message="Username already registered",
                 details={"username": user.username},
@@ -313,6 +319,11 @@ def register(request: Request, user: UserCreate, db: Session = Depends(get_db)):
         # Check if email exists
         db_user = db.query(User).filter(User.email == user.email).first()
         if db_user:
+            record_auth_attempt(
+                settings.FASTAPI_ENV,
+                action="register",
+                status="validation_error",
+            )
             raise ValidationError(message="Email already registered", details={"email": user.email})
 
         # Create new user
@@ -326,10 +337,20 @@ def register(request: Request, user: UserCreate, db: Session = Depends(get_db)):
             "User registered successfully",
             extra={"user_id": db_user.id, "username": db_user.username},
         )
+        record_auth_attempt(
+            settings.FASTAPI_ENV,
+            action="register",
+            status="success",
+        )
         return db_user
     except ValidationError:
         raise
     except Exception as e:
+        record_auth_attempt(
+            settings.FASTAPI_ENV,
+            action="register",
+            status="error",
+        )
         logger.logger.error("Error registering user", extra={"error": str(e), "username": user.username})
         raise TarotAPIException(message="Error registering user", details={"error": str(e)})
 
@@ -366,6 +387,11 @@ async def login(request: Request, form_data: OAuth2PasswordRequestForm = Depends
 
         user = db.query(User).filter(or_(User.username == form_data.username, User.email == form_data.username)).first()
         if not user:
+            record_auth_attempt(
+                settings.FASTAPI_ENV,
+                action="login",
+                status="rejected",
+            )
             logger.logger.warning(
                 "Login failed: User not found",
                 extra={"username_or_email": form_data.username},
@@ -376,6 +402,11 @@ async def login(request: Request, form_data: OAuth2PasswordRequestForm = Depends
             )
 
         if not user.verify_password(form_data.password):
+            record_auth_attempt(
+                settings.FASTAPI_ENV,
+                action="login",
+                status="rejected",
+            )
             logger.logger.warning(
                 "Login failed: Invalid password",
                 extra={"username_or_email": form_data.username},
@@ -389,6 +420,11 @@ async def login(request: Request, form_data: OAuth2PasswordRequestForm = Depends
             access_token = create_access_token(data={"sub": user.username})
             refresh_token = create_refresh_token(data={"sub": user.username})
         except Exception as token_error:
+            record_auth_attempt(
+                settings.FASTAPI_ENV,
+                action="login",
+                status="error",
+            )
             logger.logger.error(
                 "Error creating tokens",
                 extra={"error": str(token_error), "username_or_email": form_data.username},
@@ -399,10 +435,20 @@ async def login(request: Request, form_data: OAuth2PasswordRequestForm = Depends
             "User logged in successfully",
             extra={"user_id": user.id, "username": user.username},
         )
+        record_auth_attempt(
+            settings.FASTAPI_ENV,
+            action="login",
+            status="success",
+        )
         return {"access_token": access_token, "refresh_token": refresh_token, "token_type": "bearer"}
     except AuthenticationError:
         raise
     except Exception as e:
+        record_auth_attempt(
+            settings.FASTAPI_ENV,
+            action="login",
+            status="error",
+        )
         logger.logger.error(
             "Error during login",
             extra={
@@ -445,25 +491,39 @@ async def refresh_token(request: Request, refresh_token_data: RefreshToken, db: 
 
         # Check if it's a refresh token
         if payload.get("type") != "refresh":
+            record_auth_attempt(settings.FASTAPI_ENV, action="refresh", status="rejected")
             raise AuthenticationError(message="Invalid token type")
 
         username: str = payload.get("sub")
         if username is None:
+            record_auth_attempt(settings.FASTAPI_ENV, action="refresh", status="rejected")
             raise AuthenticationError(message="Invalid token payload")
 
         # Verify user exists
         user = db.query(User).filter(User.username == username).first()
         if user is None:
+            record_auth_attempt(settings.FASTAPI_ENV, action="refresh", status="rejected")
             raise AuthenticationError(message="User not found")
 
         # Generate new tokens
         access_token = create_access_token(data={"sub": user.username})
         refresh_token = create_refresh_token(data={"sub": user.username})
 
+        record_auth_attempt(settings.FASTAPI_ENV, action="refresh", status="success")
         return {"access_token": access_token, "refresh_token": refresh_token, "token_type": "bearer"}
     except JWTError as e:
+        record_auth_attempt(settings.FASTAPI_ENV, action="refresh", status="rejected")
         logger.logger.error("JWT decode error", extra={"error": str(e)})
         raise AuthenticationError(message="Invalid refresh token", details={"error": str(e)})
+    except AuthenticationError:
+        raise
+    except TarotAPIException:
+        record_auth_attempt(settings.FASTAPI_ENV, action="refresh", status="error")
+        raise
+    except Exception as e:
+        record_auth_attempt(settings.FASTAPI_ENV, action="refresh", status="error")
+        logger.logger.error("Error refreshing token", extra={"error": str(e)})
+        raise TarotAPIException(message="Error refreshing token", details={"error": str(e)})
 
 
 @router.post("/forgot-password")
@@ -512,8 +572,10 @@ async def forgot_password(request: Request, request_data: ForgotPasswordRequest,
         if user:
             # Queue the email task (always send to user's email)
             EmailTaskManager.send_password_reset_email_async(user.email, token, user.id)
+        record_auth_attempt(settings.FASTAPI_ENV, action="forgot_password", status="success")
         return {"message": "If an account exists with this email or username, a password reset token has been sent."}
     except Exception as e:
+        record_auth_attempt(settings.FASTAPI_ENV, action="forgot_password", status="error")
         logger.logger.error(
             "Error in forgot password process",
             extra={"error": str(e), "email_or_username": request_data.email_or_username},
@@ -573,6 +635,7 @@ async def reset_password(request: Request, request_data: ResetPasswordRequest, d
         )
 
         if not reset_token:
+            record_auth_attempt(settings.FASTAPI_ENV, action="reset_password", status="validation_error")
             raise ValidationError(
                 message="Invalid or expired reset token",
                 details={"token": request_data.token},
@@ -588,10 +651,12 @@ async def reset_password(request: Request, request_data: ResetPasswordRequest, d
         db.commit()
 
         logger.logger.info("Password reset successful", extra={"user_id": user.id})
+        record_auth_attempt(settings.FASTAPI_ENV, action="reset_password", status="success")
         return {"message": "Password has been reset successfully"}
     except ValidationError:
         raise
     except Exception as e:
+        record_auth_attempt(settings.FASTAPI_ENV, action="reset_password", status="error")
         logger.logger.error("Error resetting password", extra={"error": str(e), "token": request_data.token})
         raise TarotAPIException(message="Error resetting password", details={"error": str(e)})
 

--- a/backend/routers/changelog.py
+++ b/backend/routers/changelog.py
@@ -13,9 +13,7 @@ Author: ArcanaAI Development Team
 Version: 1.0.0
 """
 
-import os
 from pathlib import Path
-from typing import Optional
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import PlainTextResponse
@@ -46,7 +44,7 @@ async def get_changelog():
                 detail="Changelog file not found"
             )
 
-        with open(CHANGELOG_PATH, 'r', encoding='utf-8') as file:
+        with open(CHANGELOG_PATH, encoding='utf-8') as file:
             content = file.read()
 
         return content
@@ -77,7 +75,7 @@ async def get_latest_version():
                 detail="Changelog file not found"
             )
 
-        with open(CHANGELOG_PATH, 'r', encoding='utf-8') as file:
+        with open(CHANGELOG_PATH, encoding='utf-8') as file:
             content = file.read()
 
         # Parse the changelog to find the latest version
@@ -161,7 +159,7 @@ async def get_all_versions():
                 detail="Changelog file not found"
             )
 
-        with open(CHANGELOG_PATH, 'r', encoding='utf-8') as file:
+        with open(CHANGELOG_PATH, encoding='utf-8') as file:
             content = file.read()
 
         lines = content.split('\n')
@@ -238,7 +236,7 @@ async def get_version_info(version: str):
                 detail="Changelog file not found"
             )
 
-        with open(CHANGELOG_PATH, 'r', encoding='utf-8') as file:
+        with open(CHANGELOG_PATH, encoding='utf-8') as file:
             content = file.read()
 
         # Parse the changelog to find the specific version

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -28,6 +28,12 @@ from utils.error_handlers import (
     ResourceNotFoundError,
     logger,
 )
+from utils.metrics import (
+    record_chat_conversation,
+    record_chat_message,
+    record_openai_request,
+    set_active_chat_conversations,
+)
 from utils.rate_limiter import RATE_LIMITS, limiter
 
 router = APIRouter(prefix="/chat", tags=["chat"])
@@ -39,6 +45,46 @@ CARD_DRAW_ANIMATION_SECONDS = 5
 
 # Initialize TarotReader
 reader = TarotReader()
+
+
+def _openai_token_usage(response) -> tuple[int, int]:
+    usage = getattr(response, "usage_metadata", {}) or {}
+    metadata = getattr(response, "response_metadata", {}) or {}
+    token_usage = metadata.get("token_usage", {}) or {}
+    prompt_tokens = int(usage.get("input_tokens") or token_usage.get("prompt_tokens") or 0)
+    completion_tokens = int(usage.get("output_tokens") or token_usage.get("completion_tokens") or 0)
+    return prompt_tokens, completion_tokens
+
+
+def _estimate_openai_cost_usd(prompt_tokens: int, completion_tokens: int) -> float:
+    input_cost = prompt_tokens * settings.OPENAI_INPUT_COST_USD_PER_1M_TOKENS / 1_000_000
+    output_cost = completion_tokens * settings.OPENAI_OUTPUT_COST_USD_PER_1M_TOKENS / 1_000_000
+    return input_cost + output_cost
+
+
+def _record_openai_success(response, start_time: float, operation: str = "chat_message") -> None:
+    prompt_tokens, completion_tokens = _openai_token_usage(response)
+    record_openai_request(
+        env=settings.FASTAPI_ENV,
+        model=settings.OPENAI_MODEL,
+        operation=operation,
+        status="success",
+        duration=time.perf_counter() - start_time,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        cost_usd=_estimate_openai_cost_usd(prompt_tokens, completion_tokens),
+    )
+
+
+def _record_openai_error(exc: Exception, start_time: float, operation: str = "chat_message") -> None:
+    record_openai_request(
+        env=settings.FASTAPI_ENV,
+        model=settings.OPENAI_MODEL,
+        operation=operation,
+        status="error",
+        duration=time.perf_counter() - start_time,
+        error_type=type(exc).__name__,
+    )
 
 
 def load_system_prompt() -> str:
@@ -398,6 +444,9 @@ def create_chat_session(
         db.add(db_chat)
         db.commit()
         db.refresh(db_chat)
+        active_count = db.query(ChatSession).count()
+        record_chat_conversation(settings.FASTAPI_ENV, source="api", status="created")
+        set_active_chat_conversations(settings.FASTAPI_ENV, active_count)
 
         logger.logger.info(
             "Chat session created",
@@ -412,6 +461,7 @@ def create_chat_session(
         raise
     except Exception as e:
         db.rollback()
+        record_chat_conversation(settings.FASTAPI_ENV, source="api", status="error")
         logger.logger.error(
             "Error creating chat session",
             extra={"error": str(e), "user_id": current_user.id, "title": chat.title},
@@ -662,6 +712,9 @@ def delete_chat_session(
 
         db.delete(session)
         db.commit()
+        active_count = db.query(ChatSession).count()
+        record_chat_conversation(settings.FASTAPI_ENV, source="api", status="deleted")
+        set_active_chat_conversations(settings.FASTAPI_ENV, active_count)
 
         logger.logger.info(
             "Chat session deleted",
@@ -674,6 +727,7 @@ def delete_chat_session(
         raise
     except Exception as e:
         db.rollback()
+        record_chat_conversation(settings.FASTAPI_ENV, source="api", status="error")
         logger.logger.error(
             "Error deleting chat session",
             extra={
@@ -904,8 +958,10 @@ async def create_message(
         try:
             db.commit()
             db.refresh(user_message)
+            record_chat_message(settings.FASTAPI_ENV, role="user", status="success")
         except Exception as db_exc:
             db.rollback()
+            record_chat_message(settings.FASTAPI_ENV, role="user", status="error")
             logger.logger.error(
                 "Error saving user message before streaming",
                 extra={
@@ -983,7 +1039,14 @@ async def create_message(
                     f"Invoking LLM with {len(messages_for_llm)} messages and {len(available_tools)} tools available"
                 )
 
-                llm_response = llm.bind_tools(available_tools).invoke(messages_for_llm)
+                openai_start_time = time.perf_counter()
+                try:
+                    llm_response = llm.bind_tools(available_tools).invoke(messages_for_llm)
+                except Exception as exc:
+                    _record_openai_error(exc, openai_start_time)
+                    raise
+                else:
+                    _record_openai_success(llm_response, openai_start_time)
 
                 if llm_response.tool_calls:
                     logger.logger.info(
@@ -1003,7 +1066,14 @@ async def create_message(
                         yield f"data: {json.dumps({'type': 'session_renamed', 'title': renamed_title})}\n\n"
 
                     if not tool_call:
-                        llm_response = llm.bind_tools([DRAW_CARDS_TOOL]).invoke(messages_for_llm)
+                        openai_start_time = time.perf_counter()
+                        try:
+                            llm_response = llm.bind_tools([DRAW_CARDS_TOOL]).invoke(messages_for_llm)
+                        except Exception as exc:
+                            _record_openai_error(exc, openai_start_time)
+                            raise
+                        else:
+                            _record_openai_success(llm_response, openai_start_time)
                         if llm_response.tool_calls:
                             tool_call, renamed_title = handle_llm_tool_calls(
                                 llm_response.tool_calls,
@@ -1110,6 +1180,7 @@ async def create_message(
 
                             db.commit()
                             db.refresh(ai_message)
+                            record_chat_message(settings.FASTAPI_ENV, role="assistant", status="success")
 
                             ai_message_response_pydantic = MessageResponse.from_orm(ai_message)
                             # Pydantic V2 style for a dict ready for json.dumps
@@ -1150,6 +1221,7 @@ async def create_message(
                                 db.add(error_message)
                                 db.commit()
                                 db.refresh(error_message)
+                                record_chat_message(settings.FASTAPI_ENV, role="assistant", status="error")
 
                                 error_message_response = MessageResponse.from_orm(error_message)
                                 message_dict_error = error_message_response.model_dump(mode="json")
@@ -1167,10 +1239,23 @@ async def create_message(
 
                 else:
                     response_content = ""
-                    async for chunk in llm.astream(messages_for_llm):
-                        if chunk.content:
-                            response_content += chunk.content  # Accumulate content for saving
-                            yield f"data: {json.dumps({'type': 'content_chunk', 'content': chunk.content})}\n\n"
+                    openai_start_time = time.perf_counter()
+                    try:
+                        async for chunk in llm.astream(messages_for_llm):
+                            if chunk.content:
+                                response_content += chunk.content  # Accumulate content for saving
+                                yield f"data: {json.dumps({'type': 'content_chunk', 'content': chunk.content})}\n\n"
+                    except Exception as exc:
+                        _record_openai_error(exc, openai_start_time)
+                        raise
+                    else:
+                        record_openai_request(
+                            env=settings.FASTAPI_ENV,
+                            model=settings.OPENAI_MODEL,
+                            operation="chat_message",
+                            status="success",
+                            duration=time.perf_counter() - openai_start_time,
+                        )
 
                     # Save the complete AI response if no tools were called
                     if response_content:  # Ensure there's content to save
@@ -1195,6 +1280,7 @@ async def create_message(
                         db.add(ai_message)
                         db.commit()
                         db.refresh(ai_message)
+                        record_chat_message(settings.FASTAPI_ENV, role="assistant", status="success")
 
                         no_tool_ai_message_response = MessageResponse.from_orm(ai_message)
                         # Pydantic V2 style for a dict ready for json.dumps
@@ -1222,6 +1308,7 @@ async def create_message(
                         db.add(empty_ai_message)
                         db.commit()
                         db.refresh(empty_ai_message)
+                        record_chat_message(settings.FASTAPI_ENV, role="assistant", status="error")
                         empty_message_response = MessageResponse.from_orm(empty_ai_message)
                         message_dict_empty = empty_message_response.model_dump(mode="json")
                         event_payload_empty = {
@@ -1240,6 +1327,7 @@ async def create_message(
                 )
 
             except Exception as e_stream:
+                record_chat_message(settings.FASTAPI_ENV, role="assistant", status="error")
                 logger.logger.error(f"Error during streaming response: {e_stream}", exc_info=True)
                 raise HTTPException(
                     status_code=500, detail=f"An unexpected error occurred during response generation: {str(e_stream)}"

--- a/backend/routers/subscription.py
+++ b/backend/routers/subscription.py
@@ -1,26 +1,26 @@
 import json
 import logging
-
-from fastapi import APIRouter, Depends, HTTPException, Request, status
-from sqlalchemy.orm import Session
-from sqlalchemy import desc
 from datetime import datetime, timedelta
 
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy import desc
+from sqlalchemy.orm import Session
+
 from database import get_db
-from models import User, SubscriptionEvent, PaymentTransaction, TurnUsageHistory, SubscriptionPlan, CheckoutSession
+from models import PaymentTransaction, SubscriptionEvent, SubscriptionPlan, TurnUsageHistory, User
 from routers.auth import get_current_user
 from schemas import (
     CheckoutRequest,
     CheckoutResponse,
     EthereumPaymentRequest,
     EthereumPaymentResponse,
+    PaymentTransactionResponse,
+    SubscriptionEventResponse,
+    SubscriptionHistoryResponse,
+    SubscriptionPlanResponse,
     SubscriptionResponse,
     TurnsResponse,
-    SubscriptionEventResponse,
-    PaymentTransactionResponse,
     TurnUsageHistoryResponse,
-    SubscriptionPlanResponse,
-    SubscriptionHistoryResponse,
 )
 from services.ethereum_service import EthereumService
 from services.subscription_service import SubscriptionService

--- a/backend/routers/subscription.py
+++ b/backend/routers/subscription.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import desc
 from sqlalchemy.orm import Session
 
+from config import settings
 from database import get_db
 from models import PaymentTransaction, SubscriptionEvent, SubscriptionPlan, TurnUsageHistory, User
 from routers.auth import get_current_user
@@ -24,12 +25,30 @@ from schemas import (
 )
 from services.ethereum_service import EthereumService
 from services.subscription_service import SubscriptionService
+from utils.metrics import record_payment_event
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api", tags=["subscription"])
 subscription_service = SubscriptionService()
 ethereum_service = EthereumService()
+
+
+def _extract_lemon_squeezy_amount_usd(event_data: dict) -> float:
+    attributes = event_data.get("data", {}).get("attributes", {})
+    total_cents = attributes.get("total") or 0
+    try:
+        return float(total_cents) / 100
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _product_amount_usd(product_variant: str) -> float:
+    try:
+        price = subscription_service.get_product_info(product_variant).get("price", "")
+        return float(price.replace("$", "").strip())
+    except (AttributeError, TypeError, ValueError):
+        return 0.0
 
 
 @router.get("/user/turns", response_model=TurnsResponse)
@@ -70,12 +89,30 @@ async def create_checkout_session(
     try:
         logger.info(f"Creating checkout session for user {current_user.id} with product variant: {request.product_variant}")
         checkout_url = await subscription_service.create_checkout_url(current_user, request.product_variant, db)
+        record_payment_event(
+            settings.FASTAPI_ENV,
+            provider="lemon_squeezy",
+            event_type="checkout_created",
+            status="created",
+        )
         logger.info(f"Successfully created checkout session for user {current_user.id}")
         return CheckoutResponse(checkout_url=checkout_url)
     except ValueError as e:
+        record_payment_event(
+            settings.FASTAPI_ENV,
+            provider="lemon_squeezy",
+            event_type="checkout_created",
+            status="validation_error",
+        )
         logger.warning(f"Invalid product variant for user {current_user.id}: {str(e)}")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
+        record_payment_event(
+            settings.FASTAPI_ENV,
+            provider="lemon_squeezy",
+            event_type="checkout_created",
+            status="error",
+        )
         logger.error(f"Failed to create checkout session for user {current_user.id}: {str(e)}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -86,6 +123,7 @@ async def create_checkout_session(
 @router.post("/webhooks/lemon-squeezy")
 async def handle_lemon_squeezy_webhook(request: Request, db: Session = Depends(get_db)):
     """Handle webhook events from Lemon Squeezy."""
+    event_name = "webhook_received"
     try:
         # Get the raw payload
         payload = await request.body()
@@ -93,23 +131,38 @@ async def handle_lemon_squeezy_webhook(request: Request, db: Session = Depends(g
         # Get the signature from headers
         signature = request.headers.get("x-signature")
         if not signature:
+            record_payment_event(settings.FASTAPI_ENV, "lemon_squeezy", event_name, "signature_error")
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing signature")
 
         # Verify the webhook signature
         if not subscription_service.verify_webhook_signature(payload, signature):
+            record_payment_event(settings.FASTAPI_ENV, "lemon_squeezy", event_name, "signature_error")
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid signature")
 
         # Parse the JSON payload
         event_data = json.loads(payload)
+        event_name = event_data.get("meta", {}).get("event_name", "unknown")
+        record_payment_event(settings.FASTAPI_ENV, "lemon_squeezy", event_name, "received")
 
         # Process the webhook event
         subscription_service.process_webhook_event(db, event_data)
+        record_payment_event(
+            settings.FASTAPI_ENV,
+            provider="lemon_squeezy",
+            event_type=event_name,
+            status="paid" if event_name == "order_created" else "success",
+            amount_usd=_extract_lemon_squeezy_amount_usd(event_data),
+        )
 
         return {"status": "success"}
 
     except json.JSONDecodeError:
+        record_payment_event(settings.FASTAPI_ENV, "lemon_squeezy", event_name, "invalid_json")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid JSON payload")
+    except HTTPException:
+        raise
     except Exception:
+        record_payment_event(settings.FASTAPI_ENV, "lemon_squeezy", event_name, "error")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to process webhook")
 
 
@@ -143,6 +196,7 @@ async def process_ethereum_payment(
     try:
         # Check if Ethereum service is available
         if not ethereum_service.is_connected():
+            record_payment_event(settings.FASTAPI_ENV, "ethereum", "ethereum_payment", "service_unavailable")
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Ethereum verification service is unavailable"
             )
@@ -160,10 +214,18 @@ async def process_ethereum_payment(
         )
 
         if not result["success"]:
+            record_payment_event(settings.FASTAPI_ENV, "ethereum", "ethereum_payment", "verification_failed")
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST, detail=result.get("message", "Payment verification failed")
             )
 
+        record_payment_event(
+            settings.FASTAPI_ENV,
+            provider="ethereum",
+            event_type="ethereum_payment",
+            status="paid",
+            amount_usd=_product_amount_usd(request.product_variant),
+        )
         return EthereumPaymentResponse(
             success=result["success"],
             transaction_verified=result["transaction_verified"],
@@ -175,6 +237,7 @@ async def process_ethereum_payment(
     except HTTPException:
         raise
     except Exception as e:
+        record_payment_event(settings.FASTAPI_ENV, "ethereum", "ethereum_payment", "error")
         logger.error(f"Error processing Ethereum payment: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to process Ethereum payment"
@@ -278,7 +341,7 @@ async def get_subscription_plans(db: Session = Depends(get_db)):
     try:
         plans = (
             db.query(SubscriptionPlan)
-            .filter(SubscriptionPlan.is_active == True)
+            .filter(SubscriptionPlan.is_active.is_(True))
             .order_by(SubscriptionPlan.sort_order, SubscriptionPlan.turns_included)
             .all()
         )
@@ -337,7 +400,7 @@ async def get_user_subscription_history(
         # Get subscription plans
         plans = (
             db.query(SubscriptionPlan)
-            .filter(SubscriptionPlan.is_active == True)
+            .filter(SubscriptionPlan.is_active.is_(True))
             .order_by(SubscriptionPlan.sort_order, SubscriptionPlan.turns_included)
             .all()
         )

--- a/backend/routers/support.py
+++ b/backend/routers/support.py
@@ -1,7 +1,6 @@
 import traceback
 import uuid
 from pathlib import Path
-from typing import Optional
 
 import httpx
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
@@ -77,7 +76,7 @@ def validate_file(file: UploadFile) -> None:
         )
 
 
-async def upload_file_to_slack(file: UploadFile, ticket_id: str, channel: str) -> Optional[dict]:
+async def upload_file_to_slack(file: UploadFile, ticket_id: str, channel: str) -> dict | None:
     """Upload file to Slack using the new external upload API.
 
     The old files.upload method has been deprecated by Slack. This function uses
@@ -221,7 +220,7 @@ async def upload_file_to_slack(file: UploadFile, ticket_id: str, channel: str) -
 
 async def send_to_slack(
     ticket_id: str, user: User, title: str, description: str, uploaded_files: list[dict] = None
-) -> Optional[str]:
+) -> str | None:
     """Send support ticket to Slack via webhook.
 
     Args:

--- a/backend/routers/tarot.py
+++ b/backend/routers/tarot.py
@@ -8,6 +8,7 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
+from config import settings
 from database import get_db
 from models import Card, DailyCardPull, Spread, User
 from routers.auth import get_current_user, get_optional_current_user
@@ -28,6 +29,7 @@ from services.streak_service import record_activity as record_streak_activity
 from services.subscription_service import SubscriptionService
 from tarot_reader import TarotReader
 from utils.error_handlers import TarotAPIException, ValidationError, logger
+from utils.metrics import record_tarot_reading
 from utils.rate_limiter import RATE_LIMITS, limiter
 
 router = APIRouter(prefix="/tarot", tags=["tarot"])
@@ -48,11 +50,7 @@ async def get_featured_cards(
     favorite deck; otherwise the default deck is used.
     """
     deck_id = (current_user.favorite_deck_id if current_user else None) or DEFAULT_DECK_ID
-    major_arcana = (
-        db.query(Card)
-        .filter(Card.suit == "Major Arcana", Card.deck_id == deck_id)
-        .all()
-    )
+    major_arcana = db.query(Card).filter(Card.suit == "Major Arcana", Card.deck_id == deck_id).all()
     if not major_arcana:
         major_arcana = db.query(Card).filter(Card.suit == "Major Arcana").all()
     if not major_arcana:
@@ -90,12 +88,7 @@ async def get_card_of_the_day(
         .all()
     )
     if not major_arcana:
-        major_arcana = (
-            db.query(Card)
-            .filter(Card.suit == "Major Arcana")
-            .order_by(Card.id.asc())
-            .all()
-        )
+        major_arcana = db.query(Card).filter(Card.suit == "Major Arcana").order_by(Card.id.asc()).all()
     if not major_arcana:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -212,6 +205,8 @@ async def get_reading(
         The meanings are contextually generated based on the user's concern.
     """
     start_time = time.time()
+    reading_type = f"{request_data.num_cards}_card"
+    reading_status = "error"
 
     try:
         # Check and consume turns before generating reading
@@ -226,6 +221,7 @@ async def get_reading(
                 extra={"user_id": current_user.id},
             )
         elif not turn_result.success:
+            reading_status = "insufficient_turns"
             raise HTTPException(
                 status_code=status.HTTP_402_PAYMENT_REQUIRED,
                 detail={
@@ -241,6 +237,7 @@ async def get_reading(
         if request_data.spread_id:
             spread = db.query(Spread).filter(Spread.id == request_data.spread_id).first()
             if not spread:
+                reading_status = "validation_error"
                 raise ValidationError(
                     message="Spread not found",
                     details={"spread_id": request_data.spread_id},
@@ -248,9 +245,11 @@ async def get_reading(
             # Use spread's card count, but allow override if num_cards is explicitly provided
             if request_data.num_cards == 3:  # Default value, use spread's count
                 request_data.num_cards = spread.num_cards
+                reading_type = f"{request_data.num_cards}_card"
 
         # Validate number of cards
         if request_data.num_cards < 1 or request_data.num_cards > 10:
+            reading_status = "validation_error"
             raise ValidationError(
                 message="Invalid number of cards",
                 details={"num_cards": "Must be between 1 and 10"},
@@ -298,6 +297,7 @@ async def get_reading(
                 "deck_id": current_user.favorite_deck_id,
             },
         )
+        reading_status = "success"
         return response_cards
 
     except ValidationError:
@@ -308,6 +308,13 @@ async def get_reading(
             extra={"user_id": current_user.id, "error": str(e)},
         )
         raise TarotAPIException(message="Error generating reading", details={"error": str(e)})
+    finally:
+        record_tarot_reading(
+            env=settings.FASTAPI_ENV,
+            reading_type=reading_type,
+            status=reading_status,
+            duration=time.time() - start_time,
+        )
 
 
 COMPATIBILITY_SPREAD_NAME = "Relationship Cross"
@@ -339,24 +346,27 @@ async def get_compatibility_reading(
     provided names. Consumes one turn (same as a standard reading).
     """
     start_time = time.time()
-
-    spread = db.query(Spread).filter(Spread.name == COMPATIBILITY_SPREAD_NAME).first()
-    if not spread:
-        raise TarotAPIException(
-            message="Compatibility spread is not configured",
-            details={"spread_name": COMPATIBILITY_SPREAD_NAME},
-        )
+    reading_type = "compatibility"
+    reading_status = "error"
 
     try:
+        spread = db.query(Spread).filter(Spread.name == COMPATIBILITY_SPREAD_NAME).first()
+        if not spread:
+            reading_status = "not_found"
+            raise TarotAPIException(
+                message="Compatibility spread is not configured",
+                details={"spread_name": COMPATIBILITY_SPREAD_NAME},
+            )
         subscription_service = SubscriptionService()
         turn_result = subscription_service.consume_user_turn(db, current_user, usage_context="reading")
 
         if not turn_result.success and current_user.is_specialized_premium:
             logger.logger.warning(
-                "Turn consumption failed but user is specialized premium – proceeding",
+                "Turn consumption failed but user is specialized premium - proceeding",
                 extra={"user_id": current_user.id},
             )
         elif not turn_result.success:
+            reading_status = "insufficient_turns"
             raise HTTPException(
                 status_code=status.HTTP_402_PAYMENT_REQUIRED,
                 detail={
@@ -408,6 +418,7 @@ async def get_compatibility_reading(
                 "duration": duration,
             },
         )
+        reading_status = "success"
 
         return CompatibilityReadingResponse(
             person_a=request_data.person_a,
@@ -427,8 +438,13 @@ async def get_compatibility_reading(
             "Error generating compatibility reading",
             extra={"user_id": current_user.id, "error": str(e)},
         )
-        raise TarotAPIException(
-            message="Error generating compatibility reading", details={"error": str(e)}
+        raise TarotAPIException(message="Error generating compatibility reading", details={"error": str(e)})
+    finally:
+        record_tarot_reading(
+            env=settings.FASTAPI_ENV,
+            reading_type=reading_type,
+            status=reading_status,
+            duration=time.time() - start_time,
         )
 
 
@@ -464,9 +480,7 @@ async def interpret_compatibility_reading(
             "Error interpreting compatibility reading",
             extra={"user_id": current_user.id, "error": str(e)},
         )
-        raise TarotAPIException(
-            message="Error interpreting compatibility reading", details={"error": str(e)}
-        )
+        raise TarotAPIException(message="Error interpreting compatibility reading", details={"error": str(e)})
 
 
 @router.post("/compatibility/interpret/stream")
@@ -570,9 +584,7 @@ async def get_library_cards(
     if suit:
         query = query.filter(Card.suit.ilike(f"%{suit}%"))
     if search:
-        query = query.filter(
-            or_(Card.name.ilike(f"%{search}%"), Card.rank.ilike(f"%{search}%"))
-        )
+        query = query.filter(or_(Card.name.ilike(f"%{search}%"), Card.rank.ilike(f"%{search}%")))
 
     cards = query.order_by(Card.suit, Card.numerology.asc().nullslast(), Card.id).all()
 
@@ -582,9 +594,7 @@ async def get_library_cards(
         if suit:
             query = query.filter(Card.suit.ilike(f"%{suit}%"))
         if search:
-            query = query.filter(
-                or_(Card.name.ilike(f"%{search}%"), Card.rank.ilike(f"%{search}%"))
-            )
+            query = query.filter(or_(Card.name.ilike(f"%{search}%"), Card.rank.ilike(f"%{search}%")))
         cards = query.order_by(Card.suit, Card.numerology.asc().nullslast(), Card.id).all()
 
     return cards

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, EmailStr
 
 from models import User
-from routers.auth import get_admin_user, get_current_user
+from routers.auth import get_admin_user
 from utils.celery_utils import (
     email_task_manager,
     notification_task_manager,

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -61,7 +61,7 @@ Version: 1.0.0
 
 import re
 from datetime import date, datetime
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
@@ -1555,14 +1555,14 @@ class JournalEntryCreate(BaseModel):
         is_favorite (bool): Whether entry is marked as favorite.
     """
 
-    reading_id: Optional[int] = None
+    reading_id: int | None = None
     reading_snapshot: dict[str, Any]
-    personal_notes: Optional[str] = None
-    mood_before: Optional[int] = Field(None, ge=1, le=10)
-    mood_after: Optional[int] = Field(None, ge=1, le=10)
-    outcome_rating: Optional[int] = Field(None, ge=1, le=5)
-    follow_up_date: Optional[datetime] = None
-    tags: Optional[list[str]] = []
+    personal_notes: str | None = None
+    mood_before: int | None = Field(None, ge=1, le=10)
+    mood_after: int | None = Field(None, ge=1, le=10)
+    outcome_rating: int | None = Field(None, ge=1, le=5)
+    follow_up_date: datetime | None = None
+    tags: list[str] | None = []
     is_favorite: bool = False
 
     @field_validator("personal_notes")
@@ -1602,13 +1602,13 @@ class JournalEntryUpdate(BaseModel):
         follow_up_completed (Optional[bool]): Whether follow-up was completed.
     """
 
-    personal_notes: Optional[str] = None
-    mood_after: Optional[int] = Field(None, ge=1, le=10)
-    outcome_rating: Optional[int] = Field(None, ge=1, le=5)
-    follow_up_date: Optional[datetime] = None
-    tags: Optional[list[str]] = None
-    is_favorite: Optional[bool] = None
-    follow_up_completed: Optional[bool] = None
+    personal_notes: str | None = None
+    mood_after: int | None = Field(None, ge=1, le=10)
+    outcome_rating: int | None = Field(None, ge=1, le=5)
+    follow_up_date: datetime | None = None
+    tags: list[str] | None = None
+    is_favorite: bool | None = None
+    follow_up_completed: bool | None = None
 
     @field_validator("personal_notes")
     def validate_personal_notes(cls, v):
@@ -1655,13 +1655,13 @@ class JournalEntryResponse(BaseModel):
 
     id: int
     user_id: int
-    reading_id: Optional[int]
+    reading_id: int | None
     reading_snapshot: dict[str, Any]
-    personal_notes: Optional[str]
-    mood_before: Optional[int]
-    mood_after: Optional[int]
-    outcome_rating: Optional[int]
-    follow_up_date: Optional[datetime]
+    personal_notes: str | None
+    mood_before: int | None
+    mood_after: int | None
+    outcome_rating: int | None
+    follow_up_date: datetime | None
     follow_up_completed: bool
     tags: list[str]
     is_favorite: bool
@@ -1684,7 +1684,7 @@ class PersonalCardMeaningCreate(BaseModel):
 
     card_id: int
     personal_meaning: str
-    emotional_keywords: Optional[list[str]] = []
+    emotional_keywords: list[str] | None = []
 
     @field_validator("personal_meaning")
     def validate_personal_meaning(cls, v):
@@ -1715,8 +1715,8 @@ class PersonalCardMeaningUpdate(BaseModel):
         emotional_keywords (Optional[List[str]]): Updated emotional associations.
     """
 
-    personal_meaning: Optional[str] = None
-    emotional_keywords: Optional[list[str]] = None
+    personal_meaning: str | None = None
+    emotional_keywords: list[str] | None = None
 
     @field_validator("personal_meaning")
     def validate_personal_meaning(cls, v):
@@ -1766,7 +1766,7 @@ class PersonalCardMeaningResponse(BaseModel):
     is_active: bool
     created_at: datetime
     updated_at: datetime
-    card: Optional[Card] = None
+    card: Card | None = None
 
     class Config:
         from_attributes = True
@@ -1794,9 +1794,9 @@ class JournalAnalytics(BaseModel):
     mood_trends: dict[str, Any]
     reading_frequency: dict[str, int]
     growth_metrics: dict[str, Any]
-    average_mood_improvement: Optional[float] = None
+    average_mood_improvement: float | None = None
     most_used_tags: list[dict[str, Any]]
-    follow_up_completion_rate: Optional[float] = None
+    follow_up_completion_rate: float | None = None
 
 
 class ReminderCreate(BaseModel):
@@ -1812,7 +1812,7 @@ class ReminderCreate(BaseModel):
     journal_entry_id: int
     reminder_type: str = Field(..., pattern="^(anniversary|follow_up|milestone)$")
     reminder_date: datetime
-    message: Optional[str] = None
+    message: str | None = None
 
     @field_validator("message")
     def validate_message(cls, v):
@@ -1843,11 +1843,11 @@ class ReminderResponse(BaseModel):
     journal_entry_id: int
     reminder_type: str
     reminder_date: datetime
-    message: Optional[str]
+    message: str | None
     is_sent: bool
     is_completed: bool
     created_at: datetime
-    journal_entry: Optional[JournalEntryResponse] = None
+    journal_entry: JournalEntryResponse | None = None
 
     class Config:
         from_attributes = True
@@ -1869,15 +1869,15 @@ class JournalFilters(BaseModel):
         search_notes (Optional[str]): Search in personal notes.
     """
 
-    tags: Optional[str] = None
+    tags: str | None = None
     favorite_only: bool = False
-    start_date: Optional[date] = None
-    end_date: Optional[date] = None
-    mood_min: Optional[int] = Field(None, ge=1, le=10)
-    mood_max: Optional[int] = Field(None, ge=1, le=10)
-    has_follow_up: Optional[bool] = None
-    completed_follow_up: Optional[bool] = None
-    search_notes: Optional[str] = None
+    start_date: date | None = None
+    end_date: date | None = None
+    mood_min: int | None = Field(None, ge=1, le=10)
+    mood_max: int | None = Field(None, ge=1, le=10)
+    has_follow_up: bool | None = None
+    completed_follow_up: bool | None = None
+    search_notes: str | None = None
 
     @field_validator("search_notes")
     def validate_search_notes(cls, v):
@@ -1921,7 +1921,7 @@ class SupportTicketResponse(BaseModel):
 
     message: str
     ticket_id: str
-    slack_message_id: Optional[str] = None
+    slack_message_id: str | None = None
 
 
 # --- Streaks & Achievements ---
@@ -1931,7 +1931,7 @@ class StreakResponse(BaseModel):
     current_streak: int
     longest_streak: int
     total_active_days: int
-    last_activity_date: Optional[date] = None
+    last_activity_date: date | None = None
     is_active_today: bool
 
 
@@ -1940,7 +1940,7 @@ class AchievementResponse(BaseModel):
     title: str
     description: str
     unlocked: bool
-    unlocked_at: Optional[datetime] = None
+    unlocked_at: datetime | None = None
 
 
 class StreakProgressResponse(BaseModel):
@@ -1964,7 +1964,7 @@ class RecentReadingEntry(BaseModel):
     id: int
     turn_type: str
     usage_context: str
-    feature_used: Optional[str] = None
+    feature_used: str | None = None
     consumed_at: datetime
 
     class Config:
@@ -1993,7 +1993,7 @@ class UserDashboardStats(BaseModel):
     current_streak: int
     longest_streak: int
     total_active_days: int
-    last_activity_date: Optional[date] = None
+    last_activity_date: date | None = None
     is_active_today: bool
     period_days: int
     usage_by_context: list[UsageBreakdown]
@@ -2011,7 +2011,7 @@ class WebPushKeys(BaseModel):
 class WebPushSubscribeRequest(BaseModel):
     endpoint: str = Field(..., min_length=8, max_length=2000)
     keys: WebPushKeys
-    user_agent: Optional[str] = Field(None, max_length=255)
+    user_agent: str | None = Field(None, max_length=255)
 
 
 class WebPushSubscribeResponse(BaseModel):

--- a/backend/scripts/cleanup_avatars.py
+++ b/backend/scripts/cleanup_avatars.py
@@ -23,11 +23,10 @@ Examples:
     python scripts/cleanup_avatars.py user --username john_doe --keep 1
 """
 
-import os
-import sys
 import argparse
+import sys
+from datetime import datetime
 from pathlib import Path
-from datetime import datetime, timedelta
 
 # Add backend to Python path
 sys.path.append(str(Path(__file__).parent.parent))
@@ -120,23 +119,23 @@ def find_orphaned_avatars(dry_run=False):
             print(f"     Age: {file_age.days} days")
 
             if dry_run:
-                print(f"     🔍 [DRY RUN] Would delete")
+                print("     🔍 [DRY RUN] Would delete")
             else:
                 try:
                     orphaned_file.unlink()
-                    print(f"     ✅ Deleted")
+                    print("     ✅ Deleted")
                 except Exception as e:
                     print(f"     ❌ Error deleting: {e}")
             print()
 
-        print(f"📊 Summary:")
+        print("📊 Summary:")
         print(f"   Orphaned files: {len(orphaned_files)}")
         print(f"   Total size: {total_size:,} bytes ({total_size/1024/1024:.1f} MB)")
 
         if dry_run:
-            print(f"   🔍 [DRY RUN] Files would be deleted")
+            print("   🔍 [DRY RUN] Files would be deleted")
         else:
-            print(f"   ✅ Files deleted")
+            print("   ✅ Files deleted")
 
         return len(orphaned_files)
 
@@ -188,18 +187,18 @@ def cleanup_old_avatars(keep_latest=1, dry_run=False):
                 print(f"         Age: {file_age.days} days, Size: {file_size:,} bytes")
 
                 if dry_run:
-                    print(f"         🔍 [DRY RUN] Would delete")
+                    print("         🔍 [DRY RUN] Would delete")
                 else:
                     try:
                         old_avatar.unlink()
-                        print(f"         ✅ Deleted")
+                        print("         ✅ Deleted")
                         total_deleted += 1
                     except Exception as e:
                         print(f"         ❌ Error deleting: {e}")
 
             print()
 
-        print(f"📊 Summary:")
+        print("📊 Summary:")
         print(f"   Total files deleted: {total_deleted}")
 
         return total_deleted
@@ -259,11 +258,11 @@ def cleanup_user_avatars(username, keep_latest=1, dry_run=False):
             print(f"      Size: {file_size:,} bytes")
 
             if dry_run:
-                print(f"      🔍 [DRY RUN] Would delete")
+                print("      🔍 [DRY RUN] Would delete")
             else:
                 try:
                     old_avatar.unlink()
-                    print(f"      ✅ Deleted successfully")
+                    print("      ✅ Deleted successfully")
                     deleted_count += 1
                 except Exception as e:
                     print(f"      ❌ Error deleting: {e}")
@@ -347,7 +346,7 @@ def main():
         parser.print_help()
         return
 
-    print(f"🛠️  Avatar Cleanup Tool")
+    print("🛠️  Avatar Cleanup Tool")
     print(f"📁 Avatar directory: {avatar_manager.upload_dir}")
     print()
 

--- a/backend/scripts/migrate_avatars_to_new_format.py
+++ b/backend/scripts/migrate_avatars_to_new_format.py
@@ -12,12 +12,12 @@ Arguments:
     --dry-run    Show what would be changed without making any modifications
 """
 
-import os
-import sys
-import shutil
 import argparse
-from pathlib import Path
+import os
+import shutil
+import sys
 from datetime import datetime
+from pathlib import Path
 
 # Add backend to Python path
 sys.path.append(str(Path(__file__).parent.parent))
@@ -122,16 +122,16 @@ def migrate_avatars(dry_run=False):
                 try:
                     # Copy file to new location
                     shutil.copy2(old_file_path, new_file_path)
-                    print(f"   ✅ Copied file successfully")
+                    print("   ✅ Copied file successfully")
 
                     # Update database
                     user.avatar_filename = new_filename
                     db.commit()
-                    print(f"   ✅ Updated database record")
+                    print("   ✅ Updated database record")
 
                     # Delete old file
                     old_file_path.unlink()
-                    print(f"   ✅ Deleted old file")
+                    print("   ✅ Deleted old file")
 
                     migrated_count += 1
 

--- a/backend/scripts/set_last_free_turns_reset_to_null.py
+++ b/backend/scripts/set_last_free_turns_reset_to_null.py
@@ -12,7 +12,7 @@ import sys
 from pathlib import Path
 
 from sqlalchemy import create_engine
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import sessionmaker
 
 # Set minimal environment variables to prevent validation errors
 os.environ.setdefault("MAIL_FROM", "test@example.com")

--- a/backend/services/subscription_service.py
+++ b/backend/services/subscription_service.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from config import settings
 from database import get_db
-from models import User, SubscriptionEvent, PaymentTransaction, TurnUsageHistory, CheckoutSession
+from models import CheckoutSession, PaymentTransaction, SubscriptionEvent, TurnUsageHistory, User
 from schemas import TurnConsumptionResult
 
 logger = logging.getLogger(__name__)

--- a/backend/tarot_reader.py
+++ b/backend/tarot_reader.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import random
+import time
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
@@ -10,6 +11,9 @@ from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 from sqlalchemy.orm import Session
+
+from config import settings
+from utils.metrics import record_openai_request
 
 # Configure logging
 logging.basicConfig(
@@ -153,7 +157,7 @@ class TarotReader:
             shuffled.extend(left)
             shuffled.extend(right)
             deck = shuffled
-            logger.info(f"Completed shuffle {i+1}/{num_shuffles}")
+            logger.info(f"Completed shuffle {i + 1}/{num_shuffles}")
 
         # Draw cards
         logger.info("Drawing cards...")
@@ -188,8 +192,8 @@ class TarotReader:
             drawn.append(card_copy)
             logger.info(
                 (
-                    f"Drew card {i+1}: {card_copy['name']} ({card_copy['orientation']}) in position "
-                    f"'{card_copy.get('position', f'Card {i+1}')}'"
+                    f"Drew card {i + 1}: {card_copy['name']} ({card_copy['orientation']}) in position "
+                    f"'{card_copy.get('position', f'Card {i + 1}')}'"
                 ),
             )
 
@@ -230,11 +234,33 @@ class TarotReader:
         logger.info("Generating reading with language model...")
         prompt = ChatPromptTemplate.from_template(template)
         chain = prompt | self.llm | self.output_parser
+        start_time = time.perf_counter()
+        model = getattr(self.llm, "model_name", settings.OPENAI_MODEL)
+        operation = "tarot_interpretation"
 
         # Generate the reading in streaming mode
-        async for chunk in chain.astream({"concern": concern, "cards": cards_text}):
-            yield chunk
-            await asyncio.sleep(0)  # Allow other tasks to run
+        try:
+            async for chunk in chain.astream({"concern": concern, "cards": cards_text}):
+                yield chunk
+                await asyncio.sleep(0)  # Allow other tasks to run
+        except Exception as exc:
+            record_openai_request(
+                env=settings.FASTAPI_ENV,
+                model=model,
+                operation=operation,
+                status="error",
+                duration=time.perf_counter() - start_time,
+                error_type=type(exc).__name__,
+            )
+            raise
+        else:
+            record_openai_request(
+                env=settings.FASTAPI_ENV,
+                model=model,
+                operation=operation,
+                status="success",
+                duration=time.perf_counter() - start_time,
+            )
 
         logger.info("Reading generation completed")
 
@@ -274,16 +300,39 @@ class TarotReader:
 
         prompt = ChatPromptTemplate.from_template(template)
         chain = prompt | self.llm | self.output_parser
-        async for chunk in chain.astream(
-            {
-                "person_a": person_a,
-                "person_b": person_b,
-                "focus_line": focus_line,
-                "cards": cards_text,
-            }
-        ):
-            yield chunk
-            await asyncio.sleep(0)
+        start_time = time.perf_counter()
+        model = getattr(self.llm, "model_name", settings.OPENAI_MODEL)
+        operation = "compatibility_interpretation"
+
+        try:
+            async for chunk in chain.astream(
+                {
+                    "person_a": person_a,
+                    "person_b": person_b,
+                    "focus_line": focus_line,
+                    "cards": cards_text,
+                }
+            ):
+                yield chunk
+                await asyncio.sleep(0)
+        except Exception as exc:
+            record_openai_request(
+                env=settings.FASTAPI_ENV,
+                model=model,
+                operation=operation,
+                status="error",
+                duration=time.perf_counter() - start_time,
+                error_type=type(exc).__name__,
+            )
+            raise
+        else:
+            record_openai_request(
+                env=settings.FASTAPI_ENV,
+                model=model,
+                operation=operation,
+                status="success",
+                duration=time.perf_counter() - start_time,
+            )
 
     async def create_compatibility_reading(
         self,
@@ -329,14 +378,36 @@ class TarotReader:
 
         prompt = ChatPromptTemplate.from_template(template)
         chain = prompt | self.llm | self.output_parser
-        result = await chain.ainvoke(
-            {
-                "person_a": person_a,
-                "person_b": person_b,
-                "focus_line": focus_line,
-                "cards": cards_text,
-            }
-        )
+        start_time = time.perf_counter()
+        model = getattr(self.llm, "model_name", settings.OPENAI_MODEL)
+        operation = "compatibility_interpretation"
+        try:
+            result = await chain.ainvoke(
+                {
+                    "person_a": person_a,
+                    "person_b": person_b,
+                    "focus_line": focus_line,
+                    "cards": cards_text,
+                }
+            )
+        except Exception as exc:
+            record_openai_request(
+                env=settings.FASTAPI_ENV,
+                model=model,
+                operation=operation,
+                status="error",
+                duration=time.perf_counter() - start_time,
+                error_type=type(exc).__name__,
+            )
+            raise
+        else:
+            record_openai_request(
+                env=settings.FASTAPI_ENV,
+                model=model,
+                operation=operation,
+                status="success",
+                duration=time.perf_counter() - start_time,
+            )
         logger.info("Compatibility reading generation completed")
         return result
 

--- a/backend/tasks/email_tasks.py
+++ b/backend/tasks/email_tasks.py
@@ -1,6 +1,7 @@
 import asyncio
 import inspect
 import logging
+import time
 from datetime import datetime, timedelta
 
 from celery import current_task
@@ -11,9 +12,19 @@ from celery_app import celery_app
 from config import settings
 from database import SessionLocal
 from models import Base, PasswordResetToken, User
+from utils.metrics import record_email_send
 
 # Setup logging
 logger = logging.getLogger(__name__)
+
+
+def _record_email_send(email_type: str, status: str, start_time: float) -> None:
+    record_email_send(
+        env=settings.FASTAPI_ENV,
+        email_type=email_type,
+        status=status,
+        duration=time.perf_counter() - start_time,
+    )
 
 """
 # Attempt to reuse the TestingSessionLocal defined in the unit tests' conftest, if available.
@@ -53,6 +64,7 @@ def send_password_reset_email_task(self, email: str, token: str, user_id: int | 
     Returns:
         dict: Task result with status and details
     """
+    email_type = "password_reset"
     try:
         # Create database session
         db = SessionLocal()
@@ -145,7 +157,14 @@ def send_password_reset_email_task(self, email: str, token: str, user_id: int | 
             # message.subtype = "html"
 
             # Send email
-            _send_email_sync(message)
+            start_time = time.perf_counter()
+            try:
+                _send_email_sync(message)
+            except Exception:
+                _record_email_send(email_type, "error", start_time)
+                raise
+            else:
+                _record_email_send(email_type, "success", start_time)
 
             logger.info(
                 "Password reset email sent successfully",
@@ -184,6 +203,7 @@ def send_welcome_email_task(self, email: str, username: str):
     Returns:
         dict: Task result with status and details
     """
+    email_type = "welcome"
     try:
         subject = "Welcome to ArcanaAI!"
         html_body = f"""
@@ -213,7 +233,14 @@ def send_welcome_email_task(self, email: str, username: str):
         )
 
         # Send email
-        _send_email_sync(message)
+        start_time = time.perf_counter()
+        try:
+            _send_email_sync(message)
+        except Exception:
+            _record_email_send(email_type, "error", start_time)
+            raise
+        else:
+            _record_email_send(email_type, "success", start_time)
 
         logger.info(
             "Welcome email sent successfully",
@@ -252,6 +279,7 @@ def send_reminder_email_task(self, email: str, username: str, reminder_type: str
     Returns:
         dict: Task result with status and details
     """
+    email_type = "reading_reminder"
     try:
         # Customize message based on reminder type and days since reading
         if reminder_type == "daily":
@@ -294,7 +322,14 @@ def send_reminder_email_task(self, email: str, username: str, reminder_type: str
         )
 
         # Send email
-        _send_email_sync(message)
+        start_time = time.perf_counter()
+        try:
+            _send_email_sync(message)
+        except Exception:
+            _record_email_send(email_type, "error", start_time)
+            raise
+        else:
+            _record_email_send(email_type, "success", start_time)
 
         logger.info(
             "Reminder email sent successfully",
@@ -346,6 +381,7 @@ def send_system_notification_email_task(
     Returns:
         dict: Task result with status and details
     """
+    email_type = "system_notification"
     try:
         successful_sends = []
         failed_sends = []
@@ -359,7 +395,14 @@ def send_system_notification_email_task(
                     subtype=MessageType.html,
                 )
 
-                _send_email_sync(message)
+                start_time = time.perf_counter()
+                try:
+                    _send_email_sync(message)
+                except Exception:
+                    _record_email_send(email_type, "error", start_time)
+                    raise
+                else:
+                    _record_email_send(email_type, "success", start_time)
                 successful_sends.append(email)
 
             except Exception as e:
@@ -415,6 +458,7 @@ def send_bulk_notification_email_task(
     Returns:
         dict: Task result with status and details
     """
+    email_type = "bulk_notification"
     try:
         successful_sends = []
         failed_sends = []
@@ -428,7 +472,14 @@ def send_bulk_notification_email_task(
                     subtype=MessageType.html,
                 )
 
-                _send_email_sync(message)
+                start_time = time.perf_counter()
+                try:
+                    _send_email_sync(message)
+                except Exception:
+                    _record_email_send(email_type, "error", start_time)
+                    raise
+                else:
+                    _record_email_send(email_type, "success", start_time)
                 successful_sends.append(email)
 
             except Exception as e:

--- a/backend/utils/avatar_utils.py
+++ b/backend/utils/avatar_utils.py
@@ -2,7 +2,6 @@ import os
 import traceback
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
 
 from fastapi import HTTPException, UploadFile
 from PIL import Image, ImageOps
@@ -13,7 +12,7 @@ from utils.error_handlers import logger
 class AvatarManager:
     """Manages avatar file uploads, storage, and processing."""
 
-    def __init__(self, upload_dir: Optional[str] = None):
+    def __init__(self, upload_dir: str | None = None):
         """Initialize the avatar manager.
 
         Args:
@@ -192,7 +191,7 @@ class AvatarManager:
         except Exception:
             return False
 
-    def get_avatar_path(self, filename: str) -> Optional[Path]:
+    def get_avatar_path(self, filename: str) -> Path | None:
         """Get the full path to an avatar file.
 
         Args:
@@ -212,7 +211,7 @@ class AvatarManager:
             raise HTTPException(status_code=400, detail="Invalid filename")
         return file_path if file_path.exists() else None
 
-    def get_avatar_url(self, filename: str, base_url: str = "") -> Optional[str]:
+    def get_avatar_url(self, filename: str, base_url: str = "") -> str | None:
         """Get the URL to access an avatar file.
 
         Args:
@@ -317,11 +316,11 @@ class NoOpAvatarManager:
         """Delete avatar (no-op, always returns True)."""
         return True
 
-    def get_avatar_path(self, filename: str) -> Optional[Path]:
+    def get_avatar_path(self, filename: str) -> Path | None:
         """Get avatar path (always returns None in local mode)."""
         return None
 
-    def get_avatar_url(self, filename: str, base_url: str = "") -> Optional[str]:
+    def get_avatar_url(self, filename: str, base_url: str = "") -> str | None:
         """Get avatar URL (returns placeholder URL)."""
         if not filename:
             return None

--- a/backend/utils/error_handlers.py
+++ b/backend/utils/error_handlers.py
@@ -10,6 +10,7 @@ from jose import jwt
 from sqlalchemy.exc import IntegrityError, OperationalError, SQLAlchemyError
 
 from config import settings
+from utils.metrics import record_application_error
 from utils.telegram_alerts import is_telegram_configured, send_500_error_alert, send_user_error_alert
 
 
@@ -144,6 +145,30 @@ async def maybe_send_vip_error_alert(request: Request, status_code: int, error: 
         chat_id=settings.TELEGRAM_CHAT_ID,
         client_host=request.client.host if request.client else None,
         request_payload=request_payload,
+    )
+
+
+def _route_handler_label(request: Request) -> str:
+    scope = getattr(request, "scope", {}) or {}
+    route = scope.get("route") if isinstance(scope, dict) else None
+    route_path = getattr(route, "path", None)
+    if isinstance(route_path, str):
+        return route_path
+
+    url = getattr(request, "url", None)
+    url_path = getattr(url, "path", None)
+    if isinstance(url_path, str):
+        return url_path
+    if isinstance(url, str):
+        return url
+    return "unknown"
+
+
+def _record_application_error(request: Request, exc: Exception, error_type: str | None = None) -> None:
+    record_application_error(
+        env=settings.FASTAPI_ENV,
+        error_type=error_type or type(exc).__name__,
+        handler=_route_handler_label(request),
     )
 
 
@@ -349,6 +374,7 @@ async def tarot_exception_handler(request: Request, exc: TarotAPIException):
         )
 
     await maybe_send_vip_error_alert(request, exc.status_code, exc)
+    _record_application_error(request, exc, type(exc).__name__)
 
     return JSONResponse(
         status_code=exc.status_code,
@@ -359,6 +385,7 @@ async def tarot_exception_handler(request: Request, exc: TarotAPIException):
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
     logger.log_request(request, error=exc)
     await maybe_send_vip_error_alert(request, status.HTTP_422_UNPROCESSABLE_ENTITY, exc)
+    _record_application_error(request, exc, "RequestValidationError")
     return JSONResponse(
         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
         content={
@@ -388,6 +415,7 @@ async def sqlalchemy_exception_handler(request: Request, exc: SQLAlchemyError):
         )
 
     await maybe_send_vip_error_alert(request, status.HTTP_500_INTERNAL_SERVER_ERROR, exc)
+    _record_application_error(request, exc, "SQLAlchemyError")
 
     return JSONResponse(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -415,6 +443,7 @@ async def general_exception_handler(request: Request, exc: Exception):
         )
 
     await maybe_send_vip_error_alert(request, status.HTTP_500_INTERNAL_SERVER_ERROR, exc)
+    _record_application_error(request, exc)
 
     return JSONResponse(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -426,6 +455,7 @@ async def general_exception_handler(request: Request, exc: Exception):
 async def integrity_error_handler(request: Request, exc: IntegrityError):
     logger.log_request(request, error=exc)
     await maybe_send_vip_error_alert(request, status.HTTP_409_CONFLICT, exc)
+    _record_application_error(request, exc, "IntegrityError")
     return JSONResponse(
         status_code=status.HTTP_409_CONFLICT,
         content={"error": "Database integrity error", "details": str(exc)},
@@ -435,6 +465,7 @@ async def integrity_error_handler(request: Request, exc: IntegrityError):
 async def operational_error_handler(request: Request, exc: OperationalError):
     logger.log_request(request, error=exc)
     await maybe_send_vip_error_alert(request, status.HTTP_503_SERVICE_UNAVAILABLE, exc)
+    _record_application_error(request, exc, "OperationalError")
     return JSONResponse(
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         content={"error": "Database operational error", "details": str(exc)},

--- a/backend/utils/error_handlers.py
+++ b/backend/utils/error_handlers.py
@@ -6,7 +6,7 @@ from typing import Any
 from fastapi import Request, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
-from jose import JWTError, jwt
+from jose import jwt
 from sqlalchemy.exc import IntegrityError, OperationalError, SQLAlchemyError
 
 from config import settings

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -1,0 +1,73 @@
+import time
+from collections.abc import Awaitable, Callable
+
+from fastapi import FastAPI, Request, Response
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+from starlette.responses import Response as StarletteResponse
+
+PROJECT = "arcana-ai"
+COMPONENT = "backend"
+
+http_requests_total = Counter(
+    "arcana_http_requests_total",
+    "HTTP requests handled by ArcanaAI.",
+    ["project", "component", "env", "method", "handler", "status"],
+)
+http_request_duration_seconds = Histogram(
+    "arcana_http_request_duration_seconds",
+    "HTTP request latency in seconds.",
+    ["project", "component", "env", "method", "handler"],
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10),
+)
+
+
+def _handler_name(request: Request) -> str:
+    """Return the name of the route handler for the given request."""
+    route = request.scope.get("route")
+    return getattr(route, "path", request.url.path)
+
+
+def setup_metrics(app: FastAPI, env: str) -> None:
+    """Setup Prometheus metrics for the FastAPI application."""
+
+    @app.middleware("http")
+    async def prometheus_http_metrics(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        """Implement the middleware to collect Prometheus metrics for HTTP requests."""
+        if request.url.path == "/metrics":
+            return await call_next(request)
+
+        start = time.perf_counter()
+        response = await call_next(request)
+        duration = time.perf_counter() - start
+        handler = _handler_name(request)
+        status = str(response.status_code)
+
+        http_requests_total.labels(
+            project=PROJECT,
+            component=COMPONENT,
+            env=env,
+            method=request.method,
+            handler=handler,
+            status=status,
+        ).inc()
+
+        http_request_duration_seconds.labels(
+            project=PROJECT,
+            component=COMPONENT,
+            env=env,
+            method=request.method,
+            handler=handler,
+        ).observe(duration)
+
+        return response
+
+    @app.get("/metrics", include_in_schema=False)
+    async def metrics() -> StarletteResponse:
+        """Implement endpoint to serve Prometheus metrics."""
+        return StarletteResponse(
+            content=generate_latest(),
+            media_type=CONTENT_TYPE_LATEST,
+        )

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -2,22 +2,142 @@ import time
 from collections.abc import Awaitable, Callable
 
 from fastapi import FastAPI, Request, Response
-from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, Histogram, generate_latest
 from starlette.responses import Response as StarletteResponse
 
 PROJECT = "arcana-ai"
 COMPONENT = "backend"
+COMMON_LABELS = ["project", "component", "env"]
 
 http_requests_total = Counter(
     "arcana_http_requests_total",
     "HTTP requests handled by ArcanaAI.",
-    ["project", "component", "env", "method", "handler", "status"],
+    COMMON_LABELS + ["method", "handler", "status"],
 )
 http_request_duration_seconds = Histogram(
     "arcana_http_request_duration_seconds",
     "HTTP request latency in seconds.",
-    ["project", "component", "env", "method", "handler"],
+    COMMON_LABELS + ["method", "handler"],
     buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10),
+)
+
+tarot_readings_total = Counter(
+    "arcana_tarot_readings_total",
+    "Tarot reading attempts by type and outcome.",
+    COMMON_LABELS + ["reading_type", "status"],
+)
+tarot_reading_duration_seconds = Histogram(
+    "arcana_tarot_reading_duration_seconds",
+    "Tarot reading duration in seconds.",
+    COMMON_LABELS + ["reading_type"],
+    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60),
+)
+
+auth_attempts_total = Counter(
+    "arcana_auth_attempts_total",
+    "Authentication and account-management attempts",
+    COMMON_LABELS + ["action", "status"],
+)
+
+db_queries_total = Counter(
+    "arcana_db_queries_total",
+    "Database queries attempts.",
+    COMMON_LABELS + ["operation", "table", "status"],
+)
+db_query_duration_seconds = Histogram(
+    "arcana_db_query_duration_seconds",
+    "Database query duration in seconds",
+    COMMON_LABELS + ["operation", "table"],
+    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10),
+)
+
+openai_requests_total = Counter(
+    "arcana_openai_requests_total",
+    "OpenAI requests by model, operation, and outcome.",
+    COMMON_LABELS + ["model", "operation", "status"],
+)
+openai_request_duration_seconds = Histogram(
+    "arcana_openai_request_duration_seconds",
+    "OpenAI request duration in seconds.",
+    COMMON_LABELS + ["model", "operation"],
+    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60),
+)
+openai_tokens_total = Counter(
+    "arcana_openai_tokens_total",
+    "OpenAI token usage.",
+    COMMON_LABELS + ["model", "token_type"],
+)
+openai_cost_usd_total = Counter(
+    "arcana_openai_cost_usd_total",
+    "Estimated OpenAI cost in USD.",
+    COMMON_LABELS + ["model"],
+)
+openai_errors_total = Counter(
+    "arcana_openai_errors_total",
+    "OpenAI errors by model and normalized error type.",
+    COMMON_LABELS + ["model", "error_type"],
+)
+
+chat_messages_total = Counter(
+    "arcana_chat_messages_total",
+    "Chat messages sent and received.",
+    COMMON_LABELS + ["role", "status"],
+)
+chat_conversations_total = Counter(
+    "arcana_chat_conversations_total",
+    "Chat conversation lifecycle events.",
+    COMMON_LABELS + ["source", "status"],
+)
+chat_conversations_active = Gauge(
+    "arcana_chat_conversations_active",
+    "Currently active chat conversations.",
+    COMMON_LABELS,
+)
+
+application_errors_total = Counter(
+    "arcana_application_errors_total",
+    "Application errors by normalized type and handler.",
+    COMMON_LABELS + ["error_type", "handler"],
+)
+
+celery_tasks_total = Counter(
+    "arcana_celery_tasks_total",
+    "Celery task executions by queue, task, and outcome.",
+    COMMON_LABELS + ["queue", "task_name", "status"],
+)
+celery_task_duration_seconds = Histogram(
+    "arcana_celery_task_duration_seconds",
+    "Celery task runtime in seconds.",
+    COMMON_LABELS + ["queue", "task_name"],
+    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 300, 900),
+)
+celery_task_failures_total = Counter(
+    "arcana_celery_task_failures_total",
+    "Celery task failures by normalized error type.",
+    COMMON_LABELS + ["queue", "task_name", "error_type"],
+)
+
+payments_total = Counter(
+    "arcana_payments_total",
+    "Payment events by provider, event type, and outcome.",
+    COMMON_LABELS + ["provider", "event_type", "status"],
+)
+payment_amount_usd_total = Counter(
+    "arcana_payment_amount_usd_total",
+    "Successful payment amount in USD.",
+    COMMON_LABELS + ["provider", "status"],
+)
+
+email_send_total = Counter(
+    "arcana_email_send_total",
+    "Email sends by type and outcome.",
+    COMMON_LABELS + ["email_type", "status"],
+)
+email_send_duration_seconds = Histogram(
+    "arcana_email_send_duration_seconds",
+    "Email send duration in seconds.",
+    COMMON_LABELS + ["email_type"],
+    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60),
 )
 
 
@@ -71,3 +191,230 @@ def setup_metrics(app: FastAPI, env: str) -> None:
             content=generate_latest(),
             media_type=CONTENT_TYPE_LATEST,
         )
+
+
+def base_labels(env: str) -> dict[str, str]:
+    """Return a dictionary of base labels for Prometheus metrics."""
+    return {"project": PROJECT, "component": COMPONENT, "env": env}
+
+
+def record_tarot_reading(
+    env: str,
+    reading_type: str,
+    status: str,
+    duration: float,
+) -> None:
+    """Record a tarot reading attempt in Prometheus metrics."""
+    labels = base_labels(env)
+    tarot_readings_total.labels(
+        **labels,
+        reading_type=reading_type,
+        status=status,
+    ).inc()
+    tarot_reading_duration_seconds.labels(
+        **labels,
+        reading_type=reading_type,
+    ).observe(duration)
+
+
+def record_auth_attempt(env: str, action: str, status: str) -> None:
+    """Record an authentication or account-management attempt."""
+    auth_attempts_total.labels(
+        **base_labels(env),
+        action=action,
+        status=status,
+    ).inc()
+
+
+def record_db_query(
+    env: str,
+    operation: str,
+    table: str,
+    status: str,
+    duration: float,
+) -> None:
+    """Record a database query attempt and duration."""
+    labels = base_labels(env)
+    db_queries_total.labels(
+        **labels,
+        operation=operation,
+        table=table,
+        status=status,
+    ).inc()
+    db_query_duration_seconds.labels(
+        **labels,
+        operation=operation,
+        table=table,
+    ).observe(duration)
+
+
+def record_openai_request(
+    env: str,
+    model: str,
+    operation: str,
+    status: str,
+    duration: float,
+    prompt_tokens: int = 0,
+    completion_tokens: int = 0,
+    cost_usd: float = 0.0,
+    error_type: str | None = None,
+) -> None:
+    """Record an OpenAI request, including optional tokens, cost, and error type."""
+    labels = base_labels(env)
+    openai_requests_total.labels(
+        **labels,
+        model=model,
+        operation=operation,
+        status=status,
+    ).inc()
+    openai_request_duration_seconds.labels(
+        **labels,
+        model=model,
+        operation=operation,
+    ).observe(duration)
+
+    if prompt_tokens > 0:
+        openai_tokens_total.labels(
+            **labels,
+            model=model,
+            token_type="prompt",
+        ).inc(prompt_tokens)
+    if completion_tokens > 0:
+        openai_tokens_total.labels(
+            **labels,
+            model=model,
+            token_type="completion",
+        ).inc(completion_tokens)
+    if cost_usd > 0:
+        openai_cost_usd_total.labels(
+            **labels,
+            model=model,
+        ).inc(cost_usd)
+    if error_type:
+        openai_errors_total.labels(
+            **labels,
+            model=model,
+            error_type=error_type,
+        ).inc()
+
+
+def record_chat_message(env: str, role: str, status: str) -> None:
+    """Record a chat message processed by the backend."""
+    chat_messages_total.labels(
+        **base_labels(env),
+        role=role,
+        status=status,
+    ).inc()
+
+
+def record_chat_conversation(env: str, source: str, status: str) -> None:
+    """Record a chat conversation lifecycle event."""
+    chat_conversations_total.labels(
+        **base_labels(env),
+        source=source,
+        status=status,
+    ).inc()
+
+
+def set_active_chat_conversations(env: str, count: int) -> None:
+    """Set the current active chat conversation gauge."""
+    chat_conversations_active.labels(**base_labels(env)).set(count)
+
+
+def increment_active_chat_conversations(env: str, amount: int = 1) -> None:
+    """Increase the active chat conversation gauge."""
+    chat_conversations_active.labels(**base_labels(env)).inc(amount)
+
+
+def decrement_active_chat_conversations(env: str, amount: int = 1) -> None:
+    """Decrease the active chat conversation gauge."""
+    chat_conversations_active.labels(**base_labels(env)).dec(amount)
+
+
+def record_application_error(env: str, error_type: str, handler: str) -> None:
+    """Record an application error with normalized labels."""
+    application_errors_total.labels(
+        **base_labels(env),
+        error_type=error_type,
+        handler=handler,
+    ).inc()
+
+
+def record_celery_task(
+    env: str,
+    queue: str,
+    task_name: str,
+    status: str,
+    duration: float | None = None,
+) -> None:
+    """Record a Celery task state and optional runtime."""
+    labels = base_labels(env)
+    celery_tasks_total.labels(
+        **labels,
+        queue=queue,
+        task_name=task_name,
+        status=status,
+    ).inc()
+    if duration is not None:
+        celery_task_duration_seconds.labels(
+            **labels,
+            queue=queue,
+            task_name=task_name,
+        ).observe(duration)
+
+
+def record_celery_failure(
+    env: str,
+    queue: str,
+    task_name: str,
+    error_type: str,
+) -> None:
+    """Record a Celery task failure with a normalized error type."""
+    celery_task_failures_total.labels(
+        **base_labels(env),
+        queue=queue,
+        task_name=task_name,
+        error_type=error_type,
+    ).inc()
+
+
+def record_payment_event(
+    env: str,
+    provider: str,
+    event_type: str,
+    status: str,
+    amount_usd: float = 0.0,
+) -> None:
+    """Record a payment event and optional successful amount."""
+    labels = base_labels(env)
+    payments_total.labels(
+        **labels,
+        provider=provider,
+        event_type=event_type,
+        status=status,
+    ).inc()
+    if amount_usd > 0:
+        payment_amount_usd_total.labels(
+            **labels,
+            provider=provider,
+            status=status,
+        ).inc(amount_usd)
+
+
+def record_email_send(
+    env: str,
+    email_type: str,
+    status: str,
+    duration: float,
+) -> None:
+    """Record an email send attempt and duration."""
+    labels = base_labels(env)
+    email_send_total.labels(
+        **labels,
+        email_type=email_type,
+        status=status,
+    ).inc()
+    email_send_duration_seconds.labels(
+        **labels,
+        email_type=email_type,
+    ).observe(duration)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -290,6 +290,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pillow" },
     { name = "pre-commit" },
+    { name = "prometheus-client" },
     { name = "propcache" },
     { name = "psycopg2-binary" },
     { name = "py-spy" },
@@ -375,6 +376,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=23.2" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
+    { name = "prometheus-client", specifier = ">=0.25.0" },
     { name = "propcache", specifier = ">=0.3.1" },
     { name = "psycopg2-binary", specifier = ">=2.9.9" },
     { name = "py-spy", specifier = ">=0.4.0" },
@@ -2619,6 +2621,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]

--- a/docs/grafana-monitoring-guide.md
+++ b/docs/grafana-monitoring-guide.md
@@ -2,7 +2,7 @@
 
 ArcanaAI no longer owns or runs Prometheus, Grafana, alert rules, or dashboard provisioning from this repository. The central monitoring stack is deployed from the standalone `central-monitoring` repo.
 
-This guide is for reimplementing ArcanaAI application metrics later and wiring them into that central stack. After the cleanup that introduced this guide, the backend does not expose `GET /metrics`.
+This guide is for reimplementing ArcanaAI application metrics and wiring them into that central stack. The cleanup that introduced this guide removed `GET /metrics`; after you re-add `setup_metrics(app, env=settings.FASTAPI_ENV)`, continue with the domain metrics below.
 
 ## 1. Architecture
 
@@ -81,7 +81,7 @@ import time
 from collections.abc import Awaitable, Callable
 
 from fastapi import FastAPI, Request, Response
-from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, Histogram, generate_latest
 from starlette.responses import Response as StarletteResponse
 
 PROJECT = "arcana-ai"
@@ -138,19 +138,1098 @@ from utils.metrics import setup_metrics
 setup_metrics(app, env=settings.FASTAPI_ENV)
 ```
 
-Add domain metrics where the domain work happens. Example:
+At this point, generic HTTP metrics are covered. The next step is to define
+the domain metrics below and record them beside the code that knows the
+business outcome. For example, HTTP middleware knows that `POST /tarot/reading`
+returned `200`, but `backend/routers/tarot.py` knows whether that request was a
+three-card reading, a compatibility reading, an insufficient-turns failure, or
+a successful card draw.
+
+## 5. Metrics To Define Now
+
+Add these definitions in `backend/utils/metrics.py` below the HTTP metrics you
+already created. Keep `project`, `component`, and `env` on every ArcanaAI
+application metric so central dashboards can filter with
+`project="arcana-ai"` and `component="backend"`.
 
 ```python
-tarot_readings_total.labels(
-    project="arcana-ai",
-    component="backend",
-    env=settings.FASTAPI_ENV,
-    reading_type="three_card",
-    status="success",
-).inc()
+COMMON_LABELS = ["project", "component", "env"]
+
+tarot_readings_total = Counter(
+    "arcana_tarot_readings_total",
+    "Tarot reading attempts by type and outcome.",
+    COMMON_LABELS + ["reading_type", "status"],
+)
+tarot_reading_duration_seconds = Histogram(
+    "arcana_tarot_reading_duration_seconds",
+    "Tarot reading duration in seconds.",
+    COMMON_LABELS + ["reading_type"],
+    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60),
+)
+
+auth_attempts_total = Counter(
+    "arcana_auth_attempts_total",
+    "Authentication and account-management attempts.",
+    COMMON_LABELS + ["action", "status"],
+)
+
+db_queries_total = Counter(
+    "arcana_db_queries_total",
+    "Database query attempts.",
+    COMMON_LABELS + ["operation", "table", "status"],
+)
+db_query_duration_seconds = Histogram(
+    "arcana_db_query_duration_seconds",
+    "Database query duration in seconds.",
+    COMMON_LABELS + ["operation", "table"],
+    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5),
+)
+
+openai_requests_total = Counter(
+    "arcana_openai_requests_total",
+    "OpenAI requests by model, operation, and outcome.",
+    COMMON_LABELS + ["model", "operation", "status"],
+)
+openai_request_duration_seconds = Histogram(
+    "arcana_openai_request_duration_seconds",
+    "OpenAI request duration in seconds.",
+    COMMON_LABELS + ["model", "operation"],
+    buckets=(0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60),
+)
+openai_tokens_total = Counter(
+    "arcana_openai_tokens_total",
+    "OpenAI token usage.",
+    COMMON_LABELS + ["model", "token_type"],
+)
+openai_cost_usd_total = Counter(
+    "arcana_openai_cost_usd_total",
+    "Estimated OpenAI cost in USD.",
+    COMMON_LABELS + ["model"],
+)
+openai_errors_total = Counter(
+    "arcana_openai_errors_total",
+    "OpenAI errors by model and normalized error type.",
+    COMMON_LABELS + ["model", "error_type"],
+)
+
+chat_messages_total = Counter(
+    "arcana_chat_messages_total",
+    "Chat messages processed.",
+    COMMON_LABELS + ["role", "status"],
+)
+chat_conversations_total = Counter(
+    "arcana_chat_conversations_total",
+    "Chat conversation lifecycle events.",
+    COMMON_LABELS + ["source", "status"],
+)
+chat_conversations_active = Gauge(
+    "arcana_chat_conversations_active",
+    "Currently active chat conversations.",
+    COMMON_LABELS,
+)
+
+application_errors_total = Counter(
+    "arcana_application_errors_total",
+    "Application errors by normalized type and handler.",
+    COMMON_LABELS + ["error_type", "handler"],
+)
+
+celery_tasks_total = Counter(
+    "arcana_celery_tasks_total",
+    "Celery task executions by queue, task, and outcome.",
+    COMMON_LABELS + ["queue", "task_name", "status"],
+)
+celery_task_duration_seconds = Histogram(
+    "arcana_celery_task_duration_seconds",
+    "Celery task runtime in seconds.",
+    COMMON_LABELS + ["queue", "task_name"],
+    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 300, 900),
+)
+celery_task_failures_total = Counter(
+    "arcana_celery_task_failures_total",
+    "Celery task failures by normalized error type.",
+    COMMON_LABELS + ["queue", "task_name", "error_type"],
+)
+
+payments_total = Counter(
+    "arcana_payments_total",
+    "Payment events by provider, event type, and outcome.",
+    COMMON_LABELS + ["provider", "event_type", "status"],
+)
+payment_amount_usd_total = Counter(
+    "arcana_payment_amount_usd_total",
+    "Successful payment amount in USD.",
+    COMMON_LABELS + ["provider", "status"],
+)
+
+email_send_total = Counter(
+    "arcana_email_send_total",
+    "Email sends by type and outcome.",
+    COMMON_LABELS + ["email_type", "status"],
+)
+email_send_duration_seconds = Histogram(
+    "arcana_email_send_duration_seconds",
+    "Email send duration in seconds.",
+    COMMON_LABELS + ["email_type"],
+    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60),
+)
 ```
 
-## 5. Recommended Metric Names
+Optional helper functions can keep call sites compact and consistent:
+
+```python
+def base_labels(env: str) -> dict[str, str]:
+    return {"project": PROJECT, "component": COMPONENT, "env": env}
+
+
+def record_tarot_reading(env: str, reading_type: str, status: str, duration: float) -> None:
+    labels = base_labels(env)
+    tarot_readings_total.labels(**labels, reading_type=reading_type, status=status).inc()
+    tarot_reading_duration_seconds.labels(**labels, reading_type=reading_type).observe(duration)
+```
+
+## 6. Where To Record Each Metric
+
+Use this as the implementation checklist. The metric belongs at the code path
+that has the most accurate outcome and label context.
+
+| Area | Primary files | Record |
+|---|---|---|
+| HTTP | `backend/utils/metrics.py` middleware | `arcana_http_requests_total`, `arcana_http_request_duration_seconds` for every non-`/metrics` request |
+| Tarot readings | `backend/routers/tarot.py` | `arcana_tarot_readings_total`, `arcana_tarot_reading_duration_seconds` in `/tarot/reading` and `/tarot/compatibility` |
+| Tarot interpretation | `backend/routers/tarot.py`, `backend/tarot_reader.py` | OpenAI metrics for compatibility interpretation and stream paths; use tarot metrics only for the card draw/read event |
+| Auth | `backend/routers/auth.py` | `arcana_auth_attempts_total` for `register`, `login`, `refresh`, `forgot_password`, and `reset_password` |
+| Database | `backend/database.py` SQLAlchemy engine events, or service-level wrappers where table is known | `arcana_db_queries_total`, `arcana_db_query_duration_seconds`; use `operation=select|insert|update|delete|other` and `table=unknown` if parsing table safely is not worth it |
+| OpenAI | `backend/tarot_reader.py`, `backend/routers/chat.py` | `arcana_openai_requests_total`, `arcana_openai_request_duration_seconds`, `arcana_openai_tokens_total`, `arcana_openai_cost_usd_total`, `arcana_openai_errors_total` |
+| Chat | `backend/routers/chat.py` | `arcana_chat_messages_total`, `arcana_chat_conversations_total`, `arcana_chat_conversations_active` |
+| Application errors | `backend/utils/error_handlers.py` | `arcana_application_errors_total` from normalized exception classes and route handlers |
+| Celery | `backend/celery_app.py` signals, or each module in `backend/tasks/` | `arcana_celery_tasks_total`, `arcana_celery_task_duration_seconds`, `arcana_celery_task_failures_total` |
+| Payments | `backend/routers/subscription.py`, `backend/services/subscription_service.py` | `arcana_payments_total`, `arcana_payment_amount_usd_total` for Lemon Squeezy checkout/webhooks and Ethereum payments |
+| Email | `backend/tasks/email_tasks.py`, legacy direct send paths in `backend/routers/auth.py` if still used | `arcana_email_send_total`, `arcana_email_send_duration_seconds` |
+
+Suggested status values:
+
+- Business outcomes: `success`, `error`, `validation_error`, `insufficient_turns`, `not_found`, `rejected`, `queued`.
+- HTTP status: keep the numeric status string, such as `200`, `401`, `500`.
+- Celery status: `started`, `success`, `failure`, `retry`, `revoked`.
+- Payment status: `created`, `paid`, `failed`, `refunded`, `ignored`, `signature_error`.
+
+Suggested operation values:
+
+- OpenAI: `chat_message`, `tarot_interpretation`, `compatibility_interpretation`, `title_generation`.
+- Auth: `register`, `login`, `refresh`, `forgot_password`, `reset_password`.
+- Email: `password_reset`, `welcome`, `reading_reminder`, `system_notification`, `bulk_notification`.
+- Payments: `checkout_created`, `webhook_received`, `subscription_created`, `subscription_updated`, `order_created`, `ethereum_payment`.
+
+## 7. Copy-Ready Implementation Snippets
+
+These examples use the helper functions in `backend/utils/metrics.py`. Keep the
+imports local to the file where the metric is recorded. Do not attach raw user
+data, request IDs, prompts, emails, payment IDs, or exception messages to
+labels.
+
+### 7.1 Tarot Reading Metrics
+
+File: `backend/routers/tarot.py`
+
+Metrics covered:
+
+- `arcana_tarot_readings_total`
+- `arcana_tarot_reading_duration_seconds`
+
+At the top of the file, add `settings` and `record_tarot_reading` beside the
+existing imports:
+
+```python
+from config import settings
+from utils.metrics import record_tarot_reading
+```
+
+In `get_reading`, after the existing `start_time = ...` line, add:
+
+```python
+reading_type = f"{request_data.num_cards}_card"
+reading_status = "error"
+```
+
+In `get_reading`, before the `raise HTTPException(...)` for no turns, add:
+
+```python
+reading_status = "insufficient_turns"
+```
+
+In `get_reading`, before the `raise ValidationError(...)` for a missing spread
+or invalid card count, add:
+
+```python
+reading_status = "validation_error"
+```
+
+In `get_reading`, immediately after `request_data.num_cards = spread.num_cards`,
+add:
+
+```python
+reading_type = f"{request_data.num_cards}_card"
+```
+
+In `get_reading`, immediately before `return response_cards`, add:
+
+```python
+reading_status = "success"
+```
+
+In `get_reading`, add a `finally` block after the existing `except` blocks:
+
+```python
+finally:
+    record_tarot_reading(
+        env=settings.FASTAPI_ENV,
+        reading_type=reading_type,
+        status=reading_status,
+        duration=time.time() - start_time,
+    )
+```
+
+In `get_compatibility_reading`, after the existing `start_time = ...` line, add:
+
+```python
+reading_type = "compatibility"
+reading_status = "error"
+```
+
+In `get_compatibility_reading`, move the configured spread lookup inside the
+existing `try` block if it is currently above it. Before the
+`TarotAPIException` raised for a missing compatibility spread, add:
+
+```python
+reading_status = "not_found"
+```
+
+In `get_compatibility_reading`, before the `raise HTTPException(...)` for no
+turns, add:
+
+```python
+reading_status = "insufficient_turns"
+```
+
+In `get_compatibility_reading`, immediately before returning
+`CompatibilityReadingResponse(...)`, add:
+
+```python
+reading_status = "success"
+```
+
+In `get_compatibility_reading`, add a `finally` block after the existing
+`except` blocks:
+
+```python
+finally:
+    record_tarot_reading(
+        env=settings.FASTAPI_ENV,
+        reading_type=reading_type,
+        status=reading_status,
+        duration=time.time() - start_time,
+    )
+```
+
+Use these status labels:
+
+- `success`: cards were drawn and returned.
+- `insufficient_turns`: the user had no available turn.
+- `validation_error`: bad card count, missing spread, or invalid request data.
+- `not_found`: required configured spread is missing.
+- `error`: unexpected failure.
+
+### 7.2 Auth Metrics
+
+File: `backend/routers/auth.py`
+
+Metric covered:
+
+- `arcana_auth_attempts_total`
+
+At the top of the file, add the helper import beside the existing imports:
+
+```python
+from config import settings
+from utils.metrics import record_auth_attempt
+```
+
+In `register`, after the user is created and before the success `return`, add:
+
+```python
+record_auth_attempt(settings.FASTAPI_ENV, action="register", status="success")
+```
+
+In `register`, before raising validation errors such as duplicate username or
+email, add:
+
+```python
+record_auth_attempt(settings.FASTAPI_ENV, action="register", status="validation_error")
+```
+
+In `register`, inside the generic exception path and before re-raising, add:
+
+```python
+record_auth_attempt(settings.FASTAPI_ENV, action="register", status="error")
+```
+
+In `login`, before raising invalid-user or invalid-password errors, add:
+
+```python
+record_auth_attempt(settings.FASTAPI_ENV, action="login", status="rejected")
+```
+
+In `login`, immediately before returning the token response, add:
+
+```python
+record_auth_attempt(settings.FASTAPI_ENV, action="login", status="success")
+```
+
+In `login`, inside the unexpected exception path and before re-raising, add:
+
+```python
+record_auth_attempt(settings.FASTAPI_ENV, action="login", status="error")
+```
+
+Use the same placement pattern for `refresh`, `forgot_password`, and
+`reset_password`: record `success` before the success return, `rejected` for
+bad credentials/tokens, `validation_error` for malformed input, and `error` for
+unexpected exceptions.
+
+### 7.3 OpenAI Metrics
+
+Files: `backend/tarot_reader.py`, `backend/routers/chat.py`
+
+Metrics covered:
+
+- `arcana_openai_requests_total`
+- `arcana_openai_request_duration_seconds`
+- `arcana_openai_tokens_total`
+- `arcana_openai_cost_usd_total`
+- `arcana_openai_errors_total`
+
+At the top of the file that makes the OpenAI/LangChain call, add any missing
+imports:
+
+```python
+import time
+
+from config import settings
+from utils.metrics import record_openai_request
+```
+
+This repo has two OpenAI call shapes:
+
+- `backend/tarot_reader.py` builds a LangChain `chain`, then calls
+  `chain.astream(...)` or `chain.ainvoke(...)`.
+- `backend/routers/chat.py` calls `llm.bind_tools(...).invoke(...)` and
+  `llm.astream(...)` directly.
+
+Use `settings.OPENAI_MODEL` for the model label. The older
+`settings.OPENAI_MODEL_NAME` name is not used in this repo.
+Cost metrics are only recorded when token usage is available and the optional
+`OPENAI_INPUT_COST_USD_PER_1M_TOKENS` and
+`OPENAI_OUTPUT_COST_USD_PER_1M_TOKENS` settings are configured.
+
+In `backend/tarot_reader.py`, in `create_reading`, immediately after:
+
+```python
+chain = prompt | self.llm | self.output_parser
+```
+
+add:
+
+```python
+start_time = time.perf_counter()
+model = settings.OPENAI_MODEL
+operation = "tarot_interpretation"
+```
+
+Replace only the existing streaming loop shown below with a `try` / `except` /
+`else` wrapper. Keep the existing payload exactly as it is:
+
+```python
+try:
+    async for chunk in chain.astream({"concern": concern, "cards": cards_text}):
+        yield chunk
+        await asyncio.sleep(0)
+except Exception as exc:
+    record_openai_request(
+        env=settings.FASTAPI_ENV,
+        model=model,
+        operation=operation,
+        status="error",
+        duration=time.perf_counter() - start_time,
+        error_type=type(exc).__name__,
+    )
+    raise
+else:
+    record_openai_request(
+        env=settings.FASTAPI_ENV,
+        model=model,
+        operation=operation,
+        status="success",
+        duration=time.perf_counter() - start_time,
+    )
+```
+
+In `backend/tarot_reader.py`, in `stream_compatibility_reading`, immediately
+after:
+
+```python
+chain = prompt | self.llm | self.output_parser
+```
+
+add:
+
+```python
+start_time = time.perf_counter()
+model = settings.OPENAI_MODEL
+operation = "compatibility_interpretation"
+```
+
+Then replace only the existing streaming loop shown below with a `try` /
+`except` / `else` wrapper. Keep this existing payload exactly:
+
+```python
+try:
+    async for chunk in chain.astream(
+        {
+            "person_a": person_a,
+            "person_b": person_b,
+            "focus_line": focus_line,
+            "cards": cards_text,
+        }
+    ):
+        yield chunk
+        await asyncio.sleep(0)
+except Exception as exc:
+    record_openai_request(
+        env=settings.FASTAPI_ENV,
+        model=model,
+        operation=operation,
+        status="error",
+        duration=time.perf_counter() - start_time,
+        error_type=type(exc).__name__,
+    )
+    raise
+else:
+    record_openai_request(
+        env=settings.FASTAPI_ENV,
+        model=model,
+        operation=operation,
+        status="success",
+        duration=time.perf_counter() - start_time,
+    )
+```
+
+In `backend/tarot_reader.py`, in `create_compatibility_reading`, immediately
+before:
+
+```python
+result = await chain.ainvoke(
+    {
+        "person_a": person_a,
+        "person_b": person_b,
+        "focus_line": focus_line,
+        "cards": cards_text,
+    }
+)
+```
+
+add:
+
+```python
+start_time = time.perf_counter()
+model = settings.OPENAI_MODEL
+operation = "compatibility_interpretation"
+```
+
+Then wrap that single assignment in `try` / `except` / `else`. Keep the
+existing payload exactly:
+
+```python
+try:
+    result = await chain.ainvoke(
+        {
+            "person_a": person_a,
+            "person_b": person_b,
+            "focus_line": focus_line,
+            "cards": cards_text,
+        }
+    )
+except Exception as exc:
+    record_openai_request(
+        env=settings.FASTAPI_ENV,
+        model=model,
+        operation=operation,
+        status="error",
+        duration=time.perf_counter() - start_time,
+        error_type=type(exc).__name__,
+    )
+    raise
+else:
+    record_openai_request(
+        env=settings.FASTAPI_ENV,
+        model=model,
+        operation=operation,
+        status="success",
+        duration=time.perf_counter() - start_time,
+    )
+```
+
+Keep the existing `logger.info("Compatibility reading generation completed")`
+and `return result` after this wrapper.
+
+In `backend/routers/chat.py`, immediately before each direct model call, add
+the same timer and label setup:
+
+```python
+start_time = time.perf_counter()
+model = settings.OPENAI_MODEL
+operation = "chat_message"
+```
+
+Direct model-call anchors in `backend/routers/chat.py` are:
+
+- `llm_response = llm.bind_tools(available_tools).invoke(messages_for_llm)`
+- `llm_response = llm.bind_tools([DRAW_CARDS_TOOL]).invoke(messages_for_llm)`
+- `async for chunk in llm.astream(messages_for_llm):`
+
+Immediately after each successful `.invoke(...)` call returns, add:
+
+```python
+usage = getattr(llm_response, "usage_metadata", {}) or {}
+prompt_tokens = int(usage.get("input_tokens", 0))
+completion_tokens = int(usage.get("output_tokens", 0))
+record_openai_request(
+    env=settings.FASTAPI_ENV,
+    model=model,
+    operation=operation,
+    status="success",
+    duration=time.perf_counter() - start_time,
+    prompt_tokens=prompt_tokens,
+    completion_tokens=completion_tokens,
+)
+```
+
+Wrap each `.invoke(...)` call in `try` / `except`, and inside `except Exception
+as exc:` add this before re-raising:
+
+```python
+record_openai_request(
+    env=settings.FASTAPI_ENV,
+    model=model,
+    operation=operation,
+    status="error",
+    duration=time.perf_counter() - start_time,
+    error_type=type(exc).__name__,
+)
+```
+
+For the `llm.astream(messages_for_llm)` streaming block, use the same
+`try` / `except` / `else` wrapper shown for `chain.astream(...)`. Streaming
+chunks usually do not expose token usage, so record latency and request status
+there, and leave token/cost fields at their default values unless you later
+instrument a lower-level response that exposes usage metadata.
+
+Recommended `operation` values:
+
+- `chat_message` for normal chat replies.
+- `tarot_interpretation` for reading interpretation generation.
+- `compatibility_interpretation` for relationship reading interpretation.
+- `title_generation` for chat rename/title tool flows.
+
+### 7.4 Chat Metrics
+
+File: `backend/routers/chat.py`
+
+Metrics covered:
+
+- `arcana_chat_messages_total`
+- `arcana_chat_conversations_total`
+- `arcana_chat_conversations_active`
+
+At the top of the file, add the helpers beside the existing imports:
+
+```python
+from config import settings
+from utils.metrics import (
+    decrement_active_chat_conversations,
+    increment_active_chat_conversations,
+    record_chat_conversation,
+    record_chat_message,
+    set_active_chat_conversations,
+)
+```
+
+In the session creation endpoint, immediately after the `db.commit()` that
+persists the new session, add:
+
+```python
+record_chat_conversation(settings.FASTAPI_ENV, source="api", status="created")
+increment_active_chat_conversations(settings.FASTAPI_ENV)
+```
+
+In the same endpoint, inside its exception path and before re-raising, add:
+
+```python
+record_chat_conversation(settings.FASTAPI_ENV, source="api", status="error")
+```
+
+In the message endpoint, after the user's message is persisted successfully,
+add:
+
+```python
+record_chat_message(settings.FASTAPI_ENV, role="user", status="success")
+```
+
+In the message endpoint, after the assistant response is persisted successfully,
+add:
+
+```python
+record_chat_message(settings.FASTAPI_ENV, role="assistant", status="success")
+```
+
+In the message endpoint, inside the exception path before re-raising, add:
+
+```python
+record_chat_message(settings.FASTAPI_ENV, role="assistant", status="error")
+```
+
+In the delete-session endpoint, after the delete/soft-delete commit succeeds,
+add:
+
+```python
+record_chat_conversation(settings.FASTAPI_ENV, source="api", status="deleted")
+decrement_active_chat_conversations(settings.FASTAPI_ENV)
+```
+
+If you compute active conversation count directly, add this immediately after
+that query:
+
+```python
+set_active_chat_conversations(settings.FASTAPI_ENV, active_count)
+```
+
+### 7.5 Database Metrics
+
+File: `backend/database.py`
+
+Metrics covered:
+
+- `arcana_db_queries_total`
+- `arcana_db_query_duration_seconds`
+
+At the top of the file, add any missing imports beside the existing SQLAlchemy
+and settings imports:
+
+```python
+import time
+
+from sqlalchemy import event
+
+from config import settings
+from utils.metrics import record_db_query
+```
+
+Immediately after the existing `engine = create_engine(...)` statement, add a
+listener that stores the query start time:
+
+```python
+@event.listens_for(engine, "before_cursor_execute")
+def track_db_query_start(conn, cursor, statement, parameters, context, executemany):
+    context._arcana_query_start_time = time.perf_counter()
+```
+
+Immediately after `track_db_query_start`, add the success recorder:
+
+```python
+@event.listens_for(engine, "after_cursor_execute")
+def track_db_query_success(conn, cursor, statement, parameters, context, executemany):
+    started = getattr(context, "_arcana_query_start_time", None)
+    duration = time.perf_counter() - started if started else 0.0
+    statement_text = (statement or "").strip()
+    operation = statement_text.split(maxsplit=1)[0].lower() if statement_text else "unknown"
+
+    record_db_query(
+        env=settings.FASTAPI_ENV,
+        operation=operation,
+        table="unknown",
+        status="success",
+        duration=duration,
+    )
+```
+
+Immediately after `track_db_query_success`, add the failure recorder:
+
+```python
+@event.listens_for(engine, "handle_error")
+def track_db_query_error(exception_context):
+    statement_text = (getattr(exception_context, "statement", None) or "").strip()
+    operation = statement_text.split(maxsplit=1)[0].lower() if statement_text else "unknown"
+
+    record_db_query(
+        env=settings.FASTAPI_ENV,
+        operation=operation,
+        table="unknown",
+        status="error",
+        duration=0.0,
+    )
+```
+
+If you prefer service-level DB metrics instead of SQLAlchemy engine events, add
+`record_db_query(...)` immediately after the specific query succeeds and inside
+the same block's exception path before re-raising.
+
+Use `table="unknown"` unless you can safely derive a bounded table name. Do not
+parse arbitrary SQL into labels if it can create high-cardinality values.
+
+### 7.6 Application Error Metrics
+
+File: `backend/utils/error_handlers.py`
+
+Metric covered:
+
+- `arcana_application_errors_total`
+
+At the top of the file, add the helper import beside the existing settings
+import:
+
+```python
+from utils.metrics import record_application_error
+```
+
+In `general_exception_handler`, immediately before the existing
+`return JSONResponse(...)`, add:
+
+```python
+route = request.scope.get("route")
+handler = getattr(route, "path", request.url.path)
+record_application_error(
+    env=settings.FASTAPI_ENV,
+    error_type=type(exc).__name__,
+    handler=handler,
+)
+```
+
+In custom handlers such as validation, authentication, or database exception
+handlers, use the same placement: add `record_application_error(...)`
+immediately before the handler returns its `JSONResponse`.
+
+Use normalized `error_type` values such as `ValidationError`,
+`AuthenticationError`, `OperationalError`, or `SQLAlchemyError`. Do not use raw
+exception messages as labels.
+
+### 7.7 Celery Metrics
+
+File: `backend/celery_app.py`
+
+Metrics covered:
+
+- `arcana_celery_tasks_total`
+- `arcana_celery_task_duration_seconds`
+- `arcana_celery_task_failures_total`
+
+At the top of the file, add these imports beside the existing Celery imports:
+
+```python
+import time
+
+from celery.signals import task_failure, task_postrun, task_prerun, task_retry
+
+from config import settings
+from utils.metrics import record_celery_failure, record_celery_task
+```
+
+Immediately after the existing `celery_app.conf.update(...)` block, add this
+queue-label helper:
+
+```python
+def _queue_name(task) -> str:
+    delivery_info = getattr(getattr(task, "request", None), "delivery_info", {}) or {}
+    return delivery_info.get("routing_key") or delivery_info.get("exchange") or "unknown"
+```
+
+Immediately after `_queue_name`, add the task-start signal:
+
+```python
+@task_prerun.connect
+def track_task_start(sender=None, task_id=None, task=None, **kwargs):
+    task.request._arcana_task_start_time = time.perf_counter()
+    record_celery_task(
+        env=settings.FASTAPI_ENV,
+        queue=_queue_name(task),
+        task_name=sender.name,
+        status="started",
+    )
+```
+
+Immediately after `track_task_start`, add the task-completion signal:
+
+```python
+@task_postrun.connect
+def track_task_done(sender=None, task_id=None, task=None, state=None, **kwargs):
+    started = getattr(task.request, "_arcana_task_start_time", None)
+    duration = time.perf_counter() - started if started else None
+    status = "success" if state == "SUCCESS" else str(state or "unknown").lower()
+
+    record_celery_task(
+        env=settings.FASTAPI_ENV,
+        queue=_queue_name(task),
+        task_name=sender.name,
+        status=status,
+        duration=duration,
+    )
+```
+
+Immediately after `track_task_done`, add the task-failure signal:
+
+```python
+@task_failure.connect
+def track_task_failure(sender=None, task_id=None, exception=None, task=None, **kwargs):
+    record_celery_failure(
+        env=settings.FASTAPI_ENV,
+        queue=_queue_name(task),
+        task_name=sender.name,
+        error_type=type(exception).__name__ if exception else "unknown",
+    )
+```
+
+Immediately after `track_task_failure`, add the retry signal:
+
+```python
+@task_retry.connect
+def track_task_retry(sender=None, request=None, reason=None, **kwargs):
+    delivery_info = getattr(request, "delivery_info", {}) or {}
+    queue = delivery_info.get("routing_key") or delivery_info.get("exchange") or "unknown"
+
+    record_celery_task(
+        env=settings.FASTAPI_ENV,
+        queue=queue,
+        task_name=sender.name,
+        status="retry",
+    )
+```
+
+Keep `queue` and `task_name` bounded. Use the Celery queue name and task name,
+not task IDs or argument values.
+
+### 7.8 Payment Metrics
+
+Files: `backend/routers/subscription.py`,
+`backend/services/subscription_service.py`
+
+Metrics covered:
+
+- `arcana_payments_total`
+- `arcana_payment_amount_usd_total`
+
+At the top of `backend/routers/subscription.py`, add the helper import beside
+the existing settings/service imports:
+
+```python
+from config import settings
+from utils.metrics import record_payment_event
+```
+
+In `create_checkout_session`, immediately after this statement succeeds:
+
+```python
+checkout_url = await subscription_service.create_checkout_url(current_user, request.product_variant, db)
+```
+
+add:
+
+```python
+record_payment_event(
+    settings.FASTAPI_ENV,
+    provider="lemon_squeezy",
+    event_type="checkout_created",
+    status="created",
+)
+```
+
+In `create_checkout_session`, inside `except ValueError as e:` and before
+`raise HTTPException(...)`, add:
+
+```python
+record_payment_event(
+    settings.FASTAPI_ENV,
+    provider="lemon_squeezy",
+    event_type="checkout_created",
+    status="validation_error",
+)
+```
+
+In `create_checkout_session`, inside `except Exception as e:` and before
+`raise HTTPException(...)`, add:
+
+```python
+record_payment_event(
+    settings.FASTAPI_ENV,
+    provider="lemon_squeezy",
+    event_type="checkout_created",
+    status="error",
+)
+```
+
+In `handle_lemon_squeezy_webhook`, immediately after `event_data = json.loads(payload)`,
+add:
+
+```python
+event_name = event_data.get("meta", {}).get("event_name", "unknown")
+record_payment_event(
+    settings.FASTAPI_ENV,
+    provider="lemon_squeezy",
+    event_type=event_name,
+    status="received",
+)
+```
+
+In `handle_lemon_squeezy_webhook`, before the invalid-signature
+`raise HTTPException(...)`, add:
+
+```python
+record_payment_event(
+    settings.FASTAPI_ENV,
+    provider="lemon_squeezy",
+    event_type="webhook_received",
+    status="signature_error",
+)
+```
+
+In `handle_lemon_squeezy_webhook`, immediately after
+`subscription_service.process_webhook_event(db, event_data)` succeeds, add:
+
+```python
+amount_usd = extract_amount_usd(event_data)
+record_payment_event(
+    settings.FASTAPI_ENV,
+    provider="lemon_squeezy",
+    event_type=event_name,
+    status="paid" if event_name == "order_created" else "success",
+    amount_usd=amount_usd,
+)
+```
+
+Add `extract_amount_usd(event_data)` as a small local helper only if the service
+does not already expose a normalized amount. It should return `None` when the
+webhook does not include a purchase amount.
+
+In `handle_lemon_squeezy_webhook`, inside `except json.JSONDecodeError:` and
+before `raise HTTPException(...)`, add:
+
+```python
+record_payment_event(
+    settings.FASTAPI_ENV,
+    provider="lemon_squeezy",
+    event_type="webhook_received",
+    status="invalid_json",
+)
+```
+
+In `handle_lemon_squeezy_webhook`, inside the generic `except Exception:` and
+before `raise HTTPException(...)`, add:
+
+```python
+record_payment_event(
+    settings.FASTAPI_ENV,
+    provider="lemon_squeezy",
+    event_type=locals().get("event_name", "webhook_received"),
+    status="error",
+)
+```
+
+In `process_ethereum_payment`, immediately after the `if not result["success"]:`
+block and before `return EthereumPaymentResponse(...)`, add:
+
+```python
+record_payment_event(
+    settings.FASTAPI_ENV,
+    provider="ethereum",
+    event_type="ethereum_payment",
+    status="paid",
+    amount_usd=amount_usd,
+)
+```
+
+In `process_ethereum_payment`, before the `raise HTTPException(...)` for failed
+verification, add the same metric with `status="verification_failed"` and no
+`amount_usd`.
+
+In `process_ethereum_payment`, inside the generic `except Exception as e:` and
+before `raise HTTPException(...)`, add the same metric with `status="error"`
+and no `amount_usd`.
+
+### 7.9 Email Metrics
+
+File: `backend/tasks/email_tasks.py`
+
+Metrics covered:
+
+- `arcana_email_send_total`
+- `arcana_email_send_duration_seconds`
+
+At the top of the file, add any missing imports beside the existing task
+imports:
+
+```python
+import time
+
+from utils.metrics import record_email_send
+```
+
+For each task function, set a bounded `email_type` near the start of the
+function body:
+
+```python
+email_type = "password_reset"
+```
+
+Use one of these values:
+
+- `password_reset` in `send_password_reset_email_task`.
+- `welcome` in `send_welcome_email_task`.
+- `reading_reminder` in `send_reminder_email_task`.
+- `system_notification` in `send_system_notification_email_task`.
+- `bulk_notification` in `send_bulk_notification_email_task`.
+
+Immediately before each `_send_email_sync(message)` call, add:
+
+```python
+start_time = time.perf_counter()
+```
+
+Immediately after each `_send_email_sync(message)` call succeeds, add:
+
+```python
+record_email_send(
+    env=settings.FASTAPI_ENV,
+    email_type=email_type,
+    status="success",
+    duration=time.perf_counter() - start_time,
+)
+```
+
+Inside each task's `except Exception as e:` block, before `raise self.retry(...)`,
+add:
+
+```python
+record_email_send(
+    env=settings.FASTAPI_ENV,
+    email_type=email_type,
+    status="error",
+    duration=time.perf_counter() - start_time,
+)
+```
+
+For bulk email tasks that send inside a loop, put `start_time` immediately
+before each per-recipient `_send_email_sync(message)` call so one slow recipient
+does not distort every email duration.
+
+## 8. Recommended Metric Names
 
 Use the `arcana_` prefix for application metrics.
 
@@ -180,7 +1259,7 @@ Use the `arcana_` prefix for application metrics.
 | Email sending | `arcana_email_send_total` | Counter | `project`, `component`, `env`, `email_type`, `status` |
 | Email latency | `arcana_email_send_duration_seconds` | Histogram | `project`, `component`, `env`, `email_type` |
 
-## 6. Label Conventions
+## 9. Label Conventions
 
 Use labels that have a small, bounded set of values:
 
@@ -195,7 +1274,7 @@ Prefer normalized values:
 - `reading_type="three_card"`, `reading_type="compatibility"`, or another fixed enum.
 - `model="gpt-4.1-mini"` or another bounded model name.
 
-## 7. Example PromQL
+## 10. Example PromQL
 
 All examples use central labels:
 
@@ -230,12 +1309,31 @@ sum(rate(arcana_http_requests_total{project="arcana-ai", component="backend", st
 sum(rate(arcana_http_requests_total{project="arcana-ai", component="backend"}[$__rate_interval]))
 ```
 
+Auth failures by action:
+
+```promql
+sum by (action) (
+  rate(arcana_auth_attempts_total{project="arcana-ai", component="backend", status!="success"}[$__rate_interval])
+)
+```
+
 Tarot readings per minute:
 
 ```promql
 sum by (reading_type, status) (
   rate(arcana_tarot_readings_total{project="arcana-ai", component="backend"}[$__rate_interval])
 ) * 60
+```
+
+Tarot p95 latency:
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le, reading_type) (
+    rate(arcana_tarot_reading_duration_seconds_bucket{project="arcana-ai", component="backend"}[$__rate_interval])
+  )
+)
 ```
 
 OpenAI token usage:
@@ -252,6 +1350,55 @@ OpenAI cost today:
 sum(increase(arcana_openai_cost_usd_total{project="arcana-ai", component="backend"}[24h]))
 ```
 
+OpenAI error rate:
+
+```promql
+sum by (model, error_type) (
+  rate(arcana_openai_errors_total{project="arcana-ai", component="backend"}[$__rate_interval])
+)
+```
+
+OpenAI p95 latency:
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le, model, operation) (
+    rate(arcana_openai_request_duration_seconds_bucket{project="arcana-ai", component="backend"}[$__rate_interval])
+  )
+)
+```
+
+Chat messages by role:
+
+```promql
+sum by (role, status) (
+  rate(arcana_chat_messages_total{project="arcana-ai", component="backend"}[$__rate_interval])
+)
+```
+
+Active chat conversations:
+
+```promql
+arcana_chat_conversations_active{project="arcana-ai", component="backend"}
+```
+
+Application errors by handler:
+
+```promql
+sum by (handler, error_type) (
+  rate(arcana_application_errors_total{project="arcana-ai", component="backend"}[$__rate_interval])
+)
+```
+
+Database query rate:
+
+```promql
+sum by (operation, table, status) (
+  rate(arcana_db_queries_total{project="arcana-ai", component="backend"}[$__rate_interval])
+)
+```
+
 Database p95 latency:
 
 ```promql
@@ -263,11 +1410,30 @@ histogram_quantile(
 )
 ```
 
+Celery task rate:
+
+```promql
+sum by (queue, task_name, status) (
+  rate(arcana_celery_tasks_total{project="arcana-ai", component="backend"}[$__rate_interval])
+)
+```
+
 Celery failures:
 
 ```promql
 sum by (queue, task_name) (
   rate(arcana_celery_task_failures_total{project="arcana-ai", component="backend"}[$__rate_interval])
+)
+```
+
+Celery p95 duration:
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le, queue, task_name) (
+    rate(arcana_celery_task_duration_seconds_bucket{project="arcana-ai", component="backend"}[$__rate_interval])
+  )
 )
 ```
 
@@ -279,6 +1445,14 @@ sum by (provider, event_type, status) (
 )
 ```
 
+Payment amount by provider:
+
+```promql
+sum by (provider, status) (
+  increase(arcana_payment_amount_usd_total{project="arcana-ai", component="backend"}[24h])
+)
+```
+
 Email failures:
 
 ```promql
@@ -287,7 +1461,18 @@ sum by (email_type) (
 )
 ```
 
-## 8. Suggested Grafana Dashboards
+Email p95 latency:
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le, email_type) (
+    rate(arcana_email_send_duration_seconds_bucket{project="arcana-ai", component="backend"}[$__rate_interval])
+  )
+)
+```
+
+## 11. Suggested Grafana Dashboards
 
 Create dashboards in Grafana, then export the finished JSON into `central-monitoring`.
 
@@ -306,7 +1491,7 @@ Use dashboard variables:
 - `$component`: query values from `label_values(up{project="$project"}, component)`.
 - `$env`: custom values such as `production`, `staging`, `local`.
 
-## 9. Export Dashboards to `central-monitoring`
+## 12. Export Dashboards to `central-monitoring`
 
 After a dashboard works in Grafana:
 
@@ -323,7 +1508,7 @@ central-monitoring/grafana/dashboards/arcana-ai/api-golden-signals.json
 
 Do not store exported dashboard JSON in this ArcanaAI repository unless it is only documentation or a temporary design note.
 
-## 10. Verify in Grafana Explore
+## 13. Verify in Grafana Explore
 
 After `/metrics` exists and central Prometheus has a target:
 
@@ -351,7 +1536,7 @@ sum(rate(arcana_http_requests_total{project="arcana-ai", component="backend"}[5m
 
 If `up` is `0`, verify Docker networking and the target in `central-monitoring`. If `up` is `1` but no `arcana_` metrics appear, verify the backend actually registered the metrics module and that `/metrics` returns Prometheus text format.
 
-## 11. Avoid Duplicate Metrics on the Same VPS
+## 14. Avoid Duplicate Metrics on the Same VPS
 
 When ArcanaAI runs on the same VPS as `central-monitoring`, use one ingestion path only.
 
@@ -368,15 +1553,16 @@ Avoid this duplicate setup:
 
 Duplicate ingestion creates double counts for counters such as `arcana_tarot_readings_total` and `arcana_openai_cost_usd_total`. If you must migrate from push to pull or pull to push, temporarily query by `instance` and `job` in Grafana Explore to confirm only one source remains before relying on dashboards.
 
-## 12. Reimplementation Checklist
+## 15. Reimplementation Checklist
 
 1. Add `prometheus-client` to `backend/pyproject.toml` with `uv add prometheus-client`.
 2. Create a small `backend/utils/metrics.py` module with counters, histograms, and `/metrics` exposure.
 3. Register `setup_metrics(app, env=settings.FASTAPI_ENV)` in `backend/app.py`.
-4. Add domain metrics in routers/services where the events happen.
-5. Keep labels low-cardinality and privacy-safe.
-6. Run backend tests and a local smoke check of `GET /metrics`.
-7. Update `central-monitoring` scrape or agent config outside this repo.
-8. Verify in Grafana Explore using `project="arcana-ai"` and `component="backend"`.
-9. Build dashboards in Grafana.
-10. Export finished dashboards as JSON into `central-monitoring`.
+4. Add the metric definitions from Section 5.
+5. Add domain metric calls using the snippets in Section 7.
+6. Keep labels low-cardinality and privacy-safe.
+7. Run backend tests and a local smoke check of `GET /metrics`.
+8. Update `central-monitoring` scrape or agent config outside this repo.
+9. Verify in Grafana Explore using `project="arcana-ai"` and `component="backend"`.
+10. Build dashboards in Grafana.
+11. Export finished dashboards as JSON into `central-monitoring`.


### PR DESCRIPTION
## Summary
- add ArcanaAI Prometheus metric helpers and expose `/metrics`
- record auth, tarot, OpenAI, chat, database, application error, Celery, payment, and email metrics
- update the Grafana/central-monitoring implementation guide with copy-ready placement guidance

## Validation
- `PYTHONPYCACHEPREFIX=/private/tmp/arcana-ai-pyc python -m compileall backend/config.py backend/app.py backend/celery_app.py backend/database.py backend/tarot_reader.py backend/routers/auth.py backend/routers/chat.py backend/routers/subscription.py backend/routers/tarot.py backend/tasks/email_tasks.py backend/utils/error_handlers.py backend/utils/metrics.py`
- `UV_CACHE_DIR=/private/tmp/arcana-ai-uv-cache uv run ruff check config.py app.py celery_app.py database.py tarot_reader.py routers/auth.py routers/chat.py routers/subscription.py routers/tarot.py tasks/email_tasks.py utils/error_handlers.py utils/metrics.py`
- `UV_CACHE_DIR=/private/tmp/arcana-ai-uv-cache uv run pytest -q` - 504 passed, 1 skipped

## Notes
- No deployment performed.
- No VPS, DNS, or `central-monitoring` repository changes were made.